### PR TITLE
Fix static route when using host_matching = True

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,6 +21,7 @@ Patches and Suggestions
 - Florent Xicluna
 - Georg Brandl
 - Jeff Widman @jeffwidman
+- Joshua Bronson @jab
 - Justin Quick
 - Kenneth Reitz
 - Keyan Pishdadian

--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,11 @@ Major release, unreleased
 - Change default configuration `JSONIFY_PRETTYPRINT_REGULAR=False`. jsonify()
   method returns compressed response by default, and pretty response in
   debug mode.
+- Change Flask.__init__ to accept two new keyword arguments, ``host_matching``
+  and ``static_host``. This enables ``host_matching`` to be set properly by the
+  time the constructor adds the static route, and enables the static route to
+  be properly associated with the required host. (``#1559``)
+
 
 Version 0.12.1
 --------------

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1171,6 +1171,25 @@ def test_static_url_path():
         assert flask.url_for('static', filename='index.html') == '/foo/index.html'
 
 
+def test_static_route_with_host_matching():
+    app = flask.Flask(__name__, host_matching=True, static_host='example.com')
+    c = app.test_client()
+    rv = c.get('http://example.com/static/index.html')
+    assert rv.status_code == 200
+    rv.close()
+    with app.test_request_context():
+       rv = flask.url_for('static', filename='index.html', _external=True)
+       assert rv == 'http://example.com/static/index.html'
+    # Providing static_host without host_matching=True should error.
+    with pytest.raises(Exception):
+        flask.Flask(__name__, static_host='example.com')
+    # Providing host_matching=True with static_folder but without static_host should error.
+    with pytest.raises(Exception):
+        flask.Flask(__name__, host_matching=True)
+    # Providing host_matching=True without static_host but with static_folder=None should not error.
+    flask.Flask(__name__, host_matching=True, static_folder=None)
+
+
 def test_none_response():
     app = flask.Flask(__name__)
     app.testing = True


### PR DESCRIPTION
Change `Flask.__init__` to accept two new keyword arguments, `host_matching` and `static_host`.

This enables host_matching to be set properly by the time the constructor adds
the static route, and enables the static route to be properly associated with
the required host.

Previously, you could only enable host_matching once your app was already
instantiated (e.g. `app.url_map.host_matching = True`), but at that point
the constructor would have already added the static route without host matching
and an associated host, leaving the static route in a broken state.

Fixes #1559.
