### PR TITLE
Add kwarg to disable auto OPTIONS on add_url_rule

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -70,9 +70,9 @@ Version 1.0
 - ``flask.g`` now has ``pop()`` and ``setdefault`` methods.
 - Turn on autoescape for ``flask.templating.render_template_string`` by default
   (pull request ``#1515``).
-- Added support for `provide_automatic_options` in `**kwargs` on
-  :meth:`add_url_rule` to turn off automatic OPTIONS when the `view_func`
-  argument is not a class (pull request ``#1489``).
+- Added support for `provide_automatic_options` in :meth:`add_url_rule` to
+  turn off automatic OPTIONS when the `view_func` argument is not a class
+  (pull request ``#1489``).
 
 Version 0.10.2
 --------------

--- a/CHANGES
+++ b/CHANGES
@@ -70,6 +70,9 @@ Version 1.0
 - ``flask.g`` now has ``pop()`` and ``setdefault`` methods.
 - Turn on autoescape for ``flask.templating.render_template_string`` by default
   (pull request ``#1515``).
+- Added support for `provide_automatic_options` in `**kwargs` on
+  :meth:`add_url_rule` to turn off automatic OPTIONS when the `view_func`
+  argument is not a class (pull request ``#1489``).
 
 Version 0.10.2
 --------------

--- a/flask/app.py
+++ b/flask/app.py
@@ -1013,8 +1013,10 @@ class Flask(_PackageBoundObject):
 
         # starting with Flask 0.8 the view_func object can disable and
         # force-enable the automatic options handling.
-        provide_automatic_options = getattr(view_func,
-            'provide_automatic_options', None)
+        provide_automatic_options = options.pop(
+            'provide_automatic_options', getattr(view_func,
+                'provide_automatic_options', None))
+
 
         if provide_automatic_options is None:
             if 'OPTIONS' not in methods:

--- a/flask/app.py
+++ b/flask/app.py
@@ -944,7 +944,8 @@ class Flask(_PackageBoundObject):
         return iter(self._blueprint_order)
 
     @setupmethod
-    def add_url_rule(self, rule, endpoint=None, view_func=None, **options):
+    def add_url_rule(self, rule, endpoint=None, view_func=None,
+                     provide_automatic_options=None, **options):
         """Connects a URL rule.  Works exactly like the :meth:`route`
         decorator.  If a view_func is provided it will be registered with the
         endpoint.
@@ -984,6 +985,10 @@ class Flask(_PackageBoundObject):
                          endpoint
         :param view_func: the function to call when serving a request to the
                           provided endpoint
+        :param provide_automatic_options: controls whether ``OPTIONS`` should
+                                          be provided automatically. If this
+                                          is not set, will check attributes on
+                                          the view or list of methods.
         :param options: the options to be forwarded to the underlying
                         :class:`~werkzeug.routing.Rule` object.  A change
                         to Werkzeug is handling of method options.  methods
@@ -1013,10 +1018,9 @@ class Flask(_PackageBoundObject):
 
         # starting with Flask 0.8 the view_func object can disable and
         # force-enable the automatic options handling.
-        provide_automatic_options = options.pop(
-            'provide_automatic_options', getattr(view_func,
-                'provide_automatic_options', None))
-
+        if provide_automatic_options is None:
+            provide_automatic_options = getattr(view_func,
+                'provide_automatic_options', None)
 
         if provide_automatic_options is None:
             if 'OPTIONS' not in methods:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1604,3 +1604,44 @@ def test_run_server_port(monkeypatch):
     hostname, port = 'localhost', 8000
     app.run(hostname, port, debug=True)
     assert rv['result'] == 'running on %s:%s ...' % (hostname, port)
+
+
+def test_disable_automatic_options():
+    # Issue 1488: Add support for a kwarg to add_url_rule to disable the auto OPTIONS response
+    app = flask.Flask(__name__)
+
+    def index():
+        return flask.request.method
+
+    def more():
+        return flask.request.method
+
+    app.add_url_rule('/', 'index', index, provide_automatic_options=False)
+    app.add_url_rule('/more', 'more', more, methods=['GET', 'POST'], provide_automatic_options=False)
+
+    c = app.test_client()
+    assert c.get('/').data == b'GET'
+    rv = c.post('/')
+    assert rv.status_code == 405
+    assert sorted(rv.allow) == ['GET', 'HEAD']
+    # Older versions of Werkzeug.test.Client don't have an options method
+    if hasattr(c, 'options'):
+        rv = c.options('/')
+    else:
+        rv = c.open('/', method='OPTIONS')
+    assert rv.status_code == 405
+
+    rv = c.head('/')
+    assert rv.status_code == 200
+    assert not rv.data  # head truncates
+    assert c.post('/more').data == b'POST'
+    assert c.get('/more').data == b'GET'
+    rv = c.delete('/more')
+    assert rv.status_code == 405
+    assert sorted(rv.allow) == ['GET', 'HEAD', 'POST']
+    # Older versions of Werkzeug.test.Client don't have an options method
+    if hasattr(c, 'options'):
+        rv = c.options('/more')
+    else:
+        rv = c.open('/more', method='OPTIONS')
+    assert rv.status_code == 405


### PR DESCRIPTION
Fixes #1488 : Adds support for a kwarg `provide_automatic_options` on `add_url_rule`, which
lets you turn off the automatic OPTIONS response on a per-URL basis even if
your view functions are functions, not classes (so you can't provide attrs
on them).
