### PR TITLE
Call out that teardown functions must never raise

### DIFF
--- a/docs/appcontext.rst
+++ b/docs/appcontext.rst
@@ -77,14 +77,14 @@ generate URLs even in the absence of a request.
 Locality of the Context
 -----------------------
 
-The application context is created and destroyed as necessary.  It never
-moves between threads and it will not be shared between requests.  As such
-it is the perfect place to store database connection information and other
-things.  The internal stack object is called :data:`flask._app_ctx_stack`.
-Extensions are free to store additional information on the topmost level,
-assuming they pick a sufficiently unique name and should put their
-information there, instead of on the :data:`flask.g` object which is reserved
-for user code.
+The application context is created and destroyed as necessary.  It never moves
+between threads and it will not be shared between requests (with a few
+exceptions; see :ref:`request-context-and-app-context`).  As such it is the
+perfect place to store database connection information and other things.  The
+internal stack object is called :data:`flask._app_ctx_stack`.  Extensions are
+free to store additional information on the topmost level, assuming they pick
+a sufficiently unique name and should put their information there, instead of
+on the :data:`flask.g` object which is reserved for user code.
 
 For more information about that, see :ref:`extension-dev`.
 

--- a/flask/app.py
+++ b/flask/app.py
@@ -1341,15 +1341,15 @@ class Flask(_PackageBoundObject):
         stack of active contexts.  This becomes relevant if you are using
         such constructs in tests.
 
-        Generally teardown functions must take every necessary step to avoid
-        that they will fail.  If they do execute code that might fail they
-        will have to surround the execution of these code by try/except
-        statements and log occurring errors.
-
         When a teardown function was called because of a exception it will
         be passed an error object.
 
         The return values of teardown functions are ignored.
+
+        .. admonition:: Watch Out
+
+            Teardown callbacks must never raise.  See
+            :ref:`ensuring-teardown-callbacks-succeed`.
 
         .. admonition:: Debug Note
 
@@ -1386,6 +1386,11 @@ class Flask(_PackageBoundObject):
         be passed an error object.
 
         The return values of teardown functions are ignored.
+
+        .. admonition:: Watch Out
+
+            Teardown callbacks must never raise.  See
+            :ref:`ensuring-teardown-callbacks-succeed`.
 
         .. versionadded:: 0.9
         """


### PR DESCRIPTION
Also add a more detailed explanation of how the request context and app
context interact.

Re-open of #1451, but against `master`.