### PR TITLE
make safe_join behave like os.path.join with *args

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,8 @@ Version 0.12
 - the cli command now responds to `--version`.
 - Mimetype guessing for ``send_file`` has been removed, as per issue ``#104``.
   See pull request ``#1849``.
+- Make ``flask.safe_join`` able to join multiple paths like ``os.path.join``
+  (pull request ``#1730``).
 
 Version 0.11.1
 --------------


### PR DESCRIPTION
Make safe_join behave like os.path.join, which accept multiple path components with *args.
Note that only the ``directory'' 's bound is respected and the path components are only joined together.