### PR TITLE
Fix PEP8 issues and enforce PEP8 via pytest-pep8 (i.e. also during CI)

### DIFF
--- a/flask/__init__.py
+++ b/flask/__init__.py
@@ -20,21 +20,22 @@ from jinja2 import Markup, escape
 
 from .app import Flask, Request, Response
 from .config import Config
-from .helpers import url_for, flash, send_file, send_from_directory, \
-     get_flashed_messages, get_template_attribute, make_response, safe_join, \
-     stream_with_context
-from .globals import current_app, g, request, session, _request_ctx_stack, \
-     _app_ctx_stack
-from .ctx import has_request_context, has_app_context, \
-     after_this_request, copy_current_request_context
+from .helpers import (url_for, flash, send_file, send_from_directory,
+                      get_flashed_messages, get_template_attribute,
+                      make_response, safe_join, stream_with_context)
+from .globals import (current_app, g, request, session, _request_ctx_stack,
+                      _app_ctx_stack)
+from .ctx import (has_request_context, has_app_context, after_this_request,
+                  copy_current_request_context)
 from .blueprints import Blueprint
 from .templating import render_template, render_template_string
 
 # the signals
-from .signals import signals_available, template_rendered, request_started, \
-     request_finished, got_request_exception, request_tearing_down, \
-     appcontext_tearing_down, appcontext_pushed, \
-     appcontext_popped, message_flashed, before_render_template
+from .signals import (signals_available, template_rendered, request_started,
+                      request_finished, got_request_exception,
+                      request_tearing_down, appcontext_tearing_down,
+                      appcontext_pushed, appcontext_popped, message_flashed,
+                      before_render_template)
 
 # We're not exposing the actual json module but a convenient wrapper around
 # it.

--- a/flask/app.py
+++ b/flask/app.py
@@ -18,21 +18,23 @@ from collections import deque
 
 from werkzeug.datastructures import ImmutableDict
 from werkzeug.routing import Map, Rule, RequestRedirect, BuildError
-from werkzeug.exceptions import HTTPException, InternalServerError, \
-     MethodNotAllowed, BadRequest, default_exceptions
+from werkzeug.exceptions import (HTTPException, InternalServerError,
+                                 MethodNotAllowed, BadRequest,
+                                 default_exceptions)
 
-from .helpers import _PackageBoundObject, url_for, get_flashed_messages, \
-     locked_cached_property, _endpoint_from_view_func, find_package
+from .helpers import (_PackageBoundObject, url_for, get_flashed_messages,
+                      locked_cached_property, _endpoint_from_view_func,
+                      find_package)
 from . import json, cli
 from .wrappers import Request, Response
 from .config import ConfigAttribute, Config
 from .ctx import RequestContext, AppContext, _AppCtxGlobals
 from .globals import _request_ctx_stack, request, session, g
 from .sessions import SecureCookieSessionInterface
-from .templating import DispatchingJinjaLoader, Environment, \
-     _default_template_ctx_processor
-from .signals import request_started, request_finished, got_request_exception, \
-     request_tearing_down, appcontext_tearing_down
+from .templating import (DispatchingJinjaLoader, Environment,
+                         _default_template_ctx_processor)
+from .signals import (request_started, request_finished, got_request_exception,
+                      request_tearing_down, appcontext_tearing_down)
 from ._compat import reraise, string_types, text_type, integer_types
 
 # a lock used for logger initialization
@@ -54,13 +56,16 @@ def setupmethod(f):
     """
     def wrapper_func(self, *args, **kwargs):
         if self.debug and self._got_first_request:
-            raise AssertionError('A setup function was called after the '
-                'first request was handled.  This usually indicates a bug '
-                'in the application where a module was not imported '
-                'and decorators or other functionality was called too late.\n'
-                'To fix this make sure to import all your view modules, '
-                'database models and everything related at a central place '
-                'before the application starts serving requests.')
+            raise AssertionError('A setup function was called after the first '
+                                 'request was handled.  This usually '
+                                 'indicates a bug in the application where a '
+                                 'module was not imported and decorators or '
+                                 'other functionality was called too late.\n'
+                                 'To fix this make sure to import all your '
+                                 'view modules, database models and '
+                                 'everything related at a central place '
+                                 'before the application starts serving '
+                                 'requests.')
         return f(self, *args, **kwargs)
     return update_wrapper(wrapper_func, f)
 
@@ -74,7 +79,8 @@ class Flask(_PackageBoundObject):
     The name of the package is used to resolve resources from inside the
     package or the folder the module is contained in depending on if the
     package parameter resolves to an actual python package (a folder with
-    an :file:`__init__.py` file inside) or a standard module (just a ``.py`` file).
+    an :file:`__init__.py` file inside) or a standard module (just a ``.py``
+    file).
 
     For more information about resource loading, see :func:`open_resource`.
 
@@ -96,7 +102,8 @@ class Flask(_PackageBoundObject):
         using a package, it's usually recommended to hardcode the name of
         your package there.
 
-        For example if your application is defined in :file:`yourapplication/app.py`
+        For example if your application is defined in
+        :file:`yourapplication/app.py`
         you should create it with one of the two versions below::
 
             app = Flask('yourapplication')
@@ -244,7 +251,7 @@ class Flask(_PackageBoundObject):
     #: ``PERMANENT_SESSION_LIFETIME`` configuration key.  Defaults to
     #: ``timedelta(days=31)``
     permanent_session_lifetime = ConfigAttribute('PERMANENT_SESSION_LIFETIME',
-        get_converter=_make_timedelta)
+                                                 get_converter=_make_timedelta)
 
     #: A :class:`~datetime.timedelta` which is used as default cache_timeout
     #: for the :func:`send_file` functions. The default is 12 hours.
@@ -254,7 +261,7 @@ class Flask(_PackageBoundObject):
     #: variable can also be set with an integer value used as seconds.
     #: Defaults to ``timedelta(hours=12)``
     send_file_max_age_default = ConfigAttribute('SEND_FILE_MAX_AGE_DEFAULT',
-        get_converter=_make_timedelta)
+                                                get_converter=_make_timedelta)
 
     #: Enable this if you want to use the X-Sendfile feature.  Keep in
     #: mind that the server has to support this.  This only affects files
@@ -272,12 +279,14 @@ class Flask(_PackageBoundObject):
     #: .. versionadded:: 0.4
     logger_name = ConfigAttribute('LOGGER_NAME')
 
-    #: The JSON encoder class to use.  Defaults to :class:`~flask.json.JSONEncoder`.
+    #: The JSON encoder class to use.  Defaults to
+    #: :class:`~flask.json.JSONEncoder`.
     #:
     #: .. versionadded:: 0.10
     json_encoder = json.JSONEncoder
 
-    #: The JSON decoder class to use.  Defaults to :class:`~flask.json.JSONDecoder`.
+    #: The JSON decoder class to use.  Defaults to
+    #: :class:`~flask.json.JSONDecoder`.
     #:
     #: .. versionadded:: 0.10
     json_decoder = json.JSONDecoder
@@ -289,33 +298,33 @@ class Flask(_PackageBoundObject):
 
     #: Default configuration parameters.
     default_config = ImmutableDict({
-        'DEBUG':                                False,
-        'TESTING':                              False,
-        'PROPAGATE_EXCEPTIONS':                 None,
-        'PRESERVE_CONTEXT_ON_EXCEPTION':        None,
-        'SECRET_KEY':                           None,
-        'PERMANENT_SESSION_LIFETIME':           timedelta(days=31),
-        'USE_X_SENDFILE':                       False,
-        'LOGGER_NAME':                          None,
-        'LOGGER_HANDLER_POLICY':               'always',
-        'SERVER_NAME':                          None,
-        'APPLICATION_ROOT':                     None,
-        'SESSION_COOKIE_NAME':                  'session',
-        'SESSION_COOKIE_DOMAIN':                None,
-        'SESSION_COOKIE_PATH':                  None,
-        'SESSION_COOKIE_HTTPONLY':              True,
-        'SESSION_COOKIE_SECURE':                False,
-        'SESSION_REFRESH_EACH_REQUEST':         True,
-        'MAX_CONTENT_LENGTH':                   None,
-        'SEND_FILE_MAX_AGE_DEFAULT':            timedelta(hours=12),
-        'TRAP_BAD_REQUEST_ERRORS':              False,
-        'TRAP_HTTP_EXCEPTIONS':                 False,
-        'EXPLAIN_TEMPLATE_LOADING':             False,
-        'PREFERRED_URL_SCHEME':                 'http',
-        'JSON_AS_ASCII':                        True,
-        'JSON_SORT_KEYS':                       True,
-        'JSONIFY_PRETTYPRINT_REGULAR':          True,
-        'TEMPLATES_AUTO_RELOAD':                None,
+        'DEBUG': False,
+        'TESTING': False,
+        'PROPAGATE_EXCEPTIONS': None,
+        'PRESERVE_CONTEXT_ON_EXCEPTION': None,
+        'SECRET_KEY': None,
+        'PERMANENT_SESSION_LIFETIME': timedelta(days=31),
+        'USE_X_SENDFILE': False,
+        'LOGGER_NAME': None,
+        'LOGGER_HANDLER_POLICY': 'always',
+        'SERVER_NAME': None,
+        'APPLICATION_ROOT': None,
+        'SESSION_COOKIE_NAME': 'session',
+        'SESSION_COOKIE_DOMAIN': None,
+        'SESSION_COOKIE_PATH': None,
+        'SESSION_COOKIE_HTTPONLY': True,
+        'SESSION_COOKIE_SECURE': False,
+        'SESSION_REFRESH_EACH_REQUEST': True,
+        'MAX_CONTENT_LENGTH': None,
+        'SEND_FILE_MAX_AGE_DEFAULT': timedelta(hours=12),
+        'TRAP_BAD_REQUEST_ERRORS': False,
+        'TRAP_HTTP_EXCEPTIONS': False,
+        'EXPLAIN_TEMPLATE_LOADING': False,
+        'PREFERRED_URL_SCHEME': 'http',
+        'JSON_AS_ASCII': True,
+        'JSON_SORT_KEYS': True,
+        'JSONIFY_PRETTYPRINT_REGULAR': True,
+        'TEMPLATES_AUTO_RELOAD': None,
     })
 
     #: The rule object to use for URL rules created.  This is used by
@@ -405,7 +414,8 @@ class Flask(_PackageBoundObject):
 
         #: A dictionary with lists of functions that should be called at the
         #: beginning of the request.  The key of the dictionary is the name of
-        #: the blueprint this function is active for, ``None`` for all requests.
+        #: the blueprint this function is active for, ``None`` for all
+        #: requests.
         #: This can for example be used to open database connections or
         #: getting hold of the currently logged in user.  To register a
         #: function here, use the :meth:`before_request` decorator.
@@ -419,11 +429,11 @@ class Flask(_PackageBoundObject):
         self.before_first_request_funcs = []
 
         #: A dictionary with lists of functions that should be called after
-        #: each request.  The key of the dictionary is the name of the blueprint
-        #: this function is active for, ``None`` for all requests.  This can for
-        #: example be used to open database connections or getting hold of the
-        #: currently logged in user.  To register a function here, use the
-        #: :meth:`after_request` decorator.
+        #: each request.  The key of the dictionary is the name of the
+        #: blueprint  this function is active for, ``None`` for all requests.
+        #: This can for example be used to open database connections or getting
+        #: hold of the currently logged in user.  To register a function here,
+        #: use the :meth:`after_request` decorator.
         self.after_request_funcs = {}
 
         #: A dictionary with lists of functions that are called after
@@ -494,8 +504,8 @@ class Flask(_PackageBoundObject):
 
         #: a place where extensions can store application specific state.  For
         #: example this is where an extension could store database engines and
-        #: similar things.  For backwards compatibility extensions should register
-        #: themselves like this::
+        #: similar things.  For backwards compatibility extensions should
+        #: register themselves like this::
         #:
         #:      if not hasattr(app, 'extensions'):
         #:          app.extensions = {}
@@ -550,8 +560,9 @@ class Flask(_PackageBoundObject):
 
     def _get_error_handlers(self):
         from warnings import warn
-        warn(DeprecationWarning('error_handlers is deprecated, use the '
-            'new error_handler_spec attribute instead.'), stacklevel=1)
+        warn(DeprecationWarning('error_handlers is deprecated, use the new '
+                                'error_handler_spec attribute instead.'),
+             stacklevel=1)
         return self._error_handlers
     def _set_error_handlers(self, value):
         self._error_handlers = value
@@ -856,9 +867,9 @@ class Flask(_PackageBoundObject):
             app.testing = True
             client = app.test_client()
 
-        The test client can be used in a ``with`` block to defer the closing down
-        of the context until the end of the ``with`` block.  This is useful if
-        you want to access the context locals for testing::
+        The test client can be used in a ``with`` block to defer the closing
+        down of the context until the end of the ``with`` block.  This is
+        useful if you want to access the context locals for testing::
 
             with app.test_client() as c:
                 rv = c.get('/?vodka=42')
@@ -895,7 +906,8 @@ class Flask(_PackageBoundObject):
         cls = self.test_client_class
         if cls is None:
             from flask.testing import FlaskClient as cls
-        return cls(self, self.response_class, use_cookies=use_cookies, **kwargs)
+        return cls(self, self.response_class, use_cookies=use_cookies,
+                   **kwargs)
 
     def open_session(self, request):
         """Creates or opens a new session.  Default implementation stores all
@@ -1024,7 +1036,7 @@ class Flask(_PackageBoundObject):
         # starting with Flask 0.8 the view_func object can disable and
         # force-enable the automatic options handling.
         provide_automatic_options = getattr(view_func,
-            'provide_automatic_options', None)
+                                            'provide_automatic_options', None)
 
         if provide_automatic_options is None:
             if 'OPTIONS' not in methods:
@@ -1044,7 +1056,8 @@ class Flask(_PackageBoundObject):
             old_func = self.view_functions.get(endpoint)
             if old_func is not None and old_func != view_func:
                 raise AssertionError('View function mapping is overwriting an '
-                                     'existing endpoint function: %s' % endpoint)
+                                     'existing endpoint function: %s'
+                                     % endpoint)
             self.view_functions[endpoint] = view_func
 
     def route(self, rule, **options):
@@ -1174,12 +1187,15 @@ class Flask(_PackageBoundObject):
         if isinstance(code_or_exception, HTTPException):  # old broken behavior
             raise ValueError(
                 'Tried to register a handler for an exception instance {0!r}. '
-                'Handlers can only be registered for exception classes or HTTP error codes.'
-                .format(code_or_exception))
+                'Handlers can only be registered for exception classes or '
+                'HTTP error codes.'
+                .format(code_or_exception)
+            )
 
         exc_class, code = self._get_exc_class_and_code(code_or_exception)
 
-        handlers = self.error_handler_spec.setdefault(key, {}).setdefault(code, {})
+        handlers = self.error_handler_spec.setdefault(key, {}) \
+            .setdefault(code, {})
         handlers[exc_class] = f
 
     @setupmethod
@@ -1746,8 +1762,8 @@ class Flask(_PackageBoundObject):
            URL adapter is created for the application context.
         """
         if request is not None:
-            return self.url_map.bind_to_environ(request.environ,
-                server_name=self.config['SERVER_NAME'])
+            return self.url_map.bind_to_environ(
+                request.environ, server_name=self.config['SERVER_NAME'])
         # We need at the very least the server name to be set for this
         # to work.
         if self.config['SERVER_NAME'] is not None:
@@ -1895,8 +1911,8 @@ class Flask(_PackageBoundObject):
     def request_context(self, environ):
         """Creates a :class:`~flask.ctx.RequestContext` from the given
         environment and binds it to the current context.  This must be used in
-        combination with the ``with`` statement because the request is only bound
-        to the current context for the duration of the ``with`` block.
+        combination with the ``with`` statement because the request is only
+        bound to the current context for the duration of the ``with`` block.
 
         Example usage::
 

--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -164,13 +164,15 @@ class Blueprint(_PackageBoundObject):
         return decorator
 
     def add_url_rule(self, rule, endpoint=None, view_func=None, **options):
-        """Like :meth:`Flask.add_url_rule` but for a blueprint.  The endpoint for
-        the :func:`url_for` function is prefixed with the name of the blueprint.
+        """Like :meth:`Flask.add_url_rule` but for a blueprint.  The endpoint
+        for the :func:`url_for` function is prefixed with the name of the
+        blueprint.
         """
         if endpoint:
-            assert '.' not in endpoint, "Blueprint endpoints should not contain dots"
+            assert '.' not in endpoint, \
+                "Blueprint endpoints should not contain dots"
         self.record(lambda s:
-            s.add_url_rule(rule, endpoint, view_func, **options))
+                    s.add_url_rule(rule, endpoint, view_func, **options))
 
     def endpoint(self, endpoint):
         """Like :meth:`Flask.endpoint` but for a blueprint.  This does not
@@ -272,7 +274,7 @@ class Blueprint(_PackageBoundObject):
         that blueprint.
         """
         self.record_once(lambda s: s.app.before_request_funcs
-            .setdefault(self.name, []).append(f))
+                         .setdefault(self.name, []).append(f))
         return f
 
     def before_app_request(self, f):
@@ -280,7 +282,7 @@ class Blueprint(_PackageBoundObject):
         before each request, even if outside of a blueprint.
         """
         self.record_once(lambda s: s.app.before_request_funcs
-            .setdefault(None, []).append(f))
+                         .setdefault(None, []).append(f))
         return f
 
     def before_app_first_request(self, f):
@@ -296,7 +298,7 @@ class Blueprint(_PackageBoundObject):
         that blueprint.
         """
         self.record_once(lambda s: s.app.after_request_funcs
-            .setdefault(self.name, []).append(f))
+                         .setdefault(self.name, []).append(f))
         return f
 
     def after_app_request(self, f):
@@ -304,7 +306,7 @@ class Blueprint(_PackageBoundObject):
         is executed after each request, even if outside of the blueprint.
         """
         self.record_once(lambda s: s.app.after_request_funcs
-            .setdefault(None, []).append(f))
+                         .setdefault(None, []).append(f))
         return f
 
     def teardown_request(self, f):
@@ -315,7 +317,7 @@ class Blueprint(_PackageBoundObject):
         performed.
         """
         self.record_once(lambda s: s.app.teardown_request_funcs
-            .setdefault(self.name, []).append(f))
+                         .setdefault(self.name, []).append(f))
         return f
 
     def teardown_app_request(self, f):
@@ -324,7 +326,7 @@ class Blueprint(_PackageBoundObject):
         the blueprint.
         """
         self.record_once(lambda s: s.app.teardown_request_funcs
-            .setdefault(None, []).append(f))
+                         .setdefault(None, []).append(f))
         return f
 
     def context_processor(self, f):
@@ -332,7 +334,7 @@ class Blueprint(_PackageBoundObject):
         function is only executed for requests handled by a blueprint.
         """
         self.record_once(lambda s: s.app.template_context_processors
-            .setdefault(self.name, []).append(f))
+                         .setdefault(self.name, []).append(f))
         return f
 
     def app_context_processor(self, f):
@@ -340,7 +342,7 @@ class Blueprint(_PackageBoundObject):
         function is executed each request, even if outside of the blueprint.
         """
         self.record_once(lambda s: s.app.template_context_processors
-            .setdefault(None, []).append(f))
+                         .setdefault(None, []).append(f))
         return f
 
     def app_errorhandler(self, code):
@@ -358,7 +360,7 @@ class Blueprint(_PackageBoundObject):
         can modify the url values provided.
         """
         self.record_once(lambda s: s.app.url_value_preprocessors
-            .setdefault(self.name, []).append(f))
+                         .setdefault(self.name, []).append(f))
         return f
 
     def url_defaults(self, f):
@@ -367,21 +369,21 @@ class Blueprint(_PackageBoundObject):
         in place.
         """
         self.record_once(lambda s: s.app.url_default_functions
-            .setdefault(self.name, []).append(f))
+                         .setdefault(self.name, []).append(f))
         return f
 
     def app_url_value_preprocessor(self, f):
         """Same as :meth:`url_value_preprocessor` but application wide.
         """
         self.record_once(lambda s: s.app.url_value_preprocessors
-            .setdefault(None, []).append(f))
+                         .setdefault(None, []).append(f))
         return f
 
     def app_url_defaults(self, f):
         """Same as :meth:`url_defaults` but application wide.
         """
         self.record_once(lambda s: s.app.url_default_functions
-            .setdefault(None, []).append(f))
+                         .setdefault(None, []).append(f))
         return f
 
     def errorhandler(self, code_or_exception):

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -224,13 +224,13 @@ def set_app_value(ctx, param, value):
 
 
 debug_option = click.Option(['--debug/--no-debug'],
-    help='Enable or disable debug mode.',
-    default=None, callback=set_debug_value)
+                            help='Enable or disable debug mode.',
+                            default=None, callback=set_debug_value)
 
 
 app_option = click.Option(['-a', '--app'],
-    help='The application to run',
-    callback=set_app_value, is_eager=True)
+                          help='The application to run',
+                          callback=set_app_value, is_eager=True)
 
 
 class AppGroup(click.Group):

--- a/flask/ctx.py
+++ b/flask/ctx.py
@@ -102,20 +102,22 @@ def copy_current_request_context(f):
     top = _request_ctx_stack.top
     if top is None:
         raise RuntimeError('This decorator can only be used at local scopes '
-            'when a request context is on the stack.  For instance within '
-            'view functions.')
+                           'when a request context is on the stack.  For '
+                           'instance within view functions.')
     reqctx = top.copy()
+
     def wrapper(*args, **kwargs):
         with reqctx:
             return f(*args, **kwargs)
+
     return update_wrapper(wrapper, f)
 
 
 def has_request_context():
     """If you have code that wants to test if a request context is there or
-    not this function can be used.  For instance, you may want to take advantage
-    of request information if the request object is available, but fail
-    silently if it is unavailable.
+    not this function can be used.  For instance, you may want to take
+    advantage of request information if the request object is available, but
+    fail silently if it is unavailable.
 
     ::
 
@@ -278,10 +280,8 @@ class RequestContext(object):
 
         .. versionadded:: 0.10
         """
-        return self.__class__(self.app,
-            environ=self.request.environ,
-            request=self.request
-        )
+        return self.__class__(self.app, environ=self.request.environ,
+                              request=self.request)
 
     def match_request(self):
         """Can be overridden by a subclass to hook into the matching
@@ -362,8 +362,8 @@ class RequestContext(object):
             clear_request = True
 
         rv = _request_ctx_stack.pop()
-        assert rv is self, 'Popped wrong request context.  (%r instead of %r)' \
-            % (rv, self)
+        assert rv is self, \
+            'Popped wrong request context.  (%r instead of %r)' % (rv, self)
 
         # get rid of circular dependencies at the end of the request
         # so that we don't require the GC to be active.

--- a/flask/debughelpers.py
+++ b/flask/debughelpers.py
@@ -29,15 +29,15 @@ class DebugFilesKeyError(KeyError, AssertionError):
     def __init__(self, request, key):
         form_matches = request.form.getlist(key)
         buf = ['You tried to access the file "%s" in the request.files '
-               'dictionary but it does not exist.  The mimetype for the request '
-               'is "%s" instead of "multipart/form-data" which means that no '
-               'file contents were transmitted.  To fix this error you should '
-               'provide enctype="multipart/form-data" in your form.' %
-               (key, request.mimetype)]
+               'dictionary but it does not exist.  The mimetype for the '
+               'request is "%s" instead of "multipart/form-data" which means '
+               'that no file contents were transmitted.  To fix this error '
+               'you should provide enctype="multipart/form-data" in your form.'
+               % (key, request.mimetype)]
         if form_matches:
             buf.append('\n\nThe browser instead transmitted some file names. '
-                       'This was submitted: %s' % ', '.join('"%s"' % x
-                            for x in form_matches))
+                       'This was submitted: %s'
+                       % ', '.join('"%s"' % x for x in form_matches))
         self.msg = ''.join(buf)
 
     def __str__(self):
@@ -143,13 +143,15 @@ def explain_template_loading_attempts(app, template, attempts):
         info.append('Error: the template could not be found.')
         seems_fishy = True
     elif total_found > 1:
-        info.append('Warning: multiple loaders returned a match for the template.')
+        info.append('Warning: multiple loaders returned a match for the '
+                    'template.')
         seems_fishy = True
 
     if blueprint is not None and seems_fishy:
         info.append('  The template was looked up from an endpoint that '
                     'belongs to the blueprint "%s".' % blueprint)
-        info.append('  Maybe you did not place a template in the right folder?')
+        info.append('  Maybe you did not place a template in the right '
+                    'folder?')
         info.append('  See http://flask.pocoo.org/docs/blueprints/#templates')
 
     app.logger.info('\n'.join(info))

--- a/flask/exthook.py
+++ b/flask/exthook.py
@@ -116,5 +116,5 @@ class ExtensionImporter(object):
         # the filename then.
         filename = os.path.abspath(tb.tb_frame.f_code.co_filename)
         test_string = os.path.sep + important_module.replace('.', os.path.sep)
-        return test_string + '.py' in filename or \
-               test_string + os.path.sep + '__init__.py' in filename
+        return (test_string + '.py' in filename or
+                test_string + os.path.sep + '__init__.py' in filename)

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -38,8 +38,8 @@ except ImportError:
 from jinja2 import FileSystemLoader
 
 from .signals import message_flashed
-from .globals import session, _request_ctx_stack, _app_ctx_stack, \
-     current_app, request
+from .globals import (session, _request_ctx_stack, _app_ctx_stack, current_app,
+                      request)
 from ._compat import string_types, text_type
 
 
@@ -108,8 +108,9 @@ def stream_with_context(generator_or_function):
     def generator():
         ctx = _request_ctx_stack.top
         if ctx is None:
-            raise RuntimeError('Attempted to stream with context but '
-                'there was no context in the first place to keep around.')
+            raise RuntimeError('Attempted to stream with context but there '
+                               'was no context in the first place to keep '
+                               'around.')
         with ctx:
             # Dummy sentinel.  Has to be inside the context block or we're
             # not actually keeping the context around.
@@ -202,11 +203,12 @@ def url_for(endpoint, **values):
     To integrate applications, :class:`Flask` has a hook to intercept URL build
     errors through :attr:`Flask.url_build_error_handlers`.  The `url_for`
     function results in a :exc:`~werkzeug.routing.BuildError` when the current
-    app does not have a URL for the given endpoint and values.  When it does, the
-    :data:`~flask.current_app` calls its :attr:`~Flask.url_build_error_handlers` if
-    it is not ``None``, which can return a string to use as the result of
-    `url_for` (instead of `url_for`'s default to raise the
-    :exc:`~werkzeug.routing.BuildError` exception) or re-raise the exception.
+    app does not have a URL for the given endpoint and values.  When it does,
+    the :data:`~flask.current_app` calls its
+    :attr:`~Flask.url_build_error_handlers` if it is not ``None``, which can
+    return a string to use as the result of `url_for` (instead of `url_for`'s
+    default to raise the :exc:`~werkzeug.routing.BuildError` exception) or
+    re-raise the exception.
     An example::
 
         def external_url_handler(error, endpoint, values):
@@ -249,8 +251,8 @@ def url_for(endpoint, **values):
       address can be changed via ``SERVER_NAME`` configuration variable which
       defaults to `localhost`.
     :param _scheme: a string specifying the desired URL scheme. The `_external`
-      parameter must be set to ``True`` or a :exc:`ValueError` is raised. The default
-      behavior uses the same scheme as the current request, or
+      parameter must be set to ``True`` or a :exc:`ValueError` is raised. The
+      default behavior uses the same scheme as the current request, or
       ``PREFERRED_URL_SCHEME`` from the :ref:`app configuration <config>` if no
       request context is available. As of Werkzeug 0.10, this also can be set
       to an empty string to build protocol-relative URLs.
@@ -290,9 +292,9 @@ def url_for(endpoint, **values):
         url_adapter = appctx.url_adapter
         if url_adapter is None:
             raise RuntimeError('Application was not able to create a URL '
-                               'adapter for request independent URL generation. '
-                               'You might be able to fix this by setting '
-                               'the SERVER_NAME config variable.')
+                               'adapter for request independent URL '
+                               'generation.  You might be able to fix this by '
+                               'setting the SERVER_NAME config variable.')
         external = values.pop('_external', True)
 
     anchor = values.pop('_anchor', None)
@@ -386,7 +388,8 @@ def get_flashed_messages(with_categories=False, category_filter=[]):
     arguments are distinct:
 
     * `with_categories` controls whether categories are returned with message
-      text (``True`` gives a tuple, where ``False`` gives just the message text).
+      text (``True`` gives a tuple, where ``False`` gives just the message
+      text).
     * `category_filter` filters the messages down to only those matching the
       provided categories.
 
@@ -482,15 +485,17 @@ def send_file(filename_or_fp, mimetype=None, as_attachment=False,
         if not attachment_filename and not mimetype \
            and isinstance(filename, string_types):
             warn(DeprecationWarning('The filename support for file objects '
-                'passed to send_file is now deprecated.  Pass an '
-                'attach_filename if you want mimetypes to be guessed.'),
-                stacklevel=2)
+                                    'passed to send_file is now deprecated.  '
+                                    'Pass an attach_filename if you want '
+                                    'mimetypes to be guessed.'), stacklevel=2)
         if add_etags:
             warn(DeprecationWarning('In future flask releases etags will no '
-                'longer be generated for file objects passed to the send_file '
-                'function because this behavior was unreliable.  Pass '
-                'filenames instead if possible, otherwise attach an etag '
-                'yourself based on another value'), stacklevel=2)
+                                    'longer be generated for file objects '
+                                    'passed to the send_file function because '
+                                    'this behavior was unreliable.  Pass '
+                                    'filenames instead if possible, otherwise '
+                                    'attach an etag yourself based on another '
+                                    'value'), stacklevel=2)
 
     if filename is not None:
         if not os.path.isabs(filename):
@@ -549,8 +554,8 @@ def send_file(filename_or_fp, mimetype=None, as_attachment=False,
                 ) & 0xffffffff
             ))
         except OSError:
-            warn('Access %s failed, maybe it does not exist, so ignore etags in '
-                 'headers' % filename, stacklevel=2)
+            warn('Access %s failed, maybe it does not exist, so ignore etags '
+                 'in headers' % filename, stacklevel=2)
 
         if conditional:
             rv = rv.make_conditional(request)
@@ -841,8 +846,8 @@ class _PackageBoundObject(object):
 
         Static file functions such as :func:`send_from_directory` use this
         function, and :func:`send_file` calls this function on
-        :data:`~flask.current_app` when the given cache_timeout is ``None``. If a
-        cache_timeout is given in :func:`send_file`, that timeout is used;
+        :data:`~flask.current_app` when the given cache_timeout is ``None``. If
+        a cache_timeout is given in :func:`send_file`, that timeout is used;
         otherwise, this method is called.
 
         This allows subclasses to change the behavior when sending files based

--- a/flask/json.py
+++ b/flask/json.py
@@ -201,9 +201,9 @@ def htmlsafe_dump(obj, fp, **kwargs):
 def jsonify(*args, **kwargs):
     """This function wraps :func:`dumps` to add a few enhancements that make
     life easier.  It turns the JSON output into a :class:`~flask.Response`
-    object with the :mimetype:`application/json` mimetype.  For convenience, it
-    also converts multiple arguments into an array or multiple keyword arguments
-    into a dict.  This means that both ``jsonify(1,2,3)`` and
+    object with the :mimetype:`application/json` mimetype.  For convenience,
+    it also converts multiple arguments into an array or multiple keyword
+    arguments into a dict.  This means that both ``jsonify(1,2,3)`` and
     ``jsonify([1,2,3])`` serialize to ``[1,2,3]``.
 
     For clarity, the JSON serialization behavior has the following differences
@@ -260,11 +260,11 @@ def jsonify(*args, **kwargs):
         raise TypeError(
             "jsonify() behavior undefined when passed both args and kwargs"
         )
-    elif len(args) == 1: # single args are passed directly to dumps()
+    elif len(args) == 1:  # single args are passed directly to dumps()
         data = args[0]
-    elif args: # convert multiple args into an array
+    elif args:  # convert multiple args into an array
         data = list(args)
-    else: # convert kwargs to a dict
+    else:  # convert kwargs to a dict
         data = dict(kwargs)
 
     # Note that we add '\n' to end of response

--- a/flask/sessions.py
+++ b/flask/sessions.py
@@ -69,10 +69,11 @@ def _tag(value):
             return text_type(value)
         except UnicodeError:
             from flask.debughelpers import UnexpectedUnicodeError
-            raise UnexpectedUnicodeError(u'A byte string with '
-                u'non-ASCII data was passed to the session system '
-                u'which can only store unicode strings.  Consider '
-                u'base64 encoding your string (String was %r)' % value)
+            raise UnexpectedUnicodeError(
+                u'A byte string with non-ASCII data was passed to the session '
+                u'system which can only store unicode strings.  Consider '
+                u'base64 encoding your string (String was %r)' % value
+            )
     return value
 
 
@@ -227,8 +228,9 @@ class SessionInterface(object):
         config var if it's set, and falls back to ``APPLICATION_ROOT`` or
         uses ``/`` if it's ``None``.
         """
-        return app.config['SESSION_COOKIE_PATH'] or \
-               app.config['APPLICATION_ROOT'] or '/'
+        return (app.config['SESSION_COOKIE_PATH'] or
+                app.config['APPLICATION_ROOT'] or
+                '/')
 
     def get_cookie_httponly(self, app):
         """Returns True if the session cookie should be httponly.  This

--- a/flask/templating.py
+++ b/flask/templating.py
@@ -121,8 +121,10 @@ def render_template(template_name_or_list, **context):
     """
     ctx = _app_ctx_stack.top
     ctx.app.update_template_context(context)
-    return _render(ctx.app.jinja_env.get_or_select_template(template_name_or_list),
-                   context, ctx.app)
+    return _render(
+        ctx.app.jinja_env.get_or_select_template(template_name_or_list),
+        context, ctx.app
+    )
 
 
 def render_template_string(source, **context):

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -98,8 +98,8 @@ class FlaskClient(Client):
             self.cookie_jar.extract_wsgi(c.request.environ, headers)
 
     def open(self, *args, **kwargs):
-        kwargs.setdefault('environ_overrides', {}) \
-            ['flask._preserve_context'] = self.preserve_context
+        environ_overrides = kwargs.setdefault('environ_overrides', {})
+        environ_overrides['flask._preserve_context'] = self.preserve_context
 
         as_tuple = kwargs.pop('as_tuple', False)
         buffered = kwargs.pop('buffered', False)

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,16 @@ universal = 1
 
 [pytest]
 norecursedirs = .* *.egg *.egg-info env* artwork docs
+addopts = --pep8
+pep8ignore =
+    examples/* ALL
+    scripts/* ALL
+    tests/* ALL
+    flask/__init__.py E402
+    flask/_compat.py ALL
+    flask/app.py E301
+    flask/ctx.py E301
+    flask/cli.py E301
+    flask/debughelpers.py E301
+    flask/helpers.py E301
+    flask/signals.py E301 E731

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ commands =
 
 deps=
     pytest
+    pytest-pep8
     greenlet
     redbaron
 


### PR DESCRIPTION
E301 (no empty line before function/class) is disabled for files where having compact code (e.g. non-decorator based properties) makes sense.
