### PR TITLE
Remove dotCloud host instructions

### DIFF
--- a/docs/deploying/index.rst
+++ b/docs/deploying/index.rst
@@ -19,8 +19,6 @@ Hosted options
 
 - `Deploying Flask on Heroku <https://devcenter.heroku.com/articles/getting-started-with-python>`_
 - `Deploying Flask on OpenShift <https://developers.openshift.com/en/python-flask.html>`_
-- `Deploying WSGI on dotCloud <http://docs.dotcloud.com/services/python/>`_
-  with `Flask-specific notes <http://flask.pocoo.org/snippets/48/>`_
 - `Deploying Flask on Webfaction <http://flask.pocoo.org/snippets/65/>`_
 - `Deploying Flask on Google App Engine <https://github.com/kamalgill/flask-appengine-template>`_
 - `Sharing your Localhost Server with Localtunnel <http://flask.pocoo.org/snippets/89/>`_


### PR DESCRIPTION
dotCloud is no more; their parent company went bankrupt

Fix #1769 