### PR TITLE
Fix "with" formatting in doc

### DIFF
--- a/flask/testing.py
+++ b/flask/testing.py
@@ -39,8 +39,9 @@ def make_test_environ_builder(app, path='/', base_url=None, *args, **kwargs):
 class FlaskClient(Client):
     """Works like a regular Werkzeug test client but has some knowledge about
     how Flask works to defer the cleanup of the request context stack to the
-    end of a with body when used in a with statement.  For general information
-    about how to use this class refer to :class:`werkzeug.test.Client`.
+    end of a ``with`` body when used in a ``with`` statement.  For general
+    information about how to use this class refer to
+    :class:`werkzeug.test.Client`.
 
     Basic usage is outlined in the :ref:`testing` chapter.
     """
@@ -49,9 +50,9 @@ class FlaskClient(Client):
 
     @contextmanager
     def session_transaction(self, *args, **kwargs):
-        """When used in combination with a with statement this opens a
+        """When used in combination with a ``with`` statement this opens a
         session transaction.  This can be used to modify the session that
-        the test client uses.  Once the with block is left the session is
+        the test client uses.  Once the ``with`` block is left the session is
         stored back.
 
         ::


### PR DESCRIPTION
`with` statement isn't properly formatted in reST in two sections in the `flask.testing.FlaskClient` documentation.