### PR TITLE
Add two missing converters for flask in the docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -751,6 +751,8 @@ The following converters are available:
 `int`       accepts integers
 `float`     like `int` but for floating point values
 `path`      like the default but also accepts slashes
+`any`       matches one of the items provided
+`uuid`      accepts UUID strings
 =========== ===============================================
 
 Custom converters can be defined using :attr:`flask.Flask.url_map`.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -204,6 +204,8 @@ The following converters exist:
 `int`       accepts integers
 `float`     like `int` but for floating point values
 `path`      like the default but also accepts slashes
+`any`       matches one of the items provided
+`uuid`      accepts UUID strings
 =========== ===============================================
 
 .. admonition:: Unique URLs / Redirection Behavior


### PR DESCRIPTION
All the converters are from werkzeug's builtin converters.

Documentation: http://werkzeug.pocoo.org/docs/dev/routing/#builtin-converters