### PR TITLE
Guard sys.exc_clear call for people using pypy3

### DIFF
--- a/flask/_compat.py
+++ b/flask/_compat.py
@@ -75,7 +75,8 @@ if hasattr(sys, 'pypy_version_info'):
         def __enter__(self):
             return self
         def __exit__(self, *args):
-            sys.exc_clear()
+            if hasattr(sys, 'exc_clear'):
+                sys.exc_clear()
     try:
         try:
             with _Mgr():


### PR DESCRIPTION
I believe this is behind the reason behind recent Travis-CI failures in flask-restplus pull requests; at the very least, this is obscuring the real error. For example, see https://travis-ci.org/noirbizarre/flask-restplus/jobs/134224010