### PR TITLE
Code fix for issue #1481

### DIFF
--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -635,7 +635,12 @@ def get_root_path(import_name):
         return os.path.dirname(os.path.abspath(mod.__file__))
 
     # Next attempt: check the loader.
-    loader = pkgutil.get_loader(import_name)
+    loader = None
+    try:
+        loader = pkgutil.get_loader(import_name)
+    except AttributeError:
+        pass
+
 
     # Loader does not exist or we're referring to an unloaded main module
     # or a main module without path (interactive sessions), go with the

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -678,3 +678,13 @@ class TestStreaming(object):
         rv = c.get('/?name=World')
         assert rv.data == b'Hello World!'
         assert called == [42]
+
+
+class TestGetRootPath(object):
+
+    def test_static_string_passed(self):
+        """
+        Should just return the current working directory.
+        """
+        reported_path = flask.helpers.get_root_path("testing")
+        assert os.path.realpath(".") == reported_path


### PR DESCRIPTION
This is a unit test and code fix for issue #1481 that keeps the previous behavior of get_root_path and intercepts the new `AttributeError` thrown by `pkgutil.get_loader`.