### PR TITLE
Url conflict assert

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -602,6 +602,56 @@ def test_request_preprocessing_early_return():
     assert rv == b'hello'
     assert evts == [1, 2]
 
+def test_assertion_on_two_routes_same_function_name():
+    app = flask.Flask(__name__)
+    app.testing = True
+
+    with pytest.raises(AssertionError):
+        @app.route("/testing")
+        def index():
+            return "test"
+
+        @app.route("/testing2")
+        def index():
+            return "test"
+
+def test_assertion_on_two_routes_same_url():
+    app = flask.Flask(__name__)
+    app.testing = True
+
+    with pytest.raises(AssertionError):
+        @app.route("/testing")
+        def index():
+            return "test"
+
+        @app.route("/testing")
+        def index2():
+            return "test"
+
+def test_assertion_on_two_routes_same_url_overlapping_methods():
+    app = flask.Flask(__name__)
+    app.testing = True
+
+    with pytest.raises(AssertionError):
+        @app.route("/testing", methods=["GET", "POST"])
+        def index():
+            return "test"
+
+        @app.route("/testing", methods=["POST", "PUTS"])
+        def index2():
+            return "test"
+
+def test_no_assertion_on_two_routes_same_url_different_methods():
+    app = flask.Flask(__name__)
+    app.testing = True
+
+    @app.route("/testing", methods=["GET"])
+    def index():
+        return "test"
+
+    @app.route("/testing", methods=["POST"])
+    def index2():
+        return "test"
 
 def test_after_request_processing():
     app = flask.Flask(__name__)


### PR DESCRIPTION
This PR is an attempt to reconcile the fact that you can't have two routes with the same function name but you can create two routes with the same URL.

```
from flask import Flask
app = Flask("the_flask_module")

@app.route("/hello")
def hello_page():
    return "I'm a hello page"

@app.route("/different_route")
def hello_page():
    return "Different route"
```

will throw an `AssertionError`

but 

```
@app.route("/hello")
def end_point1():
    return "I'm a hello page"

@app.route("/hello")
def end_point2():
    return "Different route"
```

wont. In fact the second route is unreachable. 

This PR checks to see if three conditions are true before raising an assertion. The new rule has to have a `subdomain`, `url_path`, and one `method` that overlap with a current rule in the `self.url_map object`.

There's a couple of wonky pieces in this pull request that were required to get all of the unit tests to pass.

```
if prior_rule.rule == "/static/<path:filename>":
    continue
```

was required to get blueprints to not throw an assertion since each blueprint registers a `"/static/<path:filename>"` rule for each blueprint. I tried to find a way to not have to use a static string but alas I failed. 

Secondly 

```
 methods_minus_required = ((rule.methods & prior_rule.methods) 
     - required_methods)
```

is used to check for all explicitly registered methods for a route since there were a bunch of cases where the `OPTIONS` method was implicitly added to rules that shared a url_path.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pallets/flask/1568)

<!-- Reviewable:end -->
