### PR TITLE
Support argument-less factory functions in CLI

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -41,10 +41,17 @@ def find_best_app(module):
 
     if len(matches) == 1:
         return matches[0]
+
+    # Finally, look for a factory function
+    factory = getattr(module, 'create_app', None)
+    if callable(factory):
+        return factory()
+
     raise NoAppException('Failed to find application in module "%s".  Are '
                          'you sure it contains a Flask application?  Maybe '
                          'you wrapped it in a WSGI middleware or you are '
-                         'using a factory function.' % module.__name__)
+                         'using a factory function with an uncommon name?.'
+                         % module.__name__)
 
 
 def prepare_exec_for_file(filename):


### PR DESCRIPTION
Since the cli module does does fairly aggressive autodiscovery of a
flask application object anyway, supporting argument-less factory
functions is not far from the current behavior.

Argument-less factory function do happen if you configuration is based on your environment. There's a whole pattern around it (see http://12factor.net) that Heroku uses. I've written a Flask-Extension to support it (http://github.com/mbr/flask-appconfig) and I want to make sure it integrates well with the 1.0 CLI features.

While it is possible to write a script to get the same functionality, this is a bit of a convention-over-configuration issue and seeing that the CLI already searches pretty thoroughly for an app instance, looking for a callable ``create_app()`` function seems reasonable (and very useful!) to me.

This may get a bit confusing if ``create_app()`` does exepct arguments, but the resulting 

    TypeError: create_app() takes exactly 1 argument (0 given)

seems very clear.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pallets/flask/1536)
<!-- Reviewable:end -->
