### PR TITLE
minor rewording of get_json documentation for clarity

### DIFF
--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -123,11 +123,12 @@ class Request(RequestBase):
         return False
 
     def get_json(self, force=False, silent=False, cache=True):
-        """Parses the incoming JSON request data and returns it.  If
-        parsing fails the :meth:`on_json_loading_failed` method on the
-        request object will be invoked.  By default this function will
-        only load the json data if the mimetype is :mimetype:`application/json`
-        but this can be overridden by the `force` parameter.
+        """Parses the incoming JSON request data and returns it.  By default
+        this function will return ``None`` if the mimetype is not
+        :mimetype:`application/json` but this can be overridden by the
+        ``force`` parameter. If parsing fails the
+        :meth:`on_json_loading_failed` method on the request object will be
+        invoked.
 
         :param force: if set to ``True`` the mimetype is ignored.
         :param silent: if set to ``True`` this method will fail silently


### PR DESCRIPTION
I did a minor rewording of the docstring for `request.get_json()`. The current documentation is misleading, by having a mention of `on_json_loading_failed` followed by a sentence that references "this function", without clearly stating if the reference is to `get_json` or `on_json_loading_failed`.

The description reads much better in my opinion, after I moved the `on_json_loading_failed` sentence to the end.