### PR TITLE
Refactored method Flask.make_response to improve readability

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -1672,11 +1672,11 @@ class Flask(_PackageBoundObject):
         """
         return False
 
-    def make_response(self, rv):
+    def make_response(self, view_func_rv):
         """Converts the return value from a view function to a real
         response object that is an instance of :attr:`response_class`.
 
-        The following types are allowed for `rv`:
+        The following types are allowed for `view_func_rv`:
 
         .. tabularcolumns:: |p{3.5cm}|p{9.5cm}|
 
@@ -1688,51 +1688,65 @@ class Flask(_PackageBoundObject):
                                 string encoded to utf-8 as body
         a WSGI function         the function is called as WSGI application
                                 and buffered as response object
-        :class:`tuple`          A tuple in the form ``(response, status,
-                                headers)`` or ``(response, headers)``
+        :class:`tuple`          A tuple in the form ``(response, status, headers)``,
+                                ``(response, status) or ``(response, headers)``,
                                 where `response` is any of the
-                                types defined here, `status` is a string
-                                or an integer and `headers` is a list or
-                                a dictionary with header values.
+                                types defined here, `status` is a string or an integer
+                                and `headers` is a dictionary of header values, or
+                                a list of tuples, e.g. [('X-Foo', 'bar')].
+                                If a :attr:`response_class` object is used as `response`
+                                and a status is specified both in the `response` object and in
+                                in the tuple, the status from the tuple is preferred.
+                                Also if a :attr:`response_class` object is used as `response`
+                                and headers are present both in the `response` object and in the tuple,
+                                the headers from both sources are included in the resulting response.
         ======================= ===========================================
 
-        :param rv: the return value from the view function
+        :param view_func_rv: the return value from the view function
 
         .. versionchanged:: 0.9
            Previously a tuple was interpreted as the arguments for the
            response object.
         """
-        status_or_headers = headers = None
-        if isinstance(rv, tuple):
-            rv, status_or_headers, headers = rv + (None,) * (3 - len(rv))
-
-        if rv is None:
+        if view_func_rv is None:
             raise ValueError('View function did not return a response')
 
-        if isinstance(status_or_headers, (dict, list)):
-            headers, status_or_headers = status_or_headers, None
+        if isinstance(view_func_rv, self.response_class):
+            return view_func_rv
+        elif isinstance(view_func_rv, (text_type, bytes, bytearray)):
+            return self.response_class(view_func_rv)
+        elif isinstance(view_func_rv, tuple):
+            return self._make_response_from_tuple(view_func_rv)
+        else:
+            return self.response_class.force_type(view_func_rv, request.environ)
 
-        if not isinstance(rv, self.response_class):
-            # When we create a response object directly, we let the constructor
-            # set the headers and status.  We do this because there can be
-            # some extra logic involved when creating these objects with
-            # specific values (like default content type selection).
-            if isinstance(rv, (text_type, bytes, bytearray)):
-                rv = self.response_class(rv, headers=headers,
-                                         status=status_or_headers)
-                headers = status_or_headers = None
+    def _make_response_from_tuple(self, view_func_rv):
+        if len(view_func_rv) == 3:
+            response_body, status, headers = view_func_rv
+        elif len(view_func_rv) == 2:
+            response_body = view_func_rv[0]
+
+            second_param_is_headers = isinstance(view_func_rv[1], (list, dict))
+            if second_param_is_headers:
+                headers, status = view_func_rv[1], None
             else:
-                rv = self.response_class.force_type(rv, request.environ)
+                headers, status = [], view_func_rv[1]
+        else:
+            raise ValueError('Tuples returned from view functions must be composed as one '
+                             'of the following options: (response_body, status, headers), '
+                             '(response_body, status) or (response_body, headers).')
 
-        if status_or_headers is not None:
-            if isinstance(status_or_headers, string_types):
-                rv.status = status_or_headers
-            else:
-                rv.status_code = status_or_headers
-        if headers:
-            rv.headers.extend(headers)
+        if isinstance(response_body, self.response_class):
+            if status is None:
+                status = response_body.status
+            if response_body.headers:
+                # Headers.extend can take a dict, or any iterable that yields key and value pairs.
+                # so this will work whether headers is a dict or a list
+                response_body.headers.extend(headers)
+                headers = response_body.headers
+            response_body = response_body.response
 
-        return rv
+        return self.response_class(response=response_body, status=status, headers=headers)
 
     def create_url_adapter(self, request):
         """Creates a URL adapter for the given request.  The URL adapter

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -897,7 +897,7 @@ def test_enctype_debug_helper():
             assert False, 'Expected exception'
 
 
-def test_response_creation():
+def test_response_creation_from_text():
     app = flask.Flask(__name__)
 
     @app.route('/unicode')
@@ -908,53 +908,76 @@ def test_response_creation():
     def from_string():
         return u'Hällo Wörld'.encode('utf-8')
 
-    @app.route('/args')
-    def from_tuple():
+    c = app.test_client()
+    assert c.get('/unicode').data == u'Hällo Wörld'.encode('utf-8')
+    assert c.get('/string').data == u'Hällo Wörld'.encode('utf-8')
+
+
+def test_response_creation_from_tuple():
+    app = flask.Flask(__name__)
+    app.testing = True  # among other things this makes the test client propagate exceptions.
+
+    @app.route('/tuple1')
+    def from_tuple_of_three_with_str_body():
         return 'Meh', 400, {
             'X-Foo': 'Testing',
             'Content-Type': 'text/plain; charset=utf-8'
         }
 
-    @app.route('/two_args')
-    def from_two_args_tuple():
+    @app.route('/tuple2')
+    def from_tuple_of_two_with_str_body():
         return 'Hello', {
             'X-Foo': 'Test',
             'Content-Type': 'text/plain; charset=utf-8'
         }
 
-    @app.route('/args_status')
-    def from_status_tuple():
+    @app.route('/tuple3')
+    def from_tuple_of_two_with_str_body_and_status():
         return 'Hi, status!', 400
 
-    @app.route('/args_header')
-    def from_response_instance_status_tuple():
+    @app.route('/tuple4')
+    def from_tuple_of_two_with_response_object_and_headers():
         return flask.Response('Hello world', 404), {
             "X-Foo": "Bar",
             "X-Bar": "Foo"
         }
 
-    c = app.test_client()
-    assert c.get('/unicode').data == u'Hällo Wörld'.encode('utf-8')
-    assert c.get('/string').data == u'Hällo Wörld'.encode('utf-8')
-    rv = c.get('/args')
-    assert rv.data == b'Meh'
-    assert rv.headers['X-Foo'] == 'Testing'
-    assert rv.status_code == 400
-    assert rv.mimetype == 'text/plain'
-    rv2 = c.get('/two_args')
-    assert rv2.data == b'Hello'
-    assert rv2.headers['X-Foo'] == 'Test'
-    assert rv2.status_code == 200
-    assert rv2.mimetype == 'text/plain'
-    rv3 = c.get('/args_status')
-    assert rv3.data == b'Hi, status!'
-    assert rv3.status_code == 400
-    assert rv3.mimetype == 'text/html'
-    rv4 = c.get('/args_header')
-    assert rv4.data == b'Hello world'
-    assert rv4.headers['X-Foo'] == 'Bar'
-    assert rv4.headers['X-Bar'] == 'Foo'
-    assert rv4.status_code == 404
+    @app.route('/tuple5')
+    def from_illegal_tuple():
+        return ('Breakin de law',)
+
+    client = app.test_client()
+
+    response1 = client.get('/tuple1')
+    assert response1.data == b'Meh'
+    assert response1.status_code == 400
+    assert response1.status == '400 BAD REQUEST'
+    assert response1.headers['X-Foo'] == 'Testing'
+
+    response2 = client.get('/tuple2')
+    assert response2.data == b'Hello'
+    assert response2.headers['X-Foo'] == 'Test'
+    assert response2.status == '200 OK'
+    assert response2.status_code == 200
+    assert response2.mimetype == 'text/plain'
+
+    response3 = client.get('/tuple3')
+    assert response3.data == b'Hi, status!'
+    assert response1.status == '400 BAD REQUEST'
+    assert response3.status_code == 400
+    assert response3.mimetype == 'text/html'
+
+    response4 = client.get('/tuple4')
+    assert response4.data == b'Hello world'
+    assert response4.headers['X-Foo'] == 'Bar'
+    assert response4.headers['X-Bar'] == 'Foo'
+    assert response4.status == '404 NOT FOUND'
+    assert response4.status_code == 404
+
+    with pytest.raises(ValueError) as exc_info:
+        client.get('/tuple5')
+    assert 'Tuples returned from view functions must be composed as one of the following options' \
+           in str(exc_info.value)
 
 
 def test_make_response():
@@ -978,6 +1001,7 @@ def test_make_response():
 
 def test_make_response_with_response_instance():
     app = flask.Flask(__name__)
+
     with app.test_request_context():
         rv = flask.make_response(
             flask.jsonify({'msg': 'W00t'}), 400)


### PR DESCRIPTION
The method now looks at the type of the object returned from the view function, and returns a `self.response_class` object based on that type.

The docstring for the method has also been improved and contains a more
detailed explanation for what can be returned from a view function.

Also refactored the test for response creation.
