### PR TITLE
Conditionally install default logging handlers

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -561,11 +561,11 @@ class TestLogging(object):
         """Test logger configuration before app creation without default
         logging handlers"""
         # setup logging
-        from io import BytesIO
-        log_output = BytesIO()
+        from io import StringIO
+        log_output = StringIO()
         stringio_handler = StreamHandler(log_output)
         stringio_handler.level = DEBUG
-        logger = getLogger("flask")
+        logger = getLogger('flask')
         logger.addHandler(stringio_handler)
 
         # initialize flask without default logging handlers
@@ -574,9 +574,9 @@ class TestLogging(object):
                           LOGGER_HANDLER_POLICY='never')
 
         # log a warning
-        log_message = 'A fair warning.'
+        log_message = u'A fair warning.'
         app.logger.warn(log_message)
-        assert log_output.getvalue() == (log_message + '\n')
+        assert log_output.getvalue() == (log_message + u'\n')
 
 
 class TestNoImports(object):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -557,6 +557,39 @@ class TestLogging(object):
             assert flask.url_for('myview', id=42, _method='GET') == '/myview/42'
             assert flask.url_for('myview', _method='POST') == '/myview/create'
 
+    def test_configuration(self):
+        """Test logger configuration without default logging handlers"""
+        # setup logging
+        from StringIO import StringIO
+        log_output = StringIO()
+        log_config = {
+            'version': 1,
+            'handlers': {
+                'stringio': {
+                    'class': 'logging.StreamHandler',
+                    'level': 'DEBUG',
+                    'stream': log_output
+                }
+            },
+            'loggers': {
+                'flask': {
+                    'handlers': ['stringio']
+                }
+            }
+         }
+        # initialize logging
+        import logging.config
+        logging.config.dictConfig(log_config)
+        # initialize flask without default logging handlers
+        app = flask.Flask(__name__)
+        app.config.update(LOGGER_NAME='flask',
+                          LOGGER_HANDLER_POLICY='never')
+
+        # log a warning
+        log_message = 'A fair warning.'
+        app.logger.warn(log_message)
+        assert log_output.getvalue() == (log_message + '\n')
+
 
 class TestNoImports(object):
     """Test Flasks are created without import.

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -561,8 +561,8 @@ class TestLogging(object):
         """Test logger configuration before app creation without default
         logging handlers"""
         # setup logging
-        from StringIO import StringIO
-        log_output = StringIO()
+        from io import BytesIO
+        log_output = BytesIO()
         stringio_handler = StreamHandler(log_output)
         stringio_handler.level = DEBUG
         logger = getLogger("flask")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -13,7 +13,7 @@ import pytest
 
 import os
 import flask
-from logging import StreamHandler
+from logging import StreamHandler, getLogger, DEBUG
 from werkzeug.http import parse_cache_control_header, parse_options_header
 from flask._compat import StringIO, text_type
 
@@ -558,28 +558,16 @@ class TestLogging(object):
             assert flask.url_for('myview', _method='POST') == '/myview/create'
 
     def test_configuration(self):
-        """Test logger configuration without default logging handlers"""
+        """Test logger configuration before app creation without default
+        logging handlers"""
         # setup logging
         from StringIO import StringIO
         log_output = StringIO()
-        log_config = {
-            'version': 1,
-            'handlers': {
-                'stringio': {
-                    'class': 'logging.StreamHandler',
-                    'level': 'DEBUG',
-                    'stream': log_output
-                }
-            },
-            'loggers': {
-                'flask': {
-                    'handlers': ['stringio']
-                }
-            }
-         }
-        # initialize logging
-        import logging.config
-        logging.config.dictConfig(log_config)
+        stringio_handler = StreamHandler(log_output)
+        stringio_handler.level = DEBUG
+        logger = getLogger("flask")
+        logger.addHandler(stringio_handler)
+
         # initialize flask without default logging handlers
         app = flask.Flask(__name__)
         app.config.update(LOGGER_NAME='flask',


### PR DESCRIPTION
This is an attempt to address https://github.com/mitsuhiko/flask/issues/641, in particular the problem that `del logger.handlers[:]` is always invoked in app logger creation, destroying any previously created handlers.

Since the `LOGGER_HANDLER_POLICY` was introduced, I am using it to only conditionally install each of the two default handlers (`'debug'` and `'production'`). If the policy is `'never'`, the handlers do not need to be added and such cleanup `del logger.handlers[:]` is not necessary.

The test I added describes my use case (and I believe everyone's in https://github.com/mitsuhiko/flask/issues/641) quite accurately, and I think it is a reasonable one. 

My solution to not install handlers is different than the previous situation, which would always install them and then would do a check on each invocation of `handler.emit`. That means that if someone relied on this check and was for some reason dynamically modifying the app's configuration to change the logging policy while the app was running, it won't work any more. But, to me this seems more like an implementation artifact than a valid use-case.
