### PR TITLE
Add JSONIFY_MIMETYPE configuration variable

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -76,6 +76,7 @@ Version 1.0
 - ``flask.ext`` is now deprecated (pull request ``#1484``).
 - ``send_from_directory`` now raises BadRequest if the filename is invalid on
   the server OS (pull request ``#1763``).
+- Added the ``JSONIFY_MIMETYPE`` configuration variable (pull request ``#1728``).
 
 Version 0.10.2
 --------------

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -183,6 +183,7 @@ The following configuration values are used internally by Flask:
                                   if they are not requested by an
                                   XMLHttpRequest object (controlled by
                                   the ``X-Requested-With`` header)
+``JSONIFY_MIMETYPE``              MIME type used for jsonify responses.
 ``TEMPLATES_AUTO_RELOAD``         Whether to check for modifications of
                                   the template source and reload it
                                   automatically. By default the value is

--- a/flask/app.py
+++ b/flask/app.py
@@ -315,6 +315,7 @@ class Flask(_PackageBoundObject):
         'JSON_AS_ASCII':                        True,
         'JSON_SORT_KEYS':                       True,
         'JSONIFY_PRETTYPRINT_REGULAR':          True,
+        'JSONIFY_MIMETYPE':                     'application/json',
         'TEMPLATES_AUTO_RELOAD':                None,
     })
 

--- a/flask/json.py
+++ b/flask/json.py
@@ -264,7 +264,7 @@ def jsonify(*args, **kwargs):
 
     return current_app.response_class(
         (dumps(data, indent=indent, separators=separators), '\n'),
-        mimetype='application/json'
+        mimetype=current_app.config['JSONIFY_MIMETYPE']
     )
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1019,6 +1019,18 @@ def test_jsonify_prettyprint():
         assert rv.data == pretty_response
 
 
+def test_jsonify_mimetype():
+    app = flask.Flask(__name__)
+    app.config.update({"JSONIFY_MIMETYPE": 'application/vnd.api+json'})
+    with app.test_request_context():
+        msg = {
+            "msg": {"submsg": "W00t"},
+        }
+        rv = flask.make_response(
+            flask.jsonify(msg), 200)
+        assert rv.mimetype == 'application/vnd.api+json'
+
+
 def test_url_generation():
     app = flask.Flask(__name__)
 


### PR DESCRIPTION
It is often useful to be able to return a vendor media type for JSON responses. For example, [JSON API](http://jsonapi.org/format/#content-negotiation) requires that all responses have the `Content-Type: applications/vnd.api+json` header.