### PR TITLE
Added X-Accel-Redirect support

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -266,6 +266,15 @@ class Flask(_PackageBoundObject):
     #: ``USE_X_SENDFILE`` configuration key.  Defaults to ``False``.
     use_x_sendfile = ConfigAttribute('USE_X_SENDFILE')
 
+    #: Enable this if you want to use Nginx's X-Accel feature.
+    #: This only affects files sent with the :func:`send_file` method.
+    #:
+    #: .. versionadded:: 0.10
+    #:
+    #: This attribute can also be configured from the config with the
+    #: ``USE_X_ACCEL`` configuration key.  Defaults to ``False``.
+    use_x_accel = ConfigAttribute('USE_X_ACCEL')
+
     #: The name of the logger to use.  By default the logger name is the
     #: package name passed to the constructor.
     #:
@@ -296,6 +305,7 @@ class Flask(_PackageBoundObject):
         'SECRET_KEY':                           None,
         'PERMANENT_SESSION_LIFETIME':           timedelta(days=31),
         'USE_X_SENDFILE':                       False,
+        'USE_X_ACCEL':                          False, # kula
         'LOGGER_NAME':                          None,
         'LOGGER_HANDLER_POLICY':               'always',
         'SERVER_NAME':                          None,

--- a/flask/app.py
+++ b/flask/app.py
@@ -305,7 +305,7 @@ class Flask(_PackageBoundObject):
         'SECRET_KEY':                           None,
         'PERMANENT_SESSION_LIFETIME':           timedelta(days=31),
         'USE_X_SENDFILE':                       False,
-        'USE_X_ACCEL':                          False, # kula
+        'USE_X_ACCEL':                          False,
         'LOGGER_NAME':                          None,
         'LOGGER_HANDLER_POLICY':               'always',
         'SERVER_NAME':                          None,

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -496,7 +496,6 @@ def send_file(filename_or_fp, x_accel_uri=None,
                 'filenames instead if possible, otherwise attach an etag '
                 'yourself based on another value'), stacklevel=2)
 
-    _filename = filename
     if filename is not None:
         if not os.path.isabs(filename):
             filename = os.path.join(current_app.root_path, filename)
@@ -525,7 +524,9 @@ def send_file(filename_or_fp, x_accel_uri=None,
     elif current_app.use_x_accel and filename and x_accel_uri.endswith('/'):
         if file is not None:
             file.close()
-        headers['X-Accel-Redirect'] = x_accel_uri + _filename
+        # pass only the filename, split any paths.
+        # eg: if `files/1.zip` was passed, add only `1.zip` to `x_accel_uri`
+        headers['X-Accel-Redirect'] = x_accel_uri + filename.split('/')[-1]
         headers['Content-Length'] = os.path.getsize(filename)
         data = None
     else:

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -526,6 +526,7 @@ def send_file(filename_or_fp, x_accel_uri=None,
         if file is not None:
             file.close()
         headers['X-Accel-Redirect'] = x_accel_uri + _filename
+        headers['Content-Length'] = os.path.getsize(filename)
         data = None
     else:
         if file is None:

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -521,14 +521,15 @@ def send_file(filename_or_fp, x_accel_uri=None,
         headers['X-Sendfile'] = filename
         headers['Content-Length'] = os.path.getsize(filename)
         data = None
-    elif current_app.use_x_accel and filename and x_accel_uri.endswith('/'):
-        if file is not None:
-            file.close()
-        # pass only the filename, split any paths.
-        # eg: if `files/1.zip` was passed, add only `1.zip` to `x_accel_uri`
-        headers['X-Accel-Redirect'] = x_accel_uri + filename.split('/')[-1]
-        headers['Content-Length'] = os.path.getsize(filename)
-        data = None
+    elif current_app.use_x_accel and filename and x_accel_uri is not None:
+        if x_accel_uri.startswith('/') and x_accel_uri.endswith('/'):
+            if file is not None:
+                file.close()
+            # pass only the filename, split any paths.
+            # eg: if `files/1.zip` was passed, add only `1.zip` to `x_accel_uri`
+            headers['X-Accel-Redirect'] = x_accel_uri + filename.split('/')[-1]
+            headers['Content-Length'] = os.path.getsize(filename)
+            data = None
     else:
         if file is None:
             file = open(filename, 'rb')

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -496,7 +496,7 @@ def send_file(filename_or_fp, x_accel_uri=None,
                 'filenames instead if possible, otherwise attach an etag '
                 'yourself based on another value'), stacklevel=2)
 
-    if filename is not None and not current_app.use_x_sendfile:
+    if filename is not None and not current_app.use_x_accel:
         if not os.path.isabs(filename):
             filename = os.path.join(current_app.root_path, filename)
     if mimetype is None and (filename or attachment_filename):

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -412,7 +412,8 @@ def get_flashed_messages(with_categories=False, category_filter=[]):
     return flashes
 
 
-def send_file(filename_or_fp, mimetype=None, as_attachment=False,
+def send_file(filename_or_fp, x_accel_uri=None,
+              mimetype=None, as_attachment=False,
               attachment_filename=None, add_etags=True,
               cache_timeout=None, conditional=False):
     """Sends the contents of a file to the client.  This will use the
@@ -454,6 +455,9 @@ def send_file(filename_or_fp, mimetype=None, as_attachment=False,
                            back to the traditional method.  Make sure that the
                            file pointer is positioned at the start of data to
                            send before calling :func:`send_file`.
+
+    :param x_accel_uri: The internal uri to send the file to. This setting is
+                        active only if USE_X_ACCEL is set to ``True``.
     :param mimetype: the mimetype of the file if provided, otherwise
                      auto detection happens.
     :param as_attachment: set to ``True`` if you want to send this file with
@@ -492,7 +496,7 @@ def send_file(filename_or_fp, mimetype=None, as_attachment=False,
                 'filenames instead if possible, otherwise attach an etag '
                 'yourself based on another value'), stacklevel=2)
 
-    if filename is not None:
+    if filename is not None and not current_app.use_x_sendfile:
         if not os.path.isabs(filename):
             filename = os.path.join(current_app.root_path, filename)
     if mimetype is None and (filename or attachment_filename):
@@ -515,6 +519,11 @@ def send_file(filename_or_fp, mimetype=None, as_attachment=False,
             file.close()
         headers['X-Sendfile'] = filename
         headers['Content-Length'] = os.path.getsize(filename)
+        data = None
+    elif current_app.use_x_accel and filename and x_accel_uri.endswith('/'):
+        if file is not None:
+            file.close()
+        headers['X-Accel-Redirect'] = x_accel_uri + filename
         data = None
     else:
         if file is None:


### PR DESCRIPTION
`X-Accel-Redirect` is very much alike Apache's `XSendfile` it instead however needs a `URI` pointing to the file than an absolute path. This is a tricky problem to solve and there  have been discussions on implementing a `nginx_sendfile` method, this however is disastrous since in development machines `nginx_sendfile` won't send the file since it is on a default flask server, thus every time the developer wishes to test an app on his own machine, it is required to change all `nginx_sendfile` calls to normal `flask.send_file` calls manually changing url's and such.

How is this patch different? As seen below in the test app simply set the config  `USE_X_ACCEL` to true and then when calling `send_file` set the `x_accel_uri` parameter to the internal `uri` configured in your nginx config. And when testing simply keep `USE_X_ACCEL` at the default value `False`, this will make `send_file` ignore the `x_accel_uri` even if it is set. :smile: 

## A test app:

```
from flask import Flask, send_file

app = Flask(__name__)
app.use_x_accel = True  
# app.config['USE_X_ACCEL'] = True

@app.route('/dl')
def download():
        return send_file('files/1GB.zip', as_attachment=True, x_accel_uri='/protected/')

app.run(debug=True, port=8080)
```

## For the following nginx config:

```
server {
        listen 80;

        location / {
                proxy_pass http://localhost:8080/;
        }

        location /protected {
                internal;
                alias /home/test/files;
        }
}
```



### Headers retrieved using `Curl`:

```
deelaka@deelaka-Lap:~$ curl -I your.server.ip/dl
HTTP/1.1 200 OK
Server: nginx/1.4.6 (Ubuntu)
Date: Sun, 15 May 2016 08:42:49 GMT
Content-Type: application/zip
Content-Length: 1073741824
Last-Modified: Sat, 14 May 2016 16:51:22 GMT
Connection: keep-alive
Content-Disposition: attachment; filename=1GB.zip
Cache-Control: public, max-age=43200
Expires: Sun, 15 May 2016 20:42:49 GMT
ETag: "5737578a-40000000"
Accept-Ranges: bytes

```