### PR TITLE
Document flash message size limit

### DIFF
--- a/docs/patterns/flashing.rst
+++ b/docs/patterns/flashing.rst
@@ -9,7 +9,9 @@ application.  Flask provides a really simple way to give feedback to a
 user with the flashing system.  The flashing system basically makes it
 possible to record a message at the end of a request and access it next
 request and only next request.  This is usually combined with a layout
-template that does this.
+template that does this. Note that browsers and sometimes web servers enforce
+a limit on cookie sizes. This means that flashing messages that are too
+large for session cookies causes message flashing to fail silently.
 
 Simple Flashing
 ---------------


### PR DESCRIPTION
Reason: Messages of size 68,493 - 91,326 characters cause flash to fail silently.
Session cookies cannot have such large messages.

Issue: pallets/flask#1789