### PR TITLE
Add IPython support to flask shell

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -427,8 +427,9 @@ def run_command(info, host, port, reload, debugger, eager_loading,
 
 
 @click.command('shell', short_help='Runs a shell in the app context.')
+@click.option('--ipython/--no-ipython', default=True)
 @with_appcontext
-def shell_command():
+def shell_command(ipython):
     """Runs an interactive Python shell in the context of a given
     Flask application.  The application will populate the default
     namespace of this shell according to it's configuration.
@@ -447,6 +448,14 @@ def shell_command():
         app.instance_path,
     )
     ctx = {}
+
+    if ipython:
+        try:
+            from IPython import embed
+            embed(banner1=banner, user_ns=app.make_shell_context())
+            return
+        except ImportError:
+            pass
 
     # Support the regular Python interpreter startup script if someone
     # is using it.


### PR DESCRIPTION
It could be useful to create an IPython shell in an application context, since IPython has several features a normal Python shell lacks, like autocompletion.

This patch adds support for it. In fact, it makes the IPython shell the privileged choice. The Python shell will be used if IPython is not available or the `--no-ipython` flag is passed.

The code is patterned on the similar feature available in `flask-script`: https://github.com/smurfix/flask-script/blob/d03cc660cf5a92e0bff367f982a872f7dd5bae07/flask_script/commands.py#L277-L312. Many thanks to @lnielsen for pointing out this snippet.