### PR TITLE
Fix Issue 1847 - Adding Current Path when Invoking Flask-Cli Run

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -398,6 +398,8 @@ def run_command(info, host, port, reload, debugger, eager_loading,
     The reloader and debugger are by default enabled if the debug flag of
     Flask is enabled and disabled otherwise.
     """
+    import sys
+    sys.path.append('.')
     from werkzeug.serving import run_simple
 
     debug = get_debug_flag()


### PR DESCRIPTION
Fix for: #1847 

Adds the current directory to the Python path, when invoking a local development server.  `flask run` was unable to find the app's module in the PYTHONPATH, while `python -m flask run` adds the current working directory to the PYTHONPATH automatically.