### PR TITLE
Add issue template, resolves #1773

### DIFF
--- a/.github/ISSUE_TEMPLATE.rst
+++ b/.github/ISSUE_TEMPLATE.rst
@@ -1,0 +1,2 @@
+The issue tracker is a tool to address bugs.
+Please use `#pocoo` IRC channel on freenode or `StackOverflow` for questions.


### PR DESCRIPTION
On issue #1773, we wanted use issue templates to accomplish two things:
1. guide questions into StackOverflow and IRC channel
2. not duplicate CONTRIBUTING content
To resolve these, ISSUE_TEMPLATE is added to remind users not
to ask questions, and mark prerequisites.