### PR TITLE
Document Runtime Error when running outside of application context

### DIFF
--- a/docs/appcontext.rst
+++ b/docs/appcontext.rst
@@ -74,6 +74,11 @@ The application context is also used by the :func:`~flask.url_for`
 function in case a ``SERVER_NAME`` was configured.  This allows you to
 generate URLs even in the absence of a request.
 
+If a request context has not been pushed and an application context has 
+not been explicitly set, a ``RuntimeError`` will be raised.
+::
+    RuntimeError: Working outside of application context.
+
 Locality of the Context
 -----------------------
 


### PR DESCRIPTION
Adds a little documentation of the Runtime Error that you get when working outside an applications context.

fix #1521