### PR TITLE
url_for with alternating schemes

### DIFF
--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -303,6 +303,8 @@ def url_for(endpoint, **values):
         if not external:
             raise ValueError('When specifying _scheme, _external must be True')
         url_adapter.url_scheme = scheme
+    else:
+        url_adapter.url_scheme = current_app.config['PREFERRED_URL_SCHEME']
 
     try:
         rv = url_adapter.build(endpoint, values, method=method,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -578,6 +578,16 @@ class TestLogging(object):
                                'index',
                                _scheme='https')
 
+    def test_url_for_with_alternating_schemes(self):
+        app = flask.Flask(__name__)
+        @app.route('/')
+        def index():
+            return '42'
+        with app.test_request_context():
+            assert flask.url_for('index', _external=True) == 'http://localhost/'
+            assert flask.url_for('index', _external=True, _scheme='https') == 'https://localhost/'
+            assert flask.url_for('index', _external=True) == 'http://localhost/'
+
     def test_url_with_method(self):
         from flask.views import MethodView
         app = flask.Flask(__name__)


### PR DESCRIPTION
I noticed unexpected behaviour with ```url_for``` when generating multiple urls with different schemes during a request. After calling ```url_for``` with a specific ```_scheme```, this scheme will become the default scheme in the current context's url_adapter.

Best demonstrated with a small example:
```
import flask

app = flask.Flask(__name__)

@app.route('/')
def hello():
    return 'Hello World'


with app.test_request_context('/'):
    flask.url_for('hello', _external=True)
    # http://localhost/
    flask.url_for('hello', _external=True, _scheme='https')
    # https://localhost/
    flask.url_for('hello', _external=True)
    # https://localhost/
```
I would expect the first and third call to return the exact same result.

PR contains a test demonstrating the issue and a proposed fix.