### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -36,7 +36,7 @@ Running the testsuite
 ---------------------
 
 You probably want to set up a `virtualenv
-<http://virtualenv.readthedocs.org/en/latest/index.html>`_.
+<https://virtualenv.readthedocs.io/en/latest/index.html>`_.
 
 The minimal requirement for running the testsuite is ``py.test``.  You can
 install it with::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -250,7 +250,7 @@ intersphinx_mapping = {
     'http://click.pocoo.org/': None,
     'http://jinja.pocoo.org/docs/': None,
     'http://www.sqlalchemy.org/docs/': None,
-    'https://wtforms.readthedocs.org/en/latest/': None,
+    'https://wtforms.readthedocs.io/en/latest/': None,
     'https://pythonhosted.org/blinker/': None
 }
 

--- a/docs/deploying/wsgi-standalone.rst
+++ b/docs/deploying/wsgi-standalone.rst
@@ -25,7 +25,7 @@ For example, to run a Flask application with 4 worker processes (``-w
 
 .. _Gunicorn: http://gunicorn.org/
 .. _eventlet: http://eventlet.net/
-.. _greenlet: http://greenlet.readthedocs.org/en/latest/
+.. _greenlet: https://greenlet.readthedocs.io/en/latest/
 
 Gevent
 -------
@@ -41,7 +41,7 @@ event loop::
     http_server.serve_forever()
 
 .. _Gevent: http://www.gevent.org/
-.. _greenlet: http://greenlet.readthedocs.org/en/latest/
+.. _greenlet: https://greenlet.readthedocs.io/en/latest/
 .. _libev: http://software.schmorp.de/pkg/libev.html
 
 Twisted Web

--- a/docs/patterns/wtforms.rst
+++ b/docs/patterns/wtforms.rst
@@ -122,5 +122,5 @@ takes advantage of the :file:`_formhelpers.html` template:
 For more information about WTForms, head over to the `WTForms
 website`_.
 
-.. _WTForms: http://wtforms.readthedocs.org/
-.. _WTForms website: http://wtforms.readthedocs.org/
+.. _WTForms: https://wtforms.readthedocs.io/
+.. _WTForms website: https://wtforms.readthedocs.io/


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.