### PR TITLE
JSON support for test client and response object

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ Development Lead
 Patches and Suggestions
 ```````````````````````
 
+- Adam Byrtek
 - Adam Zapletal
 - Ali Afshar
 - Chris Edgemon

--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,9 @@ Version 1.0
 
 (release date to be announced, codename to be selected)
 
+- Added `json` keyword argument to :meth:`flask.testing.FlaskClient.open`
+  (and related ``get``, ``post``, etc.), which makes it more convenient to
+  send JSON requests from the test client.
 - Added before_render_template signal.
 - Added `**kwargs` to :meth:`flask.Test.test_client` to support passing
   additional keyword arguments to the constructor of

--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,8 @@ Version 1.0
 
 (release date to be announced, codename to be selected)
 
+- Added ``is_json`` and ``get_json`` to :class:``flask.wrappers.Response``
+  in order to make it easier to build assertions when testing JSON responses.
 - Added `json` keyword argument to :meth:`flask.testing.FlaskClient.open`
   (and related ``get``, ``post``, etc.), which makes it more convenient to
   send JSON requests from the test client.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -29,7 +29,7 @@ Incoming Request Data
 ---------------------
 
 .. autoclass:: Request
-   :members:
+   :members: is_json, get_json
 
    .. attribute:: form
 
@@ -141,7 +141,7 @@ Response Objects
 ----------------
 
 .. autoclass:: flask.Response
-   :members: set_cookie, data, mimetype
+   :members: set_cookie, data, mimetype, is_json, get_json
 
    .. attribute:: headers
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -368,15 +368,17 @@ convenient:
 
     @app.route('/api/auth')
     def auth():
-        email = request.get_json()['email']
-        password = request.get_json()['password']
+        json_data = request.get_json()
+        email = json_data['email']
+        password = json_data['password']
         return jsonify(token=generate_token(email, password))
 
     with app.test_client() as c:
         email = 'john@example.com'
         password = 'secret'
         resp = c.post('/api/auth', json={'login': email, 'password': password})
-        assert verify_token(email, resp.get_json()['token'])
+        json_data = resp.get_json()
+        assert verify_token(email, json_data['token'])
 
 Note that if the ``json`` argument is provided then the test client will put
 JSON-serialized data in the request body, and also set the

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -362,7 +362,7 @@ Testing JSON APIs
 
 Flask has great support for JSON, and is a popular choice for building REST
 APIs. Testing both JSON requests and responses using the test client is very
-convenient:
+convenient::
 
     from flask import jsonify
 
@@ -371,12 +371,14 @@ convenient:
         json_data = request.get_json()
         email = json_data['email']
         password = json_data['password']
+
         return jsonify(token=generate_token(email, password))
 
     with app.test_client() as c:
         email = 'john@example.com'
         password = 'secret'
         resp = c.post('/api/auth', json={'login': email, 'password': password})
+
         json_data = resp.get_json()
         assert verify_token(email, json_data['token'])
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -360,24 +360,24 @@ Testing JSON APIs
 
 .. versionadded:: 1.0
 
-Flask has a great support for JSON, and is a popular choice for building REST
+Flask has great support for JSON, and is a popular choice for building REST
 APIs. Testing both JSON requests and responses using the test client is very
 convenient:
 
-    from flask import json, jsonify
+    from flask import jsonify
 
     @app.route('/api/auth')
     def auth():
-        email = request.json['email']
-        password = request.json['password']
+        email = request.get_json()['email']
+        password = request.get_json()['password']
         return jsonify(token=generate_token(email, password))
 
     with app.test_client() as c:
         email = 'john@example.com'
         password = 'secret'
-        resp = c.post('/api/auth', json={'email': email, 'password': password})
-        assert verify_token(email, resp.json['token'])
+        resp = c.post('/api/auth', json={'login': email, 'password': password})
+        assert verify_token(email, resp.get_json()['token'])
 
 Note that if the ``json`` argument is provided then the test client will put
-the JSON-serialized object in the request body, and also set the
-``Content-Type: application/json`` header.
+JSON-serialized data in the request body, and also set the
+``Content-Type: application/json`` HTTP header.

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -353,3 +353,11 @@ independently of the session backend used::
 Note that in this case you have to use the ``sess`` object instead of the
 :data:`flask.session` proxy.  The object however itself will provide the
 same interface.
+
+
+Testing JSON APIs
+-----------------
+
+.. versionadded:: 1.0
+
+Flask has comprehensive

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -360,4 +360,24 @@ Testing JSON APIs
 
 .. versionadded:: 1.0
 
-Flask has comprehensive
+Flask has a great support for JSON, and is a popular choice for building REST
+APIs. Testing both JSON requests and responses using the test client is very
+convenient:
+
+    from flask import json, jsonify
+
+    @app.route('/api/auth')
+    def auth():
+        email = request.json['email']
+        password = request.json['password']
+        return jsonify(token=generate_token(email, password))
+
+    with app.test_client() as c:
+        email = 'john@example.com'
+        password = 'secret'
+        resp = c.post('/api/auth', json={'email': email, 'password': password})
+        assert verify_token(email, resp.json['token'])
+
+Note that if the ``json`` argument is provided then the test client will put
+the JSON-serialized object in the request body, and also set the
+``Content-Type: application/json`` header.

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -37,7 +37,7 @@ def make_test_environ_builder(app, path='/', base_url=None, json=None, *args, **
 
     if json is not None:
         if 'data' in kwargs:
-            raise RuntimeError('Client cannot provide both `json` and `data`')
+            raise ValueError('Client cannot provide both `json` and `data`')
         kwargs['data'] = json_dumps(json)
 
         # Only set Content-Type when not explicitly provided

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -35,16 +35,14 @@ def make_test_environ_builder(app, path='/', base_url=None, json=None, *args, **
             if url.query:
                 path += '?' + url.query
 
-    if json:
+    if json is not None:
         if 'data' in kwargs:
             raise RuntimeError('Client cannot provide both `json` and `data`')
         kwargs['data'] = json_dumps(json)
 
         # Only set Content-Type when not explicitly provided
-        if 'Content-Type' not in kwargs.get('headers', {}):
-            new_headers = kwargs.get('headers', {}).copy()
-            new_headers['Content-Type'] = 'application/json'
-            kwargs['headers'] = new_headers
+        if 'content_type' not in kwargs:
+            kwargs['content_type'] = 'application/json'
 
     return EnvironBuilder(path, base_url, *args, **kwargs)
 

--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -15,21 +15,21 @@ from werkzeug.exceptions import BadRequest
 from . import json
 from .globals import _app_ctx_stack
 
-_missing = object()
-
 
 class JSONMixin(object):
-    """Mixin for both request and response classes to provide JSON parsing
-    capabilities.
+    """Common mixin for both request and response objects to provide JSON
+    parsing capabilities.
 
     .. versionadded:: 1.0
     """
 
     @property
     def is_json(self):
-        """Indicates if this request/response is JSON or not.  By default it
-        is considered to include JSON data if the mimetype is
+        """Indicates if this request/response is in JSON format or not.  By
+        default it is considered to include JSON data if the mimetype is
         :mimetype:`application/json` or :mimetype:`application/*+json`.
+
+        .. versionadded:: 1.0
         """
         mt = self.mimetype
         if mt == 'application/json':
@@ -40,14 +40,14 @@ class JSONMixin(object):
 
     @property
     def json(self):
-        """If the mimetype is :mimetype:`application/json` this will contain the
-        parsed JSON data.  Otherwise this will be ``None``.
+        """If this request/response is in JSON format then this property will
+        contain the parsed JSON data.  Otherwise it will be ``None``.
 
         The :meth:`get_json` method should be used instead.
         """
         from warnings import warn
-        warn(DeprecationWarning('json is deprecated.  '
-                                'Use get_json() instead.'), stacklevel=2)
+        warn(DeprecationWarning(
+            'json is deprecated.  Use get_json() instead.'), stacklevel=2)
         return self.get_json()
 
     def _get_data_for_json(self, cache):
@@ -58,7 +58,7 @@ class JSONMixin(object):
 
     def get_json(self, force=False, silent=False, cache=True):
         """Parses the JSON request/response data and returns it.  If parsing
-        fails the :meth:`on_json_loading_failed` will be invoked. By default
+        fails :meth:`on_json_loading_failed` will be invoked. By default
         this function will only load the JSON data if :attr:`is_json` is true,
         but this can be overridden by the `force` parameter.
 
@@ -66,16 +66,17 @@ class JSONMixin(object):
         :param silent: if set to ``True`` this method will fail silently
                        and return ``None``.
         :param cache: if set to ``True`` the parsed JSON data is remembered
-                      on the request.
+                      on the object.
         """
-        rv = getattr(self, '_cached_json', _missing)
-        if rv is not _missing:
-            return rv
+        try:
+            return getattr(self, '_cached_json')
+        except AttributeError:
+            pass
 
         if not (force or self.is_json):
             return None
 
-        # We accept a request charset against the specification as certain
+        # We accept MIME charset header against the specification as certain
         # clients have been using this in the past.  For responses, we assume
         # that if the response charset was set explicitly then the data had
         # been encoded correctly as well.

--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -50,11 +50,11 @@ class JSONMixin(object):
                                 'Use get_json() instead.'), stacklevel=2)
         return self.get_json()
 
-    def _get_data_for_json(req, cache):
-        getter = getattr(req, 'get_data', None)
+    def _get_data_for_json(self, cache):
+        getter = getattr(self, 'get_data', None)
         if getter is not None:
             return getter(cache=cache)
-        return req.data
+        return self.data
 
     def get_json(self, force=False, silent=False, cache=True):
         """Parses the incoming JSON request data and returns it.  If parsing
@@ -214,9 +214,9 @@ class Response(ResponseBase, JSONMixin):
     """
     default_mimetype = 'text/html'
 
-    def _get_data_for_json(req, cache):
-        # Ignore the cache flag since response doesn't support it
-        getter = getattr(req, 'get_data', None)
+    def _get_data_for_json(self, cache):
+        getter = getattr(self, 'get_data', None)
         if getter is not None:
+            # Ignore the cache flag since response doesn't support it
             return getter()
-        return req.data
+        return self.data

--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -57,7 +57,7 @@ class JSONMixin(object):
         return self.data
 
     def get_json(self, force=False, silent=False, cache=True):
-        """Parses the incoming JSON request data and returns it.  If parsing
+        """Parses the JSON request/response data and returns it.  If parsing
         fails the :meth:`on_json_loading_failed` will be invoked. By default
         this function will only load the JSON data if :attr:`is_json` is true,
         but this can be overridden by the `force` parameter.

--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -13,7 +13,7 @@ from werkzeug.wrappers import Request as RequestBase, Response as ResponseBase
 from werkzeug.exceptions import BadRequest
 
 from . import json
-from .globals import _request_ctx_stack
+from .globals import _app_ctx_stack
 
 _missing = object()
 
@@ -99,7 +99,17 @@ class JSONMixin(object):
         """Called if decoding of the JSON data failed.  The return value of
         this method is used by :meth:`get_json` when an error occurred.  The
         default implementation just raises a :class:`BadRequest` exception.
+
+        .. versionchanged:: 0.10
+           Removed buggy previous behavior of generating a random JSON
+           response.  If you want that behavior back you can trivially
+           add it by subclassing.
+
+        .. versionadded:: 0.8
         """
+        ctx = _app_ctx_stack.top
+        if ctx is not None and ctx.app.debug:
+            raise BadRequest('Failed to decode JSON object: {0}'.format(e))
         raise BadRequest()
 
 
@@ -140,7 +150,7 @@ class Request(RequestBase, JSONMixin):
     @property
     def max_content_length(self):
         """Read-only view of the ``MAX_CONTENT_LENGTH`` config key."""
-        ctx = _request_ctx_stack.top
+        ctx = _app_ctx_stack.top
         if ctx is not None:
             return ctx.app.config['MAX_CONTENT_LENGTH']
 
@@ -173,30 +183,12 @@ class Request(RequestBase, JSONMixin):
         if self.url_rule and '.' in self.url_rule.endpoint:
             return self.url_rule.endpoint.rsplit('.', 1)[0]
 
-
-    def on_json_loading_failed(self, e):
-        """Called if decoding of the JSON data failed.  The return value of
-        this method is used by :meth:`get_json` when an error occurred.  The
-        default implementation just raises a :class:`BadRequest` exception.
-
-        .. versionchanged:: 0.10
-           Removed buggy previous behavior of generating a random JSON
-           response.  If you want that behavior back you can trivially
-           add it by subclassing.
-
-        .. versionadded:: 0.8
-        """
-        ctx = _request_ctx_stack.top
-        if ctx is not None and ctx.app.config.get('DEBUG', False):
-            raise BadRequest('Failed to decode JSON object: {0}'.format(e))
-        raise BadRequest()
-
     def _load_form_data(self):
         RequestBase._load_form_data(self)
 
         # In debug mode we're replacing the files multidict with an ad-hoc
         # subclass that raises a different error for key errors.
-        ctx = _request_ctx_stack.top
+        ctx = _app_ctx_stack.top
         if ctx is not None and ctx.app.debug and \
            self.mimetype != 'multipart/form-data' and not self.files:
             from .debughelpers import attach_enctype_error_multidict

--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -18,10 +18,10 @@ from .globals import _request_ctx_stack
 _missing = object()
 
 
-def _get_data(req, cache):
+def _get_data(req):
     getter = getattr(req, 'get_data', None)
     if getter is not None:
-        return getter(cache=cache)
+        return getter()
     return req.data
 
 
@@ -82,7 +82,7 @@ class JSONMixin(object):
         # been encoded correctly as well.
         charset = self.mimetype_params.get('charset')
         try:
-            data = _get_data(self, cache)
+            data = _get_data(self)
             if charset is not None:
                 rv = json.loads(data, encoding=charset)
             else:

--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -25,6 +25,14 @@ def _get_data(req, cache):
     return req.data
 
 
+def _is_mimetype_json(mimetype):
+    if mimetype == 'application/json':
+        return True
+    if mimetype.startswith('application/') and mimetype.endswith('+json'):
+        return True
+    return False
+
+
 class Request(RequestBase):
     """The request object used by default in Flask.  Remembers the
     matched endpoint and view arguments.
@@ -115,12 +123,7 @@ class Request(RequestBase):
 
         .. versionadded:: 1.0
         """
-        mt = self.mimetype
-        if mt == 'application/json':
-            return True
-        if mt.startswith('application/') and mt.endswith('+json'):
-            return True
-        return False
+        return _is_mimetype_json(self.mimetype)
 
     def get_json(self, force=False, silent=False, cache=True):
         """Parses the incoming JSON request data and returns it.  If
@@ -201,3 +204,69 @@ class Response(ResponseBase):
     set :attr:`~flask.Flask.response_class` to your subclass.
     """
     default_mimetype = 'text/html'
+
+    @property
+    def json(self):
+        """If the mimetype is :mimetype:`application/json` this will contain the
+        parsed JSON data.  Otherwise this will be ``None``.
+
+        The :meth:`get_json` method should be used instead.
+
+        .. versionadded:: 1.0
+        """
+        from warnings import warn
+        warn(DeprecationWarning('json is deprecated.  '
+                                'Use get_json() instead.'), stacklevel=2)
+        return self.get_json()
+
+    @property
+    def is_json(self):
+        """Indicates if this response is JSON or not.  By default a response
+        is considered to include JSON data if the mimetype is
+        :mimetype:`application/json` or :mimetype:`application/*+json`.
+
+        .. versionadded:: 1.0
+        """
+        return _is_mimetype_json(self.mimetype)
+
+    def get_json(self, force=False, silent=False, cache=True):
+        """Parses the incoming JSON request data and returns it.  If
+        parsing fails the :meth:`on_json_loading_failed` method on the
+        request object will be invoked.  By default this function will
+        only load the json data if the mimetype is :mimetype:`application/json`
+        but this can be overridden by the `force` parameter.
+
+        :param force: if set to ``True`` the mimetype is ignored.
+        :param silent: if set to ``True`` this method will fail silently
+                       and return ``None``.
+        :param cache: if set to ``True`` the parsed JSON data is remembered
+                      on the request.
+
+        .. versionadded:: 1.0
+        """
+        rv = getattr(self, '_cached_json', _missing)
+        if rv is not _missing:
+            return rv
+
+        if not (force or self.is_json):
+            return None
+
+        # We accept a request charset against the specification as
+        # certain clients have been using this in the past.  This
+        # fits our general approach of being nice in what we accept
+        # and strict in what we send out.
+        request_charset = self.mimetype_params.get('charset')
+        try:
+            data = _get_data(self, cache)
+            if request_charset is not None:
+                rv = json.loads(data, encoding=request_charset)
+            else:
+                rv = json.loads(data)
+        except ValueError as e:
+            if silent:
+                rv = None
+            else:
+                rv = self.on_json_loading_failed(e)
+        if cache:
+            self._cached_json = rv
+        return rv

--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -18,13 +18,6 @@ from .globals import _request_ctx_stack
 _missing = object()
 
 
-def _get_data(req):
-    getter = getattr(req, 'get_data', None)
-    if getter is not None:
-        return getter()
-    return req.data
-
-
 class JSONMixin(object):
     """Mixin for both request and response classes to provide JSON parsing
     capabilities.
@@ -57,6 +50,12 @@ class JSONMixin(object):
                                 'Use get_json() instead.'), stacklevel=2)
         return self.get_json()
 
+    def _get_data_for_json(req, cache):
+        getter = getattr(req, 'get_data', None)
+        if getter is not None:
+            return getter(cache=cache)
+        return req.data
+
     def get_json(self, force=False, silent=False, cache=True):
         """Parses the incoming JSON request data and returns it.  If parsing
         fails the :meth:`on_json_loading_failed` will be invoked. By default
@@ -82,7 +81,7 @@ class JSONMixin(object):
         # been encoded correctly as well.
         charset = self.mimetype_params.get('charset')
         try:
-            data = _get_data(self)
+            data = self._get_data_for_json(cache)
             if charset is not None:
                 rv = json.loads(data, encoding=charset)
             else:
@@ -214,3 +213,10 @@ class Response(ResponseBase, JSONMixin):
     set :attr:`~flask.Flask.response_class` to your subclass.
     """
     default_mimetype = 'text/html'
+
+    def _get_data_for_json(req, cache):
+        # Ignore the cache flag since response doesn't support it
+        getter = getattr(req, 'get_data', None)
+        if getter is not None:
+            return getter()
+        return req.data

--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -25,15 +25,86 @@ def _get_data(req, cache):
     return req.data
 
 
-def _is_mimetype_json(mimetype):
-    if mimetype == 'application/json':
-        return True
-    if mimetype.startswith('application/') and mimetype.endswith('+json'):
-        return True
-    return False
+class JSONMixin(object):
+    """Mixin for both request and response classes to provide JSON parsing
+    capabilities.
+
+    .. versionadded:: 1.0
+    """
+
+    @property
+    def is_json(self):
+        """Indicates if this request/response is JSON or not.  By default it
+        is considered to include JSON data if the mimetype is
+        :mimetype:`application/json` or :mimetype:`application/*+json`.
+        """
+        mt = self.mimetype
+        if mt == 'application/json':
+            return True
+        if mt.startswith('application/') and mt.endswith('+json'):
+            return True
+        return False
+
+    @property
+    def json(self):
+        """If the mimetype is :mimetype:`application/json` this will contain the
+        parsed JSON data.  Otherwise this will be ``None``.
+
+        The :meth:`get_json` method should be used instead.
+        """
+        from warnings import warn
+        warn(DeprecationWarning('json is deprecated.  '
+                                'Use get_json() instead.'), stacklevel=2)
+        return self.get_json()
+
+    def get_json(self, force=False, silent=False, cache=True):
+        """Parses the incoming JSON request data and returns it.  If parsing
+        fails the :meth:`on_json_loading_failed` will be invoked. By default
+        this function will only load the JSON data if :attr:`is_json` is true,
+        but this can be overridden by the `force` parameter.
+
+        :param force: if set to ``True`` the mimetype is ignored.
+        :param silent: if set to ``True`` this method will fail silently
+                       and return ``None``.
+        :param cache: if set to ``True`` the parsed JSON data is remembered
+                      on the request.
+        """
+        rv = getattr(self, '_cached_json', _missing)
+        if rv is not _missing:
+            return rv
+
+        if not (force or self.is_json):
+            return None
+
+        # We accept a request charset against the specification as certain
+        # clients have been using this in the past.  For responses, we assume
+        # that if the response charset was set explicitly then the data had
+        # been encoded correctly as well.
+        charset = self.mimetype_params.get('charset')
+        try:
+            data = _get_data(self, cache)
+            if charset is not None:
+                rv = json.loads(data, encoding=charset)
+            else:
+                rv = json.loads(data)
+        except ValueError as e:
+            if silent:
+                rv = None
+            else:
+                rv = self.on_json_loading_failed(e)
+        if cache:
+            self._cached_json = rv
+        return rv
+
+    def on_json_loading_failed(self, e):
+        """Called if decoding of the JSON data failed.  The return value of
+        this method is used by :meth:`get_json` when an error occurred.  The
+        default implementation just raises a :class:`BadRequest` exception.
+        """
+        raise BadRequest()
 
 
-class Request(RequestBase):
+class Request(RequestBase, JSONMixin):
     """The request object used by default in Flask.  Remembers the
     matched endpoint and view arguments.
 
@@ -103,67 +174,6 @@ class Request(RequestBase):
         if self.url_rule and '.' in self.url_rule.endpoint:
             return self.url_rule.endpoint.rsplit('.', 1)[0]
 
-    @property
-    def json(self):
-        """If the mimetype is :mimetype:`application/json` this will contain the
-        parsed JSON data.  Otherwise this will be ``None``.
-
-        The :meth:`get_json` method should be used instead.
-        """
-        from warnings import warn
-        warn(DeprecationWarning('json is deprecated.  '
-                                'Use get_json() instead.'), stacklevel=2)
-        return self.get_json()
-
-    @property
-    def is_json(self):
-        """Indicates if this request is JSON or not.  By default a request
-        is considered to include JSON data if the mimetype is
-        :mimetype:`application/json` or :mimetype:`application/*+json`.
-
-        .. versionadded:: 1.0
-        """
-        return _is_mimetype_json(self.mimetype)
-
-    def get_json(self, force=False, silent=False, cache=True):
-        """Parses the incoming JSON request data and returns it.  If
-        parsing fails the :meth:`on_json_loading_failed` method on the
-        request object will be invoked.  By default this function will
-        only load the json data if the mimetype is :mimetype:`application/json`
-        but this can be overridden by the `force` parameter.
-
-        :param force: if set to ``True`` the mimetype is ignored.
-        :param silent: if set to ``True`` this method will fail silently
-                       and return ``None``.
-        :param cache: if set to ``True`` the parsed JSON data is remembered
-                      on the request.
-        """
-        rv = getattr(self, '_cached_json', _missing)
-        if rv is not _missing:
-            return rv
-
-        if not (force or self.is_json):
-            return None
-
-        # We accept a request charset against the specification as
-        # certain clients have been using this in the past.  This
-        # fits our general approach of being nice in what we accept
-        # and strict in what we send out.
-        request_charset = self.mimetype_params.get('charset')
-        try:
-            data = _get_data(self, cache)
-            if request_charset is not None:
-                rv = json.loads(data, encoding=request_charset)
-            else:
-                rv = json.loads(data)
-        except ValueError as e:
-            if silent:
-                rv = None
-            else:
-                rv = self.on_json_loading_failed(e)
-        if cache:
-            self._cached_json = rv
-        return rv
 
     def on_json_loading_failed(self, e):
         """Called if decoding of the JSON data failed.  The return value of
@@ -194,7 +204,7 @@ class Request(RequestBase):
             attach_enctype_error_multidict(self)
 
 
-class Response(ResponseBase):
+class Response(ResponseBase, JSONMixin):
     """The response object that is used by default in Flask.  Works like the
     response object from Werkzeug but is set to have an HTML mimetype by
     default.  Quite often you don't have to create this object yourself because
@@ -204,69 +214,3 @@ class Response(ResponseBase):
     set :attr:`~flask.Flask.response_class` to your subclass.
     """
     default_mimetype = 'text/html'
-
-    @property
-    def json(self):
-        """If the mimetype is :mimetype:`application/json` this will contain the
-        parsed JSON data.  Otherwise this will be ``None``.
-
-        The :meth:`get_json` method should be used instead.
-
-        .. versionadded:: 1.0
-        """
-        from warnings import warn
-        warn(DeprecationWarning('json is deprecated.  '
-                                'Use get_json() instead.'), stacklevel=2)
-        return self.get_json()
-
-    @property
-    def is_json(self):
-        """Indicates if this response is JSON or not.  By default a response
-        is considered to include JSON data if the mimetype is
-        :mimetype:`application/json` or :mimetype:`application/*+json`.
-
-        .. versionadded:: 1.0
-        """
-        return _is_mimetype_json(self.mimetype)
-
-    def get_json(self, force=False, silent=False, cache=True):
-        """Parses the incoming JSON request data and returns it.  If
-        parsing fails the :meth:`on_json_loading_failed` method on the
-        request object will be invoked.  By default this function will
-        only load the json data if the mimetype is :mimetype:`application/json`
-        but this can be overridden by the `force` parameter.
-
-        :param force: if set to ``True`` the mimetype is ignored.
-        :param silent: if set to ``True`` this method will fail silently
-                       and return ``None``.
-        :param cache: if set to ``True`` the parsed JSON data is remembered
-                      on the request.
-
-        .. versionadded:: 1.0
-        """
-        rv = getattr(self, '_cached_json', _missing)
-        if rv is not _missing:
-            return rv
-
-        if not (force or self.is_json):
-            return None
-
-        # We accept a request charset against the specification as
-        # certain clients have been using this in the past.  This
-        # fits our general approach of being nice in what we accept
-        # and strict in what we send out.
-        request_charset = self.mimetype_params.get('charset')
-        try:
-            data = _get_data(self, cache)
-            if request_charset is not None:
-                rv = json.loads(data, encoding=request_charset)
-            else:
-                rv = json.loads(data)
-        except ValueError as e:
-            if silent:
-                rv = None
-            else:
-                rv = self.on_json_loading_failed(e)
-        if cache:
-            self._cached_json = rv
-        return rv

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -13,6 +13,7 @@ import pytest
 import flask
 
 from flask._compat import text_type
+from flask.json import jsonify
 
 
 def test_environ_defaults_from_config():
@@ -209,20 +210,26 @@ def test_full_url_request():
         assert 'gin' in flask.request.form
         assert 'vodka' in flask.request.args
 
-def test_json_request():
+def test_json_request_and_response():
     app = flask.Flask(__name__)
     app.testing = True
 
-    @app.route('/api', methods=['POST'])
-    def api():
-        return ''
+    @app.route('/echo', methods=['POST'])
+    def echo():
+        return jsonify(flask.request.json)
 
     with app.test_client() as c:
         json_data = {'drink': {'gin': 1, 'tonic': True}, 'price': 10}
-        rv = c.post('/api', json=json_data)
-        assert rv.status_code == 200
+        rv = c.post('/echo', json=json_data)
+
+        # Request should be in JSON
         assert flask.request.is_json
         assert flask.request.get_json() == json_data
+
+        # Response should be in JSON
+        assert rv.status_code == 200
+        assert rv.is_json
+        assert rv.get_json() == json_data
 
 def test_subdomain():
     app = flask.Flask(__name__)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -221,6 +221,7 @@ def test_json_request():
         json_data = {'drink': {'gin': 1, 'tonic': True}, 'price': 10}
         rv = c.post('/api', json=json_data)
         assert rv.status_code == 200
+        assert flask.request.is_json
         assert flask.request.get_json() == json_data
 
 def test_subdomain():

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -209,6 +209,20 @@ def test_full_url_request():
         assert 'gin' in flask.request.form
         assert 'vodka' in flask.request.args
 
+def test_json_request():
+    app = flask.Flask(__name__)
+    app.testing = True
+
+    @app.route('/api', methods=['POST'])
+    def api():
+        return ''
+
+    with app.test_client() as c:
+        json_data = {'drink': {'gin': 1, 'tonic': True}, 'price': 10}
+        rv = c.post('/api', json=json_data)
+        assert rv.status_code == 200
+        assert flask.request.get_json() == json_data
+
 def test_subdomain():
     app = flask.Flask(__name__)
     app.config['SERVER_NAME'] = 'example.com'


### PR DESCRIPTION
Common code has been refactored into a mixin shared between request and response classes. This is a continuation of #1408.