### PR TITLE
Making redirecting safe / Deprecating redirects to 3rd party hosts

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,7 +14,8 @@ Version 1.0
   `False` it will only be modified if the session actually modifies.
   Non permanent sessions are not affected by this and will always
   expire if the browser window closes.
-- Deprecated redirecting to 3rd party locations using :func:`~flask.redirect`
+- Deprecated redirecting to non-whitelisted 3rd party locations using
+  :func:`~flask.redirect`.
 
 Version 0.10.2
 --------------

--- a/CHANGES
+++ b/CHANGES
@@ -14,8 +14,7 @@ Version 1.0
   `False` it will only be modified if the session actually modifies.
   Non permanent sessions are not affected by this and will always
   expire if the browser window closes.
-- Added :func:`flask.safe_redirect` which does not allow redirects to
-  foreign hosts.
+- Deprecated redirecting to 3rd party locations using :func:`~flask.redirect`
 
 Version 0.10.2
 --------------

--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,8 @@ Version 1.0
   `False` it will only be modified if the session actually modifies.
   Non permanent sessions are not affected by this and will always
   expire if the browser window closes.
+- Added :func:`flask.safe_redirect` which does not allow redirects to
+  foreign hosts.
 
 Version 0.10.2
 --------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -320,6 +320,8 @@ Useful Functions and Classes
 
 .. autofunction:: redirect
 
+.. autofunction:: safe_redirect
+
 .. autofunction:: make_response
 
 .. autofunction:: after_this_request

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -320,8 +320,6 @@ Useful Functions and Classes
 
 .. autofunction:: redirect
 
-.. autofunction:: safe_redirect
-
 .. autofunction:: make_response
 
 .. autofunction:: after_this_request

--- a/flask/__init__.py
+++ b/flask/__init__.py
@@ -22,7 +22,7 @@ from .app import Flask, Request, Response
 from .config import Config
 from .helpers import url_for, flash, send_file, send_from_directory, \
     get_flashed_messages, get_template_attribute, make_response, safe_join, \
-    stream_with_context
+    stream_with_context, safe_redirect
 from .globals import current_app, g, request, session, _request_ctx_stack, \
      _app_ctx_stack
 from .ctx import has_request_context, has_app_context, \

--- a/flask/__init__.py
+++ b/flask/__init__.py
@@ -15,14 +15,13 @@ __version__ = '0.11-dev'
 # utilities we import from Werkzeug and Jinja2 that are unused
 # in the module but are exported as public interface.
 from werkzeug.exceptions import abort
-from werkzeug.utils import redirect
 from jinja2 import Markup, escape
 
 from .app import Flask, Request, Response
 from .config import Config
 from .helpers import url_for, flash, send_file, send_from_directory, \
     get_flashed_messages, get_template_attribute, make_response, safe_join, \
-    stream_with_context, safe_redirect
+    stream_with_context, redirect
 from .globals import current_app, g, request, session, _request_ctx_stack, \
      _app_ctx_stack
 from .ctx import has_request_context, has_app_context, \

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -21,11 +21,10 @@ from werkzeug.routing import BuildError
 from functools import update_wrapper
 from warnings import warn
 
-from werkzeug.urls import url_parse
 try:
-    from werkzeug.urls import url_quote
+    from werkzeug.urls import url_quote, url_parse
 except ImportError:
-    from urlparse import quote as url_quote
+    from urlparse import quote as url_quote, urlparse as url_parse
 
 from werkzeug.datastructures import Headers
 from werkzeug.exceptions import NotFound

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -28,7 +28,7 @@ except ImportError:
     from urlparse import quote as url_quote
 
 from werkzeug.datastructures import Headers
-from werkzeug.exceptions import NotFound, abort
+from werkzeug.exceptions import NotFound
 from werkzeug.utils import redirect as _redirect
 
 # this was moved in 0.7
@@ -475,7 +475,6 @@ def send_file(filename_or_fp, mimetype=None, as_attachment=False,
         filename = filename_or_fp
         file = None
     else:
-        from warnings import warn
         file = filename_or_fp
         filename = getattr(file, 'name', None)
 
@@ -852,7 +851,7 @@ class _PackageBoundObject(object):
         return open(os.path.join(self.root_path, resource), mode)
 
 
-def redirect(location, code=302):
+def redirect(location, code=302, safe_hosts=None):
     """
     Return a response object (a WSGI application) that, if called, redirects
     the client to the target location. Supported codes are 301, 302, 303, 305,
@@ -863,10 +862,15 @@ def redirect(location, code=302):
     Since Werkzeug 0.6 the location can be a unicode string that is encoded
     using the :func:`~werkzeug.urls.iri_to_uri` function.
 
+    :param safe_hosts: A container of hosts which are safe to redirect to.
+
     .. versionchanged:: 1.0
-       Deprecated redirecting to 3rd party hosts.
+       Deprecated redirecting to 3rd party hosts not whitelisted with
+       `safe_hosts`.
     """
+    safe_hosts = set([request.host]).union(safe_hosts or [])
     location_host = url_parse(location).netloc
-    if location_host and location_host != request.host:
-        warn(DeprecationWarning('redirecting to 3rd party hosts is deprecated'))
+    if location_host and location_host not in safe_hosts:
+        warn(DeprecationWarning('redirecting to 3rd party hosts is deprecated '
+                                'use safe_hosts if the redirect is intended'))
     return _redirect(location, code)

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -22,9 +22,13 @@ from functools import update_wrapper
 from warnings import warn
 
 try:
-    from werkzeug.urls import url_quote, url_parse
+    from werkzeug.urls import url_quote
 except ImportError:
-    from urlparse import quote as url_quote, urlparse as url_parse
+    from urlparse import quote as url_quote
+try:
+    from werkzeug.urls import url_parse
+except ImportError:
+    from urlparse import urlparse as url_parse
 
 from werkzeug.datastructures import Headers
 from werkzeug.exceptions import NotFound

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -20,13 +20,15 @@ from threading import RLock
 from werkzeug.routing import BuildError
 from functools import update_wrapper
 
+from werkzeug.urls import url_parse
 try:
     from werkzeug.urls import url_quote
 except ImportError:
     from urlparse import quote as url_quote
 
 from werkzeug.datastructures import Headers
-from werkzeug.exceptions import NotFound
+from werkzeug.exceptions import NotFound, abort
+from werkzeug.utils import redirect
 
 # this was moved in 0.7
 try:
@@ -847,3 +849,16 @@ class _PackageBoundObject(object):
         if mode not in ('r', 'rb'):
             raise ValueError('Resources can only be opened for reading')
         return open(os.path.join(self.root_path, resource), mode)
+
+
+def safe_redirect(location, code=302):
+    """
+    Like :func:`flask.redirect` but aborts with a 400 Bad Request, if a
+    `location` with a different host than the current is passed.
+
+    .. versionadded:: 1.0
+    """
+    location_host = url_parse(location).netloc
+    if location_host and location_host != request.host:
+        abort(400)
+    return redirect(location, code)

--- a/flask/testsuite/helpers.py
+++ b/flask/testsuite/helpers.py
@@ -622,6 +622,10 @@ class RedirectTestCase(FlaskTestCase):
         @app.route('/good_redirect_with_host')
         def good_redirect_with_host():
             return flask.redirect('http://localhost/foo')
+        @app.route('/good_redirect_to_3rd_party')
+        def good_redirect_to_3rd_party():
+            return flask.redirect('http://example.com',
+                                  safe_hosts=['example.com'])
         @app.route('/bad_redirect')
         def bad_redirect():
             return flask.redirect('http://example.com')
@@ -633,6 +637,11 @@ class RedirectTestCase(FlaskTestCase):
         self.assert_equal(rv.data, b'foo')
         rv = c.get('/good_redirect_with_host', follow_redirects=True)
         self.assert_equal(rv.data, b'foo')
+        with catch_warnings() as captured:
+            rv = c.get('/good_redirect_to_3rd_party')
+            self.assert_equal(rv.status_code, 302)
+            self.assert_equal(rv.location, 'http://example.com')
+        self.assert_equal(len(captured), 0)
         with catch_warnings() as captured:
             c.get('/bad_redirect')
         self.assert_equal(len(captured), 1)

--- a/flask/testsuite/helpers.py
+++ b/flask/testsuite/helpers.py
@@ -613,18 +613,18 @@ class StreamingTestCase(FlaskTestCase):
 
 
 class RedirectTestCase(FlaskTestCase):
-    def test_safe_redirect(self):
+    def test_redirect(self):
         app = flask.Flask(__name__)
         app.testing = True
         @app.route('/good_redirect')
         def good_redirect():
-            return flask.safe_redirect('foo')
+            return flask.redirect('foo')
         @app.route('/good_redirect_with_host')
         def good_redirect_with_host():
-            return flask.safe_redirect('http://localhost/foo')
+            return flask.redirect('http://localhost/foo')
         @app.route('/bad_redirect')
         def bad_redirect():
-            return flask.safe_redirect('http://example.com')
+            return flask.redirect('http://example.com')
         @app.route('/foo')
         def foo():
             return u'foo'
@@ -633,8 +633,9 @@ class RedirectTestCase(FlaskTestCase):
         self.assert_equal(rv.data, b'foo')
         rv = c.get('/good_redirect_with_host', follow_redirects=True)
         self.assert_equal(rv.data, b'foo')
-        rv = c.get('/bad_redirect', follow_redirects=True)
-        self.assert_equal(rv.status_code, 400)
+        with catch_warnings() as captured:
+            c.get('/bad_redirect')
+        self.assert_equal(len(captured), 1)
 
 
 def suite():


### PR DESCRIPTION
This PR adds a `safe_hosts` parameter to `redirect`, which allows defining a safe set of hosts to redirect to and issues a `DeprecationWarning`, if `redirect` is used to redirect to a different host than the one of the application or defined in `safe_hosts`. In the future instead of a `DeprecationWarning` being issued, an exception should be raised.

The purpose of this change is to prevent [unvalidated redirects](https://www.owasp.org/index.php/Top_10_2010-A10-Unvalidated_Redirects_and_Forwards), which is currently listed among the Top 10 of the most common web application vulnerabilities by OWASP and was recently mentioned by [Jacob Kaplan-Moss at a talk at PyCon Australia](https://www.youtube.com/watch?v=sra9x44lXgU). It's also an easy way to improve our results in comparisions like these ;)