### PR TITLE
Update help to >   set FLASK_APP=hello.py

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -449,7 +449,7 @@ The most useful commands are the "run" and "shell" command.
 Example usage:
 
 \b
-  %(prefix)s%(cmd)s FLASK_APP=hello
+  %(prefix)s%(cmd)s FLASK_APP=hello.py
   %(prefix)s%(cmd)s FLASK_DEBUG=1
   %(prefix)sflask run
 """ % {


### PR DESCRIPTION
When running `flask --help`, the printed string contains this:
>   Example usage:
>
>   set FLASK_APP=hello
>    set FLASK_DEBUG=1
>    flask run

but it actually only works with `set FLASK_APP=hello.py` so the help should be changed.

This is true on my Windows 7 Python 3.5 flask 0.11 setup.