### PR TITLE
Built in routes command

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -476,8 +476,11 @@ def routes_command(order_by):
     sorted_rules = sorted(app.url_map.iter_rules(), key=order_key)
 
     max_rule = max(len(rule.rule) for rule in sorted_rules)
+    max_rule = max(max_rule, len('Route'))
     max_ep = max(len(rule.endpoint) for rule in sorted_rules)
+    max_ep = max(max_ep, len('Endpoint'))
     max_meth = max(len(', '.join(rule.methods)) for rule in sorted_rules)
+    max_meth = max(max_meth, len('Methods'))
 
     columnformat = '{:<%s}  {:<%s}  {:<%s}' % (max_rule, max_ep, max_meth)
     click.echo(columnformat.format('Route', 'Endpoint', 'Methods'))

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -304,6 +304,7 @@ class FlaskGroup(AppGroup):
         if add_default_commands:
             self.add_command(run_command)
             self.add_command(shell_command)
+            self.add_command(routes_command)
 
         self._loaded_plugin_commands = False
 
@@ -459,6 +460,33 @@ def shell_command():
     ctx.update(app.make_shell_context())
 
     code.interact(banner=banner, local=ctx)
+
+
+@click.command('routes', short_help='Show routes for the app.')
+@click.option('-r', 'order_by', flag_value='rule', default=True, help='Order by route')
+@click.option('-e', 'order_by', flag_value='endpoint', help='Order by endpoint')
+@click.option('-m', 'order_by', flag_value='methods', help='Order by methods')
+@with_appcontext
+def routes_command(order_by):
+    """Show all routes with endpoints and methods."""
+    from flask.globals import _app_ctx_stack
+    app = _app_ctx_stack.top.app
+
+    order_key = lambda rule: getattr(rule, order_by)
+    sorted_rules = sorted(app.url_map.iter_rules(), key=order_key)
+
+    max_rule = max(len(rule.rule) for rule in sorted_rules)
+    max_ep = max(len(rule.endpoint) for rule in sorted_rules)
+    max_meth = max(len(', '.join(rule.methods)) for rule in sorted_rules)
+
+    columnformat = '{:<%s}  {:<%s}  {:<%s}' % (max_rule, max_ep, max_meth)
+    click.echo(columnformat.format('Route', 'Endpoint', 'Methods'))
+    under_count = max_rule + max_ep + max_meth + 4
+    click.echo('-' * under_count)
+
+    for rule in sorted_rules:
+        methods = ', '.join(rule.methods)
+        click.echo(columnformat.format(rule.rule, rule.endpoint, methods))
 
 
 cli = FlaskGroup(help="""\

--- a/tests/test_apps/cliapp/routesapp.py
+++ b/tests/test_apps/cliapp/routesapp.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import, print_function
+
+from flask import Flask
+
+
+noroute_app = Flask('noroute app')
+simpleroute_app = Flask('simpleroute app')
+only_POST_route_app = Flask('GET route app')
+
+
+@simpleroute_app.route('/simpleroute')
+def simple():
+    pass
+
+
+@only_POST_route_app.route('/only-post', methods=['POST'])
+def only_post():
+    pass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,11 @@ from flask.cli import cli, AppGroup, FlaskGroup, NoAppException, ScriptInfo, \
     find_default_import_path
 
 
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
 def test_cli_name(test_apps):
     """Make sure the CLI object's name is the app's name and not the app itself"""
     from cliapp.app import testapp
@@ -108,7 +113,7 @@ def test_scriptinfo(test_apps):
     assert obj.load_app() == app
 
 
-def test_with_appcontext():
+def test_with_appcontext(runner):
     """Test of with_appcontext."""
     @click.command()
     @with_appcontext
@@ -117,13 +122,12 @@ def test_with_appcontext():
 
     obj = ScriptInfo(create_app=lambda info: Flask("testapp"))
 
-    runner = CliRunner()
     result = runner.invoke(testcmd, obj=obj)
     assert result.exit_code == 0
     assert result.output == 'testapp\n'
 
 
-def test_appgroup():
+def test_appgroup(runner):
     """Test of with_appcontext."""
     @click.group(cls=AppGroup)
     def cli():
@@ -143,7 +147,6 @@ def test_appgroup():
 
     obj = ScriptInfo(create_app=lambda info: Flask("testappgroup"))
 
-    runner = CliRunner()
     result = runner.invoke(cli, ['test'], obj=obj)
     assert result.exit_code == 0
     assert result.output == 'testappgroup\n'
@@ -153,7 +156,7 @@ def test_appgroup():
     assert result.output == 'testappgroup\n'
 
 
-def test_flaskgroup():
+def test_flaskgroup(runner):
     """Test FlaskGroup."""
     def create_app(info):
         return Flask("flaskgroup")
@@ -166,16 +169,14 @@ def test_flaskgroup():
     def test():
         click.echo(current_app.name)
 
-    runner = CliRunner()
     result = runner.invoke(cli, ['test'])
     assert result.exit_code == 0
     assert result.output == 'flaskgroup\n'
 
 
 class TestRoutes:
-    def test_no_route(self, monkeypatch):
+    def test_no_route(self, runner, monkeypatch):
         monkeypatch.setitem(os.environ, 'FLASK_APP', 'cliapp.routesapp:noroute_app')
-        runner = CliRunner()
         result = runner.invoke(cli, ['routes'], catch_exceptions=False)
         assert result.exit_code == 0
         assert result.output == """\
@@ -184,9 +185,8 @@ Route                    Endpoint  Methods
 /static/<path:filename>  static    HEAD, OPTIONS, GET
 """
 
-    def test_simple_route(self, monkeypatch):
+    def test_simple_route(self, runner, monkeypatch):
         monkeypatch.setitem(os.environ, 'FLASK_APP', 'cliapp.routesapp:simpleroute_app')
-        runner = CliRunner()
         result = runner.invoke(cli, ['routes'], catch_exceptions=False)
         assert result.exit_code == 0
         assert result.output == """\
@@ -196,9 +196,8 @@ Route                    Endpoint  Methods
 /static/<path:filename>  static    HEAD, OPTIONS, GET
 """
 
-    def test_only_POST_route(self, monkeypatch):
+    def test_only_POST_route(self, runner, monkeypatch):
         monkeypatch.setitem(os.environ, 'FLASK_APP', 'cliapp.routesapp:only_POST_route_app')
-        runner = CliRunner()
         result = runner.invoke(cli, ['routes'], catch_exceptions=False)
         assert result.exit_code == 0
         assert result.output == """\


### PR DESCRIPTION
I don't want to spam the builtin command namespace (anyway, why not? Django have a lot of builtin commands and works pretty well) but this is the first command I always implement when I start using flask, and my collegues were doing this also.
It shows all the endpoints registered for the app. Routes can be ordered by rules, endpoints and methods.
This is a WIP, because I did not wrote tests for it yet and did not tried with 2.6 and 2.7.
I would like to have some feedback on this and I can work out the details.
