### PR TITLE
Extend documentation about uwsgi/nginx deployment

### DIFF
--- a/docs/deploying/uwsgi.rst
+++ b/docs/deploying/uwsgi.rst
@@ -31,12 +31,14 @@ Given a flask application in myapp.py, use the following command:
 
     $ uwsgi -s /tmp/uwsgi.sock --manage-script-name --mount /yourapplication=myapp:app
 
-The ``--manage-script-name`` will move the handling of ``SCRIPT_NAME`` to
-uwsgi, since its smarter about that. It is used together with the ``--mount``
-directive which will make requests to ``/yourapplication`` be directed to
-``myapp:app``, where ``myapp`` refers to the name of the file of your flask
-application (without extension). ``app`` is the callable inside of your
-application (usually the line reads ``app = Flask(__name__)``.
+The ``--manage-script-name`` will move the handling of ``SCRIPT_NAME`` to uwsgi,
+since its smarter about that. It is used together with the ``--mount`` directive
+which will make requests to ``/yourapplication`` be directed to ``myapp:app``.
+If your application is accessible at root level, you can use a single ``/``
+instead of ``/yourapplication``. ``myapp`` refers to the name of the file of
+your flask application (without extension) or the module which provides ``app``.
+``app`` is the callable inside of your application (usually the line reads
+``app = Flask(__name__)``.
 
 If you want to deploy your flask application inside of a virtual environment,
 you need to also add ``--virtualenv /path/to/virtual/environment``. You might


### PR DESCRIPTION
This patch intends to provide more information about uwsgi/nginx deployment when the app callable is in (``yourapp/__init__.py``) and the application is attached to the '/' URL.
I'm not English native so I expect some remarks ;)

Related to previous #1464