### PR TITLE
Set DEBUG and TESTING config value to default to None, not False.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,10 @@ Version 1.0
   debug server through the click CLI system.  This is recommended over the old
   ``flask.run()`` method as it works faster and more reliable due to a
   different design and also replaces ``Flask-Script``.
+- Configuration settings for the ``DEBUG`` and ``TESTING`` config keys
+  default to None, not False. This should not affect any well-written code,
+  but allows to distinguish between "DEBUG has not been set" and
+  "DEBUG is turned off".
 
 Version 0.10.2
 --------------

--- a/flask/app.py
+++ b/flask/app.py
@@ -290,8 +290,8 @@ class Flask(_PackageBoundObject):
 
     #: Default configuration parameters.
     default_config = ImmutableDict({
-        'DEBUG':                                False,
-        'TESTING':                              False,
+        'DEBUG':                                None,
+        'TESTING':                              None,
         'PROPAGATE_EXCEPTIONS':                 None,
         'PRESERVE_CONTEXT_ON_EXCEPTION':        None,
         'SECRET_KEY':                           None,


### PR DESCRIPTION
Rationale: Some code might want to distinguish between "DEBUG has not been
set, determine correct value from the environment / other means" and "DEBUG
has been turned off explicitly".

One user of this is the Flask-Script extension, which would like to use a
default of True for the DEBUG setting when its built-in script runner is
used. Rationale: Many people use a special gunicorn-or-whatever runner in
production, but start a quick local "manage.py runscript" when they want to
test something / reproduce a bug. In this case it's helpful to not require
a different set of options that the user has to remember, or to have to use
a second config file which could go out of date.
