### PR TITLE
Add note to not use plain text passwords to views.rst

### DIFF
--- a/docs/tutorial/views.rst
+++ b/docs/tutorial/views.rst
@@ -94,5 +94,11 @@ if the user was logged in.
         session.pop('logged_in', None)
         flash('You were logged out')
         return redirect(url_for('show_entries'))
+        
+Note that it is not a good idea to store passwords in plain text. You want to
+protect login credentials if someone happens to have access to your database.
+One way to do this is to use Security Helpers from Werkzeug to hash the
+password. However, the emphasis of this tutorial is to demonstrate the basics
+of Flask and plain text passwords are used for simplicity.
 
 Continue with :ref:`tutorial-templates`.


### PR DESCRIPTION
In reference to issue #836, a general note about hashing passwords for security is added. This clarifies the tutorial's choice to not use secure passwords to demonstrate the basic usage of Flask.