### PR TITLE
Fix errorhandler HTTPException normalization

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -18,8 +18,8 @@ from functools import update_wrapper
 
 from werkzeug.datastructures import ImmutableDict
 from werkzeug.routing import Map, Rule, RequestRedirect, BuildError
-from werkzeug.exceptions import HTTPException, InternalServerError, \
-     MethodNotAllowed, BadRequest
+from werkzeug.exceptions import default_exceptions, HTTPException, \
+     InternalServerError, MethodNotAllowed, BadRequest
 
 from .helpers import _PackageBoundObject, url_for, get_flashed_messages, \
      locked_cached_property, _endpoint_from_view_func, find_package
@@ -1133,7 +1133,9 @@ class Flask(_PackageBoundObject):
 
     @setupmethod
     def _register_error_handler(self, key, code_or_exception, f):
-        if isinstance(code_or_exception, HTTPException):
+        # The HTTPException base class doesn't have a code
+        if code_or_exception in default_exceptions.values() and \
+           code_or_exception is not HTTPException:
             code_or_exception = code_or_exception.code
         if isinstance(code_or_exception, integer_types):
             assert code_or_exception != 500 or key is None, \

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -817,8 +817,13 @@ def test_http_error_subclass_handling():
         assert isinstance(e, ForbiddenSubclass)
         return 'banana'
 
+    # Should get overwritten with handle_403()
+    @app.errorhandler(Forbidden)
+    def handle_forbidden(e):
+        return 'pear'
+
     @app.errorhandler(403)
-    def handle_forbidden_subclass(e):
+    def handle_403(e):
         assert not isinstance(e, ForbiddenSubclass)
         assert isinstance(e, Forbidden)
         return 'apple'


### PR DESCRIPTION
This is barely noticeable in the development code since #839, but in the latest released version. The current code to normalize the error condition misses its apparent purpose: code_or_exception will never be an instance of HTTPException, as one might only supply an exception class and not an object.
The bug still appears when you declare an errorhandler for a numeric code after setting one for the respective exception: Then, the exception's handler will always take precedence.

The HTTPException base class has no code and therefore must be dealt with like any other exception.
