### PR TITLE
Switch to CLI Light

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: clean-pyc test
 
 test:
-	py.test tests examples
+	FLASK_DEBUG= py.test tests examples
 
 tox-test:
 	tox

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -892,13 +892,6 @@ Command Line Interface
    Marks a function so that an instance of :class:`ScriptInfo` is passed
    as first argument to the click callback.
 
-.. autofunction:: script_info_option
-
-   A special decorator that informs a click callback to be passed the
-   script info object as first argument.  This is normally not useful
-   unless you implement very special commands like the run command which
-   does not want the application to be loaded yet.
-
 .. autodata:: run_command
 
 .. autodata:: shell_command

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -289,7 +289,7 @@ thing, like it does for :class:`request` and :class:`session`.
    It's now also possible to use the ``in`` operator on it to see if an
    attribute is defined and it yields all keys on iteration.
 
-   As of 1.0 you can use :meth:`pop` and :meth:`setdefault` in the same
+   As of 0.11 you can use :meth:`pop` and :meth:`setdefault` in the same
    way you would use them on a dictionary.
 
    This is a proxy.  See :ref:`notes-on-proxies` for more information.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -15,41 +15,38 @@ applications.
 Basic Usage
 -----------
 
-After installation of Flask you will now find a :command:`flask` script installed
-into your virtualenv.  If you don't want to install Flask or you have a
-special use-case you can also use ``python -m flask`` to accomplish exactly
-the same.
+After installation of Flask you will now find a :command:`flask` script
+installed into your virtualenv.  If you don't want to install Flask or you
+have a special use-case you can also use ``python -m flask`` to accomplish
+exactly the same.
 
 The way this script works is by providing access to all the commands on
 your Flask application's :attr:`Flask.cli` instance as well as some
 built-in commands that are always there.  Flask extensions can also
 register more commands there if they desire so.
 
-For the :command:`flask` script to work, an application needs to be discovered.
-The two most common ways are either an environment variable
-(``FLASK_APP``) or the :option:`--app` / :option:`-a` parameter.  It should be the
-import path for your application or the path to a Python file.  In the
-latter case Flask will attempt to setup the Python path for you
-automatically and discover the module name but that might not always work.
+For the :command:`flask` script to work, an application needs to be
+discovered.  This is achieved by exporting the ``FLASK_APP`` environment
+variable.  It can be either set to an import path or to a filename of a
+Python module that contains a Flask application.
 
 In that imported file the name of the app needs to be called ``app`` or
-optionally be specified after a colon.
+optionally be specified after a colon.  For instance
+`mymodule:application` would tell it to use the `application` object in
+the :file:`mymodule.py` file.
 
-Given a :file:`hello.py` file with the application in it named ``app`` this is
-how it can be run.
+Given a :file:`hello.py` file with the application in it named ``app``
+this is how it can be run.
 
 Environment variables (On Windows use ``set`` instead of ``export``)::
 
     export FLASK_APP=hello
     flask run
 
-Parameters::
+Or with a filename::
 
-    flask --app=hello run
-
-File names::
-
-    flask --app=hello.py run
+    export FLASK_APP=/path/to/hello.py
+    flask run
 
 Virtualenv Integration
 ----------------------
@@ -62,16 +59,20 @@ automatically also activate the correct application name.
 Debug Flag
 ----------
 
-The :command:`flask` script can be run with :option:`--debug` or :option:`--no-debug` to
-automatically flip the debug flag of the application.  This can also be
-configured by setting ``FLASK_DEBUG`` to ``1`` or ``0``.
+The :command:`flask` script can also be instructed to enable the debug
+mode of the application automatically by exporting ``FLASK_DEBUG``.  If
+set to ``1`` debug is enabled or ``0`` disables it.
+
+Or with a filename::
+
+    export FLASK_DEBUG=1
 
 Running a Shell
 ---------------
 
 To run an interactive Python shell you can use the ``shell`` command::
 
-    flask --app=hello shell
+    flask shell
 
 This will start up an interactive Python shell, setup the correct
 application context and setup the local variables in the shell.  This is
@@ -86,6 +87,7 @@ easily.  Flask uses `click`_ for the command interface which makes
 creating custom commands very easy.  For instance if you want a shell
 command to initialize the database you can do this::
 
+    import click
     from flask import Flask
 
     app = Flask(__name__)
@@ -93,11 +95,11 @@ command to initialize the database you can do this::
     @app.cli.command()
     def initdb():
         """Initialize the database."""
-        print 'Init the db'
+        click.echo('Init the db')
 
 The command will then show up on the command line::
 
-    $ flask -a hello.py initdb
+    $ flask initdb
     Init the db
 
 Application Context
@@ -122,12 +124,12 @@ Factory Functions
 -----------------
 
 In case you are using factory functions to create your application (see
-:ref:`app-factories`) you will discover that the :command:`flask` command cannot
-work with them directly.  Flask won't be able to figure out how to
+:ref:`app-factories`) you will discover that the :command:`flask` command
+cannot work with them directly.  Flask won't be able to figure out how to
 instantiate your application properly by itself.  Because of this reason
 the recommendation is to create a separate file that instantiates
-applications.  This is by far not the only way to make this work.  Another
-is the :ref:`custom-scripts` support.
+applications.  This is not the only way to make this work.  Another is the
+:ref:`custom-scripts` support.
 
 For instance if you have a factory function that creates an application
 from a filename you could make a separate file that creates such an
@@ -152,9 +154,9 @@ From this point onwards :command:`flask` will find your application.
 Custom Scripts
 --------------
 
-While the most common way is to use the :command:`flask` command, you can also
-make your own "driver scripts".  Since Flask uses click for the scripts
-there is no reason you cannot hook these scripts into any click
+While the most common way is to use the :command:`flask` command, you can
+also make your own "driver scripts".  Since Flask uses click for the
+scripts there is no reason you cannot hook these scripts into any click
 application.  There is one big caveat and that is, that commands
 registered to :attr:`Flask.cli` will expect to be (indirectly at least)
 launched from a :class:`flask.cli.FlaskGroup` click group.  This is
@@ -162,38 +164,32 @@ necessary so that the commands know which Flask application they have to
 work with.
 
 To understand why you might want custom scripts you need to understand how
-click finds and executes the Flask application.  If you use the :command:`flask`
-script you specify the application to work with on the command line or
-environment variable as an import name.  This is simple but it has some
-limitations.  Primarily it does not work with application factory
-functions (see :ref:`app-factories`).
+click finds and executes the Flask application.  If you use the
+:command:`flask` script you specify the application to work with on the
+command line or environment variable as an import name.  This is simple
+but it has some limitations.  Primarily it does not work with application
+factory functions (see :ref:`app-factories`).
 
 With a custom script you don't have this problem as you can fully
 customize how the application will be created.  This is very useful if you
 write reusable applications that you want to ship to users and they should
 be presented with a custom management script.
 
-If you are used to writing click applications this will look familiar but
-at the same time, slightly different because of how commands are loaded.
-We won't go into detail now about the differences but if you are curious
-you can have a look at the :ref:`script-info-object` section to learn all
-about it.
-
 To explain all of this, here is an example :file:`manage.py` script that
 manages a hypothetical wiki application.  We will go through the details
 afterwards::
 
+    import os
     import click
-    from flask.cli import FlaskGroup, script_info_option
+    from flask.cli import FlaskGroup
 
     def create_wiki_app(info):
         from yourwiki import create_app
-        config = info.data.get('config') or 'wikiconfig.py'
-        return create_app(config=config)
+        return create_app(
+            config=os.environ.get('WIKI_CONFIG', 'wikiconfig.py'))
 
     @click.group(cls=FlaskGroup, create_app=create_wiki_app)
-    @script_info_option('--config', script_info_key='config')
-    def cli(**params):
+    def cli():
         """This is a management script for the wiki application."""
 
     if __name__ == '__main__':
@@ -204,56 +200,17 @@ step.
 
 1.  First we import the ``click`` library as well as the click extensions
     from the ``flask.cli`` package.  Primarily we are here interested
-    in the :class:`~flask.cli.FlaskGroup` click group and the
-    :func:`~flask.cli.script_info_option` decorator.
+    in the :class:`~flask.cli.FlaskGroup` click group.
 2.  The next thing we do is defining a function that is invoked with the
-    script info object (:ref:`script-info-object`) from Flask and its
+    script info object (:class:`~flask.cli.ScriptInfo`) from Flask and its
     purpose is to fully import and create the application.  This can
     either directly import an application object or create it (see
-    :ref:`app-factories`).
-
-    What is ``info.data``?  It's a dictionary of arbitrary data on the
-    script info that can be filled by options or through other means.  We
-    will come back to this later.
+    :ref:`app-factories`).  In this case we load the config from an
+    environment variable.
 3.  Next step is to create a :class:`FlaskGroup`.  In this case we just
     make an empty function with a help doc string that just does nothing
     and then pass the ``create_wiki_app`` function as a factory function.
 
     Whenever click now needs to operate on a Flask application it will
     call that function with the script info and ask for it to be created.
-4.  In step 2 you could see that the config is passed to the actual
-    creation function.  This config comes from the :func:`script_info_option`
-    decorator for the main script.  It accepts a :option:`--config` option and
-    then stores it in the script info so we can use it to create the
-    application.
-5.  All is rounded up by invoking the script.
-
-.. _script-info-object:
-
-The Script Info
----------------
-
-The Flask script integration might be confusing at first, but there is a reason
-why it's done this way.  The reason for this is that Flask wants to
-both provide custom commands to click as well as not loading your
-application unless it has to.  The reason for this is added flexibility.
-
-This way an application can provide custom commands, but even in the
-absence of an application the :command:`flask` script is still operational on a
-basic level.  In addition to that it means that the individual commands
-have the option to avoid creating an instance of the Flask application
-unless required.  This is very useful as it allows the server commands for
-instance to load the application on a first request instead of
-immediately, therefore giving a better debug experience.
-
-All of this is provided through the :class:`flask.cli.ScriptInfo` object
-and some helper utilities around.  The basic way it operates is that when
-the :class:`flask.cli.FlaskGroup` executes as a script it creates a script
-info and keeps it around.  From that point onwards modifications on the
-script info can be done through click options.  To simplify this pattern
-the :func:`flask.cli.script_info_option` decorator was added.
-
-Once Flask actually needs the individual Flask application it will invoke
-the :meth:`flask.cli.ScriptInfo.load_app` method.  This happens when the
-server starts, when the shell is launched or when the script looks for an
-application-provided click command.
+4.  All is rounded up by invoking the script.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -7,7 +7,7 @@ Command Line Interface
 
 .. currentmodule:: flask
 
-One of the nice new features in Flask 1.0 is the built-in integration of
+One of the nice new features in Flask 0.11 is the built-in integration of
 the `click <http://click.pocoo.org/>`_ command line interface.  This
 enables a wide range of new features for the Flask ecosystem and your own
 applications.

--- a/docs/errorhandling.rst
+++ b/docs/errorhandling.rst
@@ -131,7 +131,7 @@ Logging to a File
 
 Even if you get mails, you probably also want to log warnings.  It's a
 good idea to keep as much information around that might be required to
-debug a problem.  By default as of Flask 1.0, errors are logged to your
+debug a problem.  By default as of Flask 0.11, errors are logged to your
 webserver's log automatically.  Warnings however are not.  Please note
 that Flask itself will not issue any warnings in the core system, so it's
 your responsibility to warn in the code if something seems odd.

--- a/docs/extensiondev.rst
+++ b/docs/extensiondev.rst
@@ -408,8 +408,8 @@ Flask 0.8 introduced a redirect import system as a compatibility aid for app
 developers: Importing ``flask.ext.foo`` would try ``flask_foo`` and
 ``flaskext.foo`` in that order.
 
-As of Flask 1.0, most Flask extensions have transitioned to the new naming
-schema. The ``flask.ext.foo`` compatibility alias is still in Flask 1.0 but is
+As of Flask 0.11, most Flask extensions have transitioned to the new naming
+schema. The ``flask.ext.foo`` compatibility alias is still in Flask 0.11 but is
 now deprecated -- you should use ``flask_foo``.
 
 

--- a/docs/patterns/appfactories.rst
+++ b/docs/patterns/appfactories.rst
@@ -99,7 +99,8 @@ an application::
 
 It can then be used with the :command:`flask` command::
 
-    flask --app=exampleapp run
+    export FLASK_APP=exampleapp
+    flask run
 
 Factory Improvements
 --------------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -42,14 +42,20 @@ interpreter.  Make sure to not call your application :file:`flask.py` because th
 would conflict with Flask itself.
 
 To run the application you can either use the :command:`flask` command or
-python's :option:`-m` switch with Flask::
+python's :option:`-m` switch with Flask.  Before you can do that you need
+to tell your terminal the application to work with by exporting the
+`FLASK_APP` environment variable::
 
-    $ flask -a hello run
+    $ export FLASK_APP=hello.py
+    $ flask run
      * Running on http://127.0.0.1:5000/
 
-or alternatively::
+If you are on Windows you need to use `set` instead of `export`.
 
-    $ python -m flask -a hello run
+Alternatively you can use `python -m flask`::
+
+    $ export FLASK_APP=hello.py
+    $ python -m flask run
      * Running on http://127.0.0.1:5000/
 
 This launches a very simple builtin server, which is good enough for testing
@@ -72,7 +78,7 @@ should see your hello world greeting.
    you can make the server publicly available simply by adding
    ``--host=0.0.0.0`` to the command line::
 
-       flask -a hello run --host=0.0.0.0
+       flask run --host=0.0.0.0
 
    This tells your operating system to listen on all public IPs.
 
@@ -87,28 +93,19 @@ to look at the error message.
 Old Version of Flask
 ````````````````````
 
-Versions of Flask older than 1.0 use to have different ways to start the
+Versions of Flask older than 0.11 use to have different ways to start the
 application.  In short, the :command:`flask` command did not exist, and
 neither did ``python -m flask``.  In that case you have two options:
 either upgrade to newer Flask versions or have a look at the :ref:`server`
 docs to see the alternative method for running a server.
 
-Python older 2.7
-````````````````
-
-In case you have a version of Python older than 2.7 ``python -m flask``
-does not work.  You can either use :command:`flask` or ``python -m
-flask.cli`` as an alternative.  This is because Python before 2.7 does no
-permit packages to act as executable modules.  For more information see
-:ref:`cli`.
-
 Invalid Import Name
 ```````````````````
 
-The :option:`-a` argument to :command:`flask` is the name of the module to import.  In
-case that module is incorrectly named you will get an import error upon
-start (or if debug is enabled when you navigate to the application).  It
-will tell you what it tried to import and why it failed.
+The :option:`-a` argument to :command:`flask` is the name of the module to
+import.  In case that module is incorrectly named you will get an import
+error upon start (or if debug is enabled when you navigate to the
+application).  It will tell you what it tried to import and why it failed.
 
 The most common reason is a typo or because you did not actually create an
 ``app`` object.
@@ -126,10 +123,13 @@ That is not very nice and Flask can do better.  If you enable debug
 support the server will reload itself on code changes, and it will also
 provide you with a helpful debugger if things go wrong.
 
-There are different ways to enable the debug mode.  The most obvious one
-is the :option:`--debug` parameter to the :command:`flask` command::
+To enable debug mode you can export the `FLASK_DEBUG` environment variable
+before running the server::
 
-    flask --debug -a hello run
+    $ export FLASK_DEBUG=1
+    $ flask run
+
+(On Windows you need to use `set` instead of `export`).
 
 This does the following things:
 

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -5,7 +5,7 @@ Development Server
 
 .. currentmodule:: flask
 
-Starting with Flask 1.0 there are multiple built-in ways to run a
+Starting with Flask 0.11 there are multiple built-in ways to run a
 development server.  The best one is the :command:`flask` command line utility
 but you can also continue using the :meth:`Flask.run` method.
 

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -16,7 +16,9 @@ The :command:`flask` command line script (:ref:`cli`) is strongly recommended fo
 development because it provides a superior reload experience due to how it
 loads the application.  The basic usage is like this::
 
-    $ flask -a my_application --debug run
+    $ export FLASK_APP=my_application
+    $ export FLASK_DEBUG=1
+    $ flask run
 
 This will enable the debugger, the reloader and then start the server on
 *http://localhost:5000/*.
@@ -25,7 +27,7 @@ The individual features of the server can be controlled by passing more
 arguments to the ``run`` option.  For instance the reloader can be
 disabled::
 
-    $ flask -a my_application --debug run --no-reload
+    $ flask run --no-reload
 
 In Code
 -------
@@ -40,11 +42,11 @@ Example::
         app.run()
 
 This works well for the common case but it does not work well for
-development which is why from Flask 1.0 onwards the :command:`flask` method is
-recommended.  The reason for this is that due to how the reload mechanism
-works there are some bizarre side-effects (like executing certain code
-twice, sometimes crashing without message or dying when a syntax or
-import error happens).
+development which is why from Flask 0.11 onwards the :command:`flask`
+method is recommended.  The reason for this is that due to how the reload
+mechanism works there are some bizarre side-effects (like executing
+certain code twice, sometimes crashing without message or dying when a
+syntax or import error happens).
 
 It is however still a perfectly valid method for invoking a non automatic
 reloading application.

--- a/docs/shell.rst
+++ b/docs/shell.rst
@@ -29,7 +29,7 @@ chapter of the documentation first.
 Command Line Interface
 ----------------------
 
-Starting with Flask 1.0 the recommended way to work with the shell is the
+Starting with Flask 0.11 the recommended way to work with the shell is the
 ``flask shell`` command which does a lot of this automatically for you.
 For instance the shell is automatically initialized with a loaded
 application context.

--- a/docs/tutorial/dbcon.rst
+++ b/docs/tutorial/dbcon.rst
@@ -37,7 +37,6 @@ already established connection::
             g.sqlite_db = connect_db()
         return g.sqlite_db
 
-
 So now we know how to connect, but how do we properly disconnect?  For
 that, Flask provides us with the :meth:`~flask.Flask.teardown_appcontext`
 decorator.  It's executed every time the application context tears down::

--- a/docs/tutorial/dbinit.rst
+++ b/docs/tutorial/dbinit.rst
@@ -60,7 +60,7 @@ databases will not commit unless you explicitly tell it to.
 
 Now, it is possible to create a database with the :command:`flask` script::
 
-    flask --app=flaskr initdb
+    flask initdb
     Initialized the database.
 
 .. admonition:: Troubleshooting

--- a/docs/tutorial/setup.rst
+++ b/docs/tutorial/setup.rst
@@ -91,13 +91,16 @@ tuples.
         return rv
 
 With that out of the way, you should be able to start up the application
-without problems.  Do this with the following command::
+without problems.  Do this with the following commands::
 
-    flask --app=flaskr --debug run
+    export FLASK_APP=flaskr
+    export FLASK_DEBUG=1
+    flask run
 
-The :option:`--debug` flag enables or disables the interactive debugger.  *Never
-leave debug mode activated in a production system*, because it will allow
-users to execute code on the server!
+(In case you are on Windows you need to use `set` instead of `export`).
+The :envvar:`FLASK_DEBUG` flag enables or disables the interactive debugger.
+*Never leave debug mode activated in a production system*, because it will
+allow users to execute code on the server!
 
 You will see a message telling you that server has started along with
 the address at which you can access it.

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -21,13 +21,23 @@ installation, make sure to pass it the :option:`-U` parameter::
 
 .. _upgrading-to-10:
 
-Version 1.0
------------
+Version 0.11
+------------
+
+0.11 is an odd release in the Flask release cycle because it was supposed
+to be the 1.0 release.  However because there was such a long lead time up
+to the release we decided to push out a 0.11 release first with some
+changes removed to make the transition easier.  If you have been tracking
+the master branch which was 1.0 you might see some unexpected changes.
+
+In case you did track the master branch you will notice that `flask --app`
+is removed now.  You need to use the environment variable to specify an
+application.
 
 Debugging
 `````````
 
-Flask 1.0 removed the ``debug_log_format`` attribute from Flask
+Flask 0.11 removed the ``debug_log_format`` attribute from Flask
 applications.  Instead the new ``LOGGER_HANDLER_POLICY`` configuration can
 be used to disable the default log handlers and custom log handlers can be
 set up.
@@ -206,7 +216,7 @@ before, you should catch them with :exc:`RuntimeError` now.
 
 Additionally the :func:`~flask.send_file` function is now issuing
 deprecation warnings if you depend on functionality that will be removed
-in Flask 1.0.  Previously it was possible to use etags and mimetypes
+in Flask 0.11.  Previously it was possible to use etags and mimetypes
 when file objects were passed.  This was unreliable and caused issues
 for a few setups.  If you get a deprecation warning, make sure to
 update your application to work with either filenames there or disable

--- a/examples/flaskr/README
+++ b/examples/flaskr/README
@@ -13,13 +13,17 @@
          export an FLASKR_SETTINGS environment variable
          pointing to a configuration file.
 
-      2. initialize the database with this command:
+      2. Instruct flask to use the right application
 
-         flask --app=flaskr initdb
+         export FLASK_APP=flaskr
 
-      3. now you can run flaskr:
+      3. initialize the database with this command:
 
-         flask --app=flaskr run
+         flask initdb
+
+      4. now you can run flaskr:
+
+         flask run
 
          the application will greet you on
          http://localhost:5000/

--- a/examples/minitwit/README
+++ b/examples/minitwit/README
@@ -14,13 +14,17 @@
          export an MINITWIT_SETTINGS environment variable
          pointing to a configuration file.
 
+      2. tell flask about the right application:
+
+         export FLASK_APP=minitwit
+
       2. fire up a shell and run this:
 
-         flask --app=minitwit initdb
+         flask initdb
 
       3. now you can run minitwit:
 
-         flask --app=minitwit run
+         flask run
 
          the application will greet you on
          http://localhost:5000/

--- a/flask/app.py
+++ b/flask/app.py
@@ -22,7 +22,8 @@ from werkzeug.exceptions import HTTPException, InternalServerError, \
      MethodNotAllowed, BadRequest, default_exceptions
 
 from .helpers import _PackageBoundObject, url_for, get_flashed_messages, \
-     locked_cached_property, _endpoint_from_view_func, find_package
+     locked_cached_property, _endpoint_from_view_func, find_package, \
+     get_debug_flag
 from . import json, cli
 from .wrappers import Request, Response
 from .config import ConfigAttribute, Config
@@ -289,7 +290,7 @@ class Flask(_PackageBoundObject):
 
     #: Default configuration parameters.
     default_config = ImmutableDict({
-        'DEBUG':                                False,
+        'DEBUG':                                get_debug_flag(default=False),
         'TESTING':                              False,
         'PROPAGATE_EXCEPTIONS':                 None,
         'PRESERVE_CONTEXT_ON_EXCEPTION':        None,

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -14,7 +14,6 @@ import sys
 import pkgutil
 import posixpath
 import mimetypes
-from datetime import timedelta
 from time import time
 from zlib import adler32
 from threading import RLock
@@ -52,6 +51,13 @@ _missing = object()
 # able to access files from outside the filesystem.
 _os_alt_seps = list(sep for sep in [os.path.sep, os.path.altsep]
                     if sep not in (None, '/'))
+
+
+def get_debug_flag(default=None):
+    val = os.environ.get('FLASK_DEBUG')
+    if not val:
+        return default
+    return val not in ('0', 'false', 'no')
 
 
 def _endpoint_from_view_func(view_func):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ from click.testing import CliRunner
 from flask import Flask, current_app
 
 from flask.cli import AppGroup, FlaskGroup, NoAppException, ScriptInfo, \
-    find_best_app, locate_app, script_info_option, with_appcontext
+    find_best_app, locate_app, with_appcontext
 
 
 def test_cli_name(test_apps):
@@ -123,7 +123,6 @@ def test_flaskgroup():
         return Flask("flaskgroup")
 
     @click.group(cls=FlaskGroup, create_app=create_app)
-    @script_info_option('--config', script_info_key='config')
     def cli(**params):
         pass
 


### PR DESCRIPTION
This requires some explanation because it's potentially a controversial change.  We used to have `flask --app foo` support but this pull request essentially removes it.

Why are we doing this? Turns out there is a fundamental problem with how Click currently handles certain aspects and the feature that made `--app` work will have to change in Click. As a direct result of this we have to temporarily pretend we never had an intention to make that flag work.  I understand it's not a nice thing to do but I think in the grand scheme of things this is a good way to get a release out which is really something that needs to happen.

I might want to bring this back later but this will require some major changes in Click which I rather not do at the same time as a Flask release.

In the process of this I also intentionally underdocument some APIs which I'm not super happy about. This should encourage people to not go all in with the cli for now.

The tracking issue for that is https://github.com/pallets/click/issues/590