### PR TITLE
Fixed `stream_with_context` decorator not working with generator functions that take in arguments

### DIFF
--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -100,7 +100,7 @@ def stream_with_context(generator_or_function):
         gen = iter(generator_or_function)
     except TypeError:
         def decorator(*args, **kwargs):
-            gen = generator_or_function()
+            gen = generator_or_function(*args, **kwargs)
             return stream_with_context(gen)
         return update_wrapper(decorator, generator_or_function)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -628,6 +628,22 @@ class TestStreaming(object):
         rv = c.get('/?name=World')
         assert rv.data == b'Hello World!'
 
+    def test_streaming_with_context_as_decorator_with_arguments(self):
+        app = flask.Flask(__name__)
+        app.testing = True
+        @app.route('/')
+        def index():
+            @flask.stream_with_context
+            def generate(greeting, punctuation='!'):
+                yield greeting
+                yield ' '
+                yield flask.request.args['name']
+                yield punctuation
+            return flask.Response(generate('Hello', punctuation='!'))
+        c = app.test_client()
+        rv = c.get('/?name=World')
+        assert rv.data == b'Hello World!'
+
     def test_streaming_with_context_and_custom_close(self):
         app = flask.Flask(__name__)
         app.testing = True


### PR DESCRIPTION
The `stream_with_context` decorator currently just throws away `*args` and `**kwargs`; it would be helpful to pass them along to the generator.