### PR TITLE
Match the hello.py with the one on homepage

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -19,6 +19,9 @@ A minimal Flask application looks something like this::
     @app.route('/')
     def hello_world():
         return 'Hello, World!'
+    
+    if __name__ = "__main__":
+        app.run()
 
 So what did that code do?
 


### PR DESCRIPTION
The `hello.py` script in quickstart is different from the one on the homepage. Therefore, it cannot be run with `python hello.py`, which conflicts with the next paragraph in quickstart.