### PR TITLE
Comment out old version added and changed tags. Fix #1704

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -205,7 +205,7 @@ To access the current session you can use the :class:`session` object:
 Session Interface
 -----------------
 
-.. versionadded:: 0.8
+.. #versionadded:: 0.8
 
 The session interface provides a simple way to replace the session
 implementation that Flask is using.
@@ -448,7 +448,7 @@ Extensions
 
         from flask.ext import foo
 
-   .. versionadded:: 0.8
+   .. #versionadded:: 0.8
 
 Stream Helpers
 --------------
@@ -506,7 +506,7 @@ Useful Internals
    Works similar to the request context but only binds the application.
    This is mainly there for extensions to store data.
 
-   .. versionadded:: 0.9
+   .. #versionadded:: 0.9
 
 .. autoclass:: flask.blueprints.BlueprintSetupState
    :members:
@@ -516,7 +516,7 @@ Useful Internals
 Signals
 -------
 
-.. versionadded:: 0.6
+.. #versionadded:: 0.6
 
 .. data:: signals.signals_available
 
@@ -715,7 +715,7 @@ The following signals exist in Flask:
 Class-Based Views
 -----------------
 
-.. versionadded:: 0.7
+.. #versionadded:: 0.7
 
 .. currentmodule:: None
 
@@ -868,7 +868,7 @@ Full example::
 
     app.add_url_rule('/', index)
 
-.. versionadded:: 0.8
+.. #versionadded:: 0.8
    The `provide_automatic_options` functionality was added.
 
 Command Line Interface

--- a/docs/appcontext.rst
+++ b/docs/appcontext.rst
@@ -3,7 +3,7 @@
 The Application Context
 =======================
 
-.. versionadded:: 0.9
+.. #versionadded:: 0.9
 
 One of the design ideas behind Flask is that there are two different
 “states” in which code is executed.  The application setup state in which

--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -5,7 +5,7 @@ Modular Applications with Blueprints
 
 .. currentmodule:: flask
 
-.. versionadded:: 0.7
+.. #versionadded:: 0.7
 
 Flask uses a concept of *blueprints* for making application components and
 supporting common patterns within an application or across applications.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -3,7 +3,7 @@
 Configuration Handling
 ======================
 
-.. versionadded:: 0.3
+.. #versionadded:: 0.3
 
 Applications need some kind of configuration.  There are different settings
 you might want to change depending on the application environment like
@@ -217,25 +217,25 @@ The following configuration values are used internally by Flask:
 
 .. _bind: https://www.isc.org/downloads/bind/
 
-.. versionadded:: 0.4
+.. #versionadded:: 0.4
    ``LOGGER_NAME``
 
-.. versionadded:: 0.5
+.. #versionadded:: 0.5
    ``SERVER_NAME``
 
-.. versionadded:: 0.6
+.. #versionadded:: 0.6
    ``MAX_CONTENT_LENGTH``
 
-.. versionadded:: 0.7
+.. #versionadded:: 0.7
    ``PROPAGATE_EXCEPTIONS``, ``PRESERVE_CONTEXT_ON_EXCEPTION``
 
-.. versionadded:: 0.8
+.. #versionadded:: 0.8
    ``TRAP_BAD_REQUEST_ERRORS``, ``TRAP_HTTP_EXCEPTIONS``,
    ``APPLICATION_ROOT``, ``SESSION_COOKIE_DOMAIN``,
    ``SESSION_COOKIE_PATH``, ``SESSION_COOKIE_HTTPONLY``,
    ``SESSION_COOKIE_SECURE``
 
-.. versionadded:: 0.9
+.. #versionadded:: 0.9
    ``PREFERRED_URL_SCHEME``
 
 .. versionadded:: 0.10
@@ -385,7 +385,7 @@ your configuration files.  However here a list of good recommendations:
 Instance Folders
 ----------------
 
-.. versionadded:: 0.8
+.. #versionadded:: 0.8
 
 Flask 0.8 introduces instance folders.  Flask for a long time made it
 possible to refer to paths relative to the application's folder directly

--- a/docs/errorhandling.rst
+++ b/docs/errorhandling.rst
@@ -3,7 +3,7 @@
 Application Errors
 ==================
 
-.. versionadded:: 0.3
+.. #versionadded:: 0.3
 
 Applications fail, servers fail.  Sooner or later you will see an exception
 in production.  Even if your code is 100% correct, you will still see

--- a/docs/patterns/fileuploads.rst
+++ b/docs/patterns/fileuploads.rst
@@ -134,7 +134,7 @@ If you now run the application everything should work as expected.
 Improving Uploads
 -----------------
 
-.. versionadded:: 0.6
+.. #versionadded:: 0.6
 
 So how exactly does Flask handle uploads?  Well it will store them in the
 webserver's memory if the files are reasonable small otherwise in a

--- a/docs/patterns/flashing.rst
+++ b/docs/patterns/flashing.rst
@@ -93,7 +93,7 @@ And here is the :file:`login.html` template which also inherits from
 Flashing With Categories
 ------------------------
 
-.. versionadded:: 0.3
+.. #versionadded:: 0.3
 
 It is also possible to provide categories when flashing a message.  The
 default category if nothing is provided is ``'message'``.  Alternative
@@ -128,7 +128,7 @@ might also use the category to add a prefix such as
 Filtering Flash Messages
 ------------------------
 
-.. versionadded:: 0.9
+.. #versionadded:: 0.9
 
 Optionally you can pass a list of categories which filters the results of
 :func:`~flask.get_flashed_messages`.  This is useful if you wish to

--- a/docs/patterns/streaming.rst
+++ b/docs/patterns/streaming.rst
@@ -63,7 +63,7 @@ might want to buffer up a few items in the template which you can do with
 Streaming with Context
 ----------------------
 
-.. versionadded:: 0.9
+.. #versionadded:: 0.9
 
 Note that when you stream data, the request context is already gone the
 moment the function executes.  Flask 0.9 provides you with a helper that

--- a/docs/patterns/urlprocessors.rst
+++ b/docs/patterns/urlprocessors.rst
@@ -1,7 +1,7 @@
 Using URL Processors
 ====================
 
-.. versionadded:: 0.7
+.. #versionadded:: 0.7
 
 Flask 0.7 introduces the concept of URL processors.  The idea is that you
 might have a bunch of resources with common parts in the URL that you

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -463,7 +463,7 @@ Markup(u'&lt;blink&gt;hacker&lt;/blink&gt;')
 >>> Markup('<em>Marked up</em> &raquo; HTML').striptags()
 u'Marked up \xbb HTML'
 
-.. versionchanged:: 0.5
+.. #versionchanged:: 0.5
 
    Autoescaping is no longer enabled for all templates.  The following
    extensions for templates trigger autoescaping: ``.html``, ``.htm``,
@@ -841,7 +841,7 @@ for a full example.
 Logging
 -------
 
-.. versionadded:: 0.3
+.. #versionadded:: 0.3
 
 Sometimes you might be in a situation where you deal with data that
 should be correct, but actually is not.  For example you may have some client-side

--- a/docs/shell.rst
+++ b/docs/shell.rst
@@ -3,7 +3,7 @@
 Working with the Shell
 ======================
 
-.. versionadded:: 0.3
+.. #versionadded:: 0.3
 
 One of the reasons everybody loves Python is the interactive shell.  It
 basically allows you to execute Python commands in real time and

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -3,7 +3,7 @@
 Signals
 =======
 
-.. versionadded:: 0.6
+.. #versionadded:: 0.6
 
 Starting with Flask 0.6, there is integrated support for signalling in
 Flask.  This support is provided by the excellent `blinker`_ library and

--- a/docs/templating.rst
+++ b/docs/templating.rst
@@ -39,7 +39,7 @@ by default:
 
    The current configuration object (:data:`flask.config`)
 
-   .. versionadded:: 0.6
+   .. #versionadded:: 0.6
 
    .. versionchanged:: 0.10
       This is now always available, even in imported templates.

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -305,7 +305,7 @@ And then to use it::
 Keeping the Context Around
 --------------------------
 
-.. versionadded:: 0.4
+.. #versionadded:: 0.4
 
 Sometimes it is helpful to trigger a regular request but still keep the
 context around for a little longer so that additional introspection can
@@ -326,7 +326,7 @@ is no longer available (because you are trying to use it outside of the actual r
 Accessing and Modifying Sessions
 --------------------------------
 
-.. versionadded:: 0.8
+.. #versionadded:: 0.8
 
 Sometimes it can be very helpful to access or modify the sessions from the
 test client.  Generally there are two ways for this.  If you just want to

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -3,7 +3,7 @@
 Pluggable Views
 ===============
 
-.. versionadded:: 0.7
+.. #versionadded:: 0.7
 
 Flask 0.7 introduces pluggable views inspired by the generic views from
 Django which are based on classes instead of functions.  The main

--- a/flask/app.py
+++ b/flask/app.py
@@ -113,11 +113,11 @@ class Flask(_PackageBoundObject):
         pick up SQL queries in `yourapplication.app` and not
         `yourapplication.views.frontend`)
 
-    .. versionadded:: 0.7
+    .. ##versionadded:: 0.7
        The `static_url_path`, `static_folder`, and `template_folder`
        parameters were added.
 
-    .. versionadded:: 0.8
+    .. ##versionadded:: 0.8
        The `instance_path` and `instance_relative_config` parameters were
        added.
 
@@ -261,7 +261,7 @@ class Flask(_PackageBoundObject):
     #: mind that the server has to support this.  This only affects files
     #: sent with the :func:`send_file` method.
     #:
-    #: .. versionadded:: 0.2
+    #: .. #versionadded:: 0.2
     #:
     #: This attribute can also be configured from the config with the
     #: ``USE_X_SENDFILE`` configuration key.  Defaults to ``False``.
@@ -270,7 +270,7 @@ class Flask(_PackageBoundObject):
     #: The name of the logger to use.  By default the logger name is the
     #: package name passed to the constructor.
     #:
-    #: .. versionadded:: 0.4
+    #: .. #versionadded:: 0.4
     logger_name = ConfigAttribute('LOGGER_NAME')
 
     #: The JSON encoder class to use.  Defaults to :class:`~flask.json.JSONEncoder`.
@@ -323,18 +323,18 @@ class Flask(_PackageBoundObject):
     #: The rule object to use for URL rules created.  This is used by
     #: :meth:`add_url_rule`.  Defaults to :class:`werkzeug.routing.Rule`.
     #:
-    #: .. versionadded:: 0.7
+    #: .. #versionadded:: 0.7
     url_rule_class = Rule
 
     #: the test client that is used with when `test_client` is used.
     #:
-    #: .. versionadded:: 0.7
+    #: .. #versionadded:: 0.7
     test_client_class = None
 
     #: the session interface to use.  By default an instance of
     #: :class:`~flask.sessions.SecureCookieSessionInterface` is used here.
     #:
-    #: .. versionadded:: 0.8
+    #: .. #versionadded:: 0.8
     session_interface = SecureCookieSessionInterface()
 
     def __init__(self, import_name, static_path=None, static_url_path=None,
@@ -362,7 +362,7 @@ class Flask(_PackageBoundObject):
 
         #: Holds the path to the instance folder.
         #:
-        #: .. versionadded:: 0.8
+        #: .. #versionadded:: 0.8
         self.instance_path = instance_path
 
         #: The configuration dictionary as :class:`Config`.  This behaves
@@ -402,7 +402,7 @@ class Flask(_PackageBoundObject):
         #: returns ``None`` or raises a :exc:`BuildError` the next function is
         #: tried.
         #:
-        #: .. versionadded:: 0.9
+        #: .. #versionadded:: 0.9
         self.url_build_error_handlers = []
 
         #: A dictionary with lists of functions that should be called at the
@@ -417,7 +417,7 @@ class Flask(_PackageBoundObject):
         #: first request to this instance.  To register a function here, use
         #: the :meth:`before_first_request` decorator.
         #:
-        #: .. versionadded:: 0.8
+        #: .. #versionadded:: 0.8
         self.before_first_request_funcs = []
 
         #: A dictionary with lists of functions that should be called after
@@ -436,7 +436,7 @@ class Flask(_PackageBoundObject):
         #: teardown_request function. To register a function here, use the
         #: :meth:`teardown_request` decorator.
         #:
-        #: .. versionadded:: 0.7
+        #: .. #versionadded:: 0.7
         self.teardown_request_funcs = {}
 
         #: A list of functions that are called when the application context
@@ -444,7 +444,7 @@ class Flask(_PackageBoundObject):
         #: if the request ends this is the place to store code that disconnects
         #: from databases.
         #:
-        #: .. versionadded:: 0.9
+        #: .. #versionadded:: 0.9
         self.teardown_appcontext_funcs = []
 
         #: A dictionary with lists of functions that can be used as URL
@@ -454,7 +454,7 @@ class Flask(_PackageBoundObject):
         #: callbacks, otherwise the key is the name of the blueprint.
         #: Each of these functions has the chance to modify the dictionary
         #:
-        #: .. versionadded:: 0.7
+        #: .. #versionadded:: 0.7
         self.url_value_preprocessors = {}
 
         #: A dictionary with lists of functions that can be used as URL value
@@ -466,7 +466,7 @@ class Flask(_PackageBoundObject):
         #: provide a :meth:`url_defaults` function that adds the parameters
         #: automatically again that were removed that way.
         #:
-        #: .. versionadded:: 0.7
+        #: .. #versionadded:: 0.7
         self.url_default_functions = {}
 
         #: A dictionary with list of functions that are called without argument
@@ -489,7 +489,7 @@ class Flask(_PackageBoundObject):
         #: can be attached multiple times so this dictionary does not tell
         #: you how often they got attached.
         #:
-        #: .. versionadded:: 0.7
+        #: .. #versionadded:: 0.7
         self.blueprints = {}
         self._blueprint_order = []
 
@@ -506,7 +506,7 @@ class Flask(_PackageBoundObject):
         #: case of a "Flask-Foo" extension in `flask_foo`, the key would be
         #: ``'foo'``.
         #:
-        #: .. versionadded:: 0.7
+        #: .. #versionadded:: 0.7
         self.extensions = {}
 
         #: The :class:`~werkzeug.routing.Map` for this instance.  You can use
@@ -568,7 +568,7 @@ class Flask(_PackageBoundObject):
         Flask needs the name of the application.  It can be set and overridden
         to change the value.
 
-        .. versionadded:: 0.8
+        .. #versionadded:: 0.8
         """
         if self.import_name == '__main__':
             fn = getattr(sys.modules['__main__'], '__file__', None)
@@ -582,7 +582,7 @@ class Flask(_PackageBoundObject):
         """Returns the value of the ``PROPAGATE_EXCEPTIONS`` configuration
         value in case it's set, otherwise a sensible default is returned.
 
-        .. versionadded:: 0.7
+        .. #versionadded:: 0.7
         """
         rv = self.config['PROPAGATE_EXCEPTIONS']
         if rv is not None:
@@ -595,7 +595,7 @@ class Flask(_PackageBoundObject):
         configuration value in case it's set, otherwise a sensible default
         is returned.
 
-        .. versionadded:: 0.7
+        .. #versionadded:: 0.7
         """
         rv = self.config['PRESERVE_CONTEXT_ON_EXCEPTION']
         if rv is not None:
@@ -613,7 +613,7 @@ class Flask(_PackageBoundObject):
             app.logger.warning('A warning occurred (%d apples)', 42)
             app.logger.error('An error occurred')
 
-        .. versionadded:: 0.3
+        .. #versionadded:: 0.3
         """
         if self._logger and self._logger.name == self.logger_name:
             return self._logger
@@ -634,7 +634,7 @@ class Flask(_PackageBoundObject):
         """This attribute is set to ``True`` if the application started
         handling the first request.
 
-        .. versionadded:: 0.8
+        .. #versionadded:: 0.8
         """
         return self._got_first_request
 
@@ -645,7 +645,7 @@ class Flask(_PackageBoundObject):
         the config should be relative to the instance path or the root path
         of the application.
 
-        .. versionadded:: 0.8
+        .. #versionadded:: 0.8
         """
         root_path = self.root_path
         if instance_relative:
@@ -658,7 +658,7 @@ class Flask(_PackageBoundObject):
         the path to a folder named ``instance`` next to your main file or
         the package.
 
-        .. versionadded:: 0.8
+        .. #versionadded:: 0.8
         """
         prefix, package_path = find_package(self.import_name)
         if prefix is None:
@@ -683,7 +683,7 @@ class Flask(_PackageBoundObject):
         the Jinja2 globals and filters after initialization.  Override
         this function to customize the behavior.
 
-        .. versionadded:: 0.5
+        .. #versionadded:: 0.5
         .. versionchanged:: 0.11
            ``Environment.auto_reload`` set in accordance with
            ``TEMPLATES_AUTO_RELOAD`` configuration option.
@@ -720,15 +720,15 @@ class Flask(_PackageBoundObject):
         The global loader dispatches between the loaders of the application
         and the individual blueprints.
 
-        .. versionadded:: 0.7
+        .. #versionadded:: 0.7
         """
         return DispatchingJinjaLoader(self)
 
     def init_jinja_globals(self):
         """Deprecated.  Used to initialize the Jinja2 globals.
 
-        .. versionadded:: 0.5
-        .. versionchanged:: 0.7
+        .. #versionadded:: 0.5
+        .. #versionchanged:: 0.7
            This method is deprecated with 0.7.  Override
            :meth:`create_jinja_environment` instead.
         """
@@ -737,7 +737,7 @@ class Flask(_PackageBoundObject):
         """Returns ``True`` if autoescaping should be active for the given
         template name. If no template name is given, returns `True`.
 
-        .. versionadded:: 0.5
+        .. #versionadded:: 0.5
         """
         if filename is None:
             return True
@@ -886,10 +886,10 @@ class Flask(_PackageBoundObject):
 
         See :class:`~flask.testing.FlaskClient` for more information.
 
-        .. versionchanged:: 0.4
+        .. #versionchanged:: 0.4
            added support for ``with`` block usage for the client.
 
-        .. versionadded:: 0.7
+        .. #versionadded:: 0.7
            The `use_cookies` parameter was added as well as the ability
            to override the client to be used by setting the
            :attr:`test_client_class` attribute.
@@ -929,7 +929,7 @@ class Flask(_PackageBoundObject):
         """Creates a new instance of a missing session.  Instead of overriding
         this method we recommend replacing the :class:`session_interface`.
 
-        .. versionadded:: 0.7
+        .. #versionadded:: 0.7
         """
         return self.session_interface.make_null_session(self)
 
@@ -952,7 +952,7 @@ class Flask(_PackageBoundObject):
         :param template_folder: set an alternate template folder
         :param root_path: set an alternate root path for this blueprint
 
-        .. versionadded:: 0.7
+        .. #versionadded:: 0.7
         """
         first_registration = False
         if blueprint.name in self.blueprints:
@@ -1003,10 +1003,10 @@ class Flask(_PackageBoundObject):
 
         For more information refer to :ref:`url-route-registrations`.
 
-        .. versionchanged:: 0.2
+        .. #versionchanged:: 0.2
            `view_func` parameter added.
 
-        .. versionchanged:: 0.6
+        .. #versionchanged:: 0.6
            ``OPTIONS`` is added automatically as method.
 
         :param rule: the URL rule as string
@@ -1159,12 +1159,12 @@ class Flask(_PackageBoundObject):
         The first ``None`` refers to the active blueprint.  If the error
         handler should be application wide ``None`` shall be used.
 
-        .. versionadded:: 0.7
+        .. #versionadded:: 0.7
             Use :meth:`register_error_handler` instead of modifying
             :attr:`error_handler_spec` directly, for application wide error
             handlers.
 
-        .. versionadded:: 0.7
+        .. #versionadded:: 0.7
            One can now additionally also register custom exception types
            that do not necessarily have to be a subclass of the
            :class:`~werkzeug.exceptions.HTTPException` class.
@@ -1181,7 +1181,7 @@ class Flask(_PackageBoundObject):
         decorator that is more straightforward to use for non decorator
         usage.
 
-        .. versionadded:: 0.7
+        .. #versionadded:: 0.7
         """
         self._register_error_handler(None, code_or_exception, f)
 
@@ -1320,7 +1320,7 @@ class Flask(_PackageBoundObject):
         The function will be called without any arguments and its return
         value is ignored.
 
-        .. versionadded:: 0.8
+        .. #versionadded:: 0.8
         """
         self.before_first_request_funcs.append(f)
         return f
@@ -1404,7 +1404,7 @@ class Flask(_PackageBoundObject):
 
         The return values of teardown functions are ignored.
 
-        .. versionadded:: 0.9
+        .. #versionadded:: 0.9
         """
         self.teardown_appcontext_funcs.append(f)
         return f
@@ -1485,7 +1485,7 @@ class Flask(_PackageBoundObject):
         registered error handlers and fall back to returning the
         exception as response.
 
-        .. versionadded:: 0.3
+        .. #versionadded:: 0.3
         """
         # Proxy exceptions don't have error codes.  We want to always return
         # those unchanged as errors
@@ -1509,7 +1509,7 @@ class Flask(_PackageBoundObject):
         traceback.  This is helpful for debugging implicitly raised HTTP
         exceptions.
 
-        .. versionadded:: 0.8
+        .. #versionadded:: 0.8
         """
         if self.config['TRAP_HTTP_EXCEPTIONS']:
             return True
@@ -1525,7 +1525,7 @@ class Flask(_PackageBoundObject):
         function will either return a response value or reraise the
         exception with the same traceback.
 
-        .. versionadded:: 0.7
+        .. #versionadded:: 0.7
         """
         exc_type, exc_value, tb = sys.exc_info()
         assert exc_value is e
@@ -1551,7 +1551,7 @@ class Flask(_PackageBoundObject):
         for a 500 internal server error is used.  If no such handler
         exists, a default 500 internal server error message is displayed.
 
-        .. versionadded:: 0.3
+        .. #versionadded:: 0.3
         """
         exc_type, exc_value, tb = sys.exc_info()
 
@@ -1579,7 +1579,7 @@ class Flask(_PackageBoundObject):
         The default implementation logs the exception as error on the
         :attr:`logger`.
 
-        .. versionadded:: 0.8
+        .. #versionadded:: 0.8
         """
         self.logger.error('Exception on %s [%s]' % (
             request.path,
@@ -1608,7 +1608,7 @@ class Flask(_PackageBoundObject):
         be a response object.  In order to convert the return value to a
         proper response object, call :func:`make_response`.
 
-        .. versionchanged:: 0.7
+        .. #versionchanged:: 0.7
            This no longer does the exception handling, this code was
            moved to the new :meth:`full_dispatch_request`.
         """
@@ -1629,7 +1629,7 @@ class Flask(_PackageBoundObject):
         pre and postprocessing as well as HTTP exception catching and
         error handling.
 
-        .. versionadded:: 0.7
+        .. #versionadded:: 0.7
         """
         self.try_trigger_before_first_request_functions()
         try:
@@ -1665,7 +1665,7 @@ class Flask(_PackageBoundObject):
         This can be changed through subclassing to change the default
         behavior of ``OPTIONS`` responses.
 
-        .. versionadded:: 0.7
+        .. #versionadded:: 0.7
         """
         adapter = _request_ctx_stack.top.url_adapter
         if hasattr(adapter, 'allowed_methods'):
@@ -1719,7 +1719,7 @@ class Flask(_PackageBoundObject):
 
         :param rv: the return value from the view function
 
-        .. versionchanged:: 0.9
+        .. #versionchanged:: 0.9
            Previously a tuple was interpreted as the arguments for the
            response object.
         """
@@ -1760,9 +1760,9 @@ class Flask(_PackageBoundObject):
         is created at a point where the request context is not yet set up
         so the request is passed explicitly.
 
-        .. versionadded:: 0.6
+        .. #versionadded:: 0.6
 
-        .. versionchanged:: 0.9
+        .. #versionchanged:: 0.9
            This can now also be called without a request object when the
            URL adapter is created for the application context.
         """
@@ -1782,7 +1782,7 @@ class Flask(_PackageBoundObject):
         the values dictionary passed.  This is used internally and
         automatically called on URL building.
 
-        .. versionadded:: 0.7
+        .. #versionadded:: 0.7
         """
         funcs = self.url_default_functions.get(None, ())
         if '.' in endpoint:
@@ -1843,7 +1843,7 @@ class Flask(_PackageBoundObject):
         before it's sent to the WSGI server.  By default this will
         call all the :meth:`after_request` decorated functions.
 
-        .. versionchanged:: 0.5
+        .. #versionchanged:: 0.5
            As of Flask 0.5 the functions registered for after request
            execution are called in reverse order of registration.
 
@@ -1871,7 +1871,7 @@ class Flask(_PackageBoundObject):
         triggered when the request context is popped.  That way we have a
         tighter control over certain resources under testing environments.
 
-        .. versionchanged:: 0.9
+        .. #versionchanged:: 0.9
            Added the `exc` argument.  Previously this was always using the
            current exception information.
         """
@@ -1890,7 +1890,7 @@ class Flask(_PackageBoundObject):
         much the same as :meth:`do_teardown_request` but for the application
         context.
 
-        .. versionadded:: 0.9
+        .. #versionadded:: 0.9
         """
         if exc is _sentinel:
             exc = sys.exc_info()[1]
@@ -1909,7 +1909,7 @@ class Flask(_PackageBoundObject):
             with app.app_context():
                 ...
 
-        .. versionadded:: 0.9
+        .. #versionadded:: 0.9
         """
         return AppContext(self)
 
@@ -1935,7 +1935,7 @@ class Flask(_PackageBoundObject):
             finally:
                 ctx.pop()
 
-        .. versionchanged:: 0.3
+        .. #versionchanged:: 0.3
            Added support for non-with statement usage and ``with`` statement
            is now passed the ctx object.
 
@@ -1969,7 +1969,7 @@ class Flask(_PackageBoundObject):
         Then you still have the original application object around and
         can continue to call methods on it.
 
-        .. versionchanged:: 0.7
+        .. #versionchanged:: 0.7
            The behavior of the before and after request callbacks was changed
            under error conditions and a new callback was added that will
            always execute at the end of the request, independent on if an

--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -83,7 +83,7 @@ class Blueprint(_PackageBoundObject):
     or other things on the main application.  See :ref:`blueprints` for more
     information.
 
-    .. versionadded:: 0.7
+    .. #versionadded:: 0.7
     """
 
     warn_on_modifications = False

--- a/flask/config.py
+++ b/flask/config.py
@@ -119,7 +119,7 @@ class Config(dict):
         :param silent: set to ``True`` if you want silent failure for missing
                        files.
 
-        .. versionadded:: 0.7
+        .. #versionadded:: 0.7
            `silent` parameter.
         """
         filename = os.path.join(self.root_path, filename)

--- a/flask/ctx.py
+++ b/flask/ctx.py
@@ -70,7 +70,7 @@ def after_this_request(f):
     modify a response.  For instance think of a decorator that wants to add
     some headers without converting the return value into a response object.
 
-    .. versionadded:: 0.9
+    .. #versionadded:: 0.9
     """
     _request_ctx_stack.top._after_request_functions.append(f)
     return f
@@ -138,7 +138,7 @@ def has_request_context():
                     remote_addr = request.remote_addr
                 self.remote_addr = remote_addr
 
-    .. versionadded:: 0.7
+    .. #versionadded:: 0.7
     """
     return _request_ctx_stack.top is not None
 
@@ -148,7 +148,7 @@ def has_app_context():
     context.  You can also just do a boolean check on the
     :data:`current_app` object instead.
 
-    .. versionadded:: 0.9
+    .. #versionadded:: 0.9
     """
     return _app_ctx_stack.top is not None
 
@@ -338,7 +338,7 @@ class RequestContext(object):
         also trigger the execution of functions registered by the
         :meth:`~flask.Flask.teardown_request` decorator.
 
-        .. versionchanged:: 0.9
+        .. #versionchanged:: 0.9
            Added the `exc` argument.
         """
         app_ctx = self._implicit_app_ctx_stack.pop()

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -101,7 +101,7 @@ def stream_with_context(generator_or_function):
                 yield '!'
             return Response(stream_with_context(generate()))
 
-    .. versionadded:: 0.9
+    .. #versionadded:: 0.9
     """
     try:
         gen = iter(generator_or_function)
@@ -181,7 +181,7 @@ def make_response(*args):
     -   if more than one argument is passed, the arguments are passed
         to the :meth:`flask.Flask.make_response` function as tuple.
 
-    .. versionadded:: 0.6
+    .. #versionadded:: 0.6
     """
     if not args:
         return current_app.response_class()
@@ -242,10 +242,10 @@ def url_for(endpoint, **values):
     .. versionadded:: 0.10
        The `_scheme` parameter was added.
 
-    .. versionadded:: 0.9
+    .. #versionadded:: 0.9
        The `_anchor` and `_method` parameters were added.
 
-    .. versionadded:: 0.9
+    .. #versionadded:: 0.9
        Calls :meth:`Flask.handle_build_error` on
        :exc:`~werkzeug.routing.BuildError`.
 
@@ -350,7 +350,7 @@ def get_template_attribute(template_name, attribute):
         hello = get_template_attribute('_cider.html', 'hello')
         return hello('World')
 
-    .. versionadded:: 0.2
+    .. #versionadded:: 0.2
 
     :param template_name: the name of the template
     :param attribute: the name of the variable of macro to access
@@ -364,7 +364,7 @@ def flash(message, category='message'):
     flashed message from the session and to display it to the user,
     the template has to call :func:`get_flashed_messages`.
 
-    .. versionchanged:: 0.3
+    .. #versionchanged:: 0.3
        `category` parameter added.
 
     :param message: the message to be flashed.
@@ -407,10 +407,10 @@ def get_flashed_messages(with_categories=False, category_filter=[]):
 
     See :ref:`message-flashing-pattern` for examples.
 
-    .. versionchanged:: 0.3
+    .. #versionchanged:: 0.3
        `with_categories` parameter added.
 
-    .. versionchanged:: 0.9
+    .. #versionchanged:: 0.9
         `category_filter` parameter added.
 
     :param with_categories: set to ``True`` to also receive categories.
@@ -446,19 +446,19 @@ def send_file(filename_or_fp, mimetype=None, as_attachment=False,
     Please never pass filenames to this function from user sources;
     you should use :func:`send_from_directory` instead.
 
-    .. versionadded:: 0.2
+    .. #versionadded:: 0.2
 
-    .. versionadded:: 0.5
+    .. #versionadded:: 0.5
        The `add_etags`, `cache_timeout` and `conditional` parameters were
        added.  The default behavior is now to attach etags.
 
-    .. versionchanged:: 0.7
+    .. #versionchanged:: 0.7
        mimetype guessing and etag support for file objects was
        deprecated because it was unreliable.  Pass a filename if you are
        able to, otherwise attach an etag yourself.  This functionality
        will be removed in Flask 1.0
 
-    .. versionchanged:: 0.9
+    .. #versionchanged:: 0.9
        cache_timeout pulls its default from application config, when None.
 
     :param filename_or_fp: the filename of the file to send in `latin-1`.
@@ -622,7 +622,7 @@ def send_from_directory(directory, filename, **options):
        to serve files for the given path on its own without calling into the
        web application for improved performance.
 
-    .. versionadded:: 0.5
+    .. #versionadded:: 0.5
 
     :param directory: the directory where all the files are stored.
     :param filename: the filename relative to that directory to
@@ -837,7 +837,7 @@ class _PackageBoundObject(object):
         """This is ``True`` if the package bound object's container has a
         folder for static files.
 
-        .. versionadded:: 0.5
+        .. #versionadded:: 0.5
         """
         return self.static_folder is not None
 
@@ -845,7 +845,7 @@ class _PackageBoundObject(object):
     def jinja_loader(self):
         """The Jinja loader for this package bound object.
 
-        .. versionadded:: 0.5
+        .. #versionadded:: 0.5
         """
         if self.template_folder is not None:
             return FileSystemLoader(os.path.join(self.root_path,
@@ -873,7 +873,7 @@ class _PackageBoundObject(object):
                         return 60
                     return flask.Flask.get_send_file_max_age(self, name)
 
-        .. versionadded:: 0.9
+        .. #versionadded:: 0.9
         """
         return total_seconds(current_app.send_file_max_age_default)
 
@@ -881,7 +881,7 @@ class _PackageBoundObject(object):
         """Function used internally to send static files from the static
         folder to the browser.
 
-        .. versionadded:: 0.5
+        .. #versionadded:: 0.5
         """
         if not self.has_static_folder:
             raise RuntimeError('No static folder for this object')

--- a/flask/json.py
+++ b/flask/json.py
@@ -245,7 +245,7 @@ def jsonify(*args, **kwargs):
     Compressed (not pretty) formatting currently means no indents and no
     spaces after separators.
 
-    .. versionadded:: 0.2
+    .. #versionadded:: 0.2
     """
 
     indent = None

--- a/flask/sessions.py
+++ b/flask/sessions.py
@@ -158,7 +158,7 @@ class SessionInterface(object):
         app = Flask(__name__)
         app.session_interface = MySessionInterface()
 
-    .. versionadded:: 0.8
+    .. #versionadded:: 0.8
     """
 
     #: :meth:`make_null_session` will look here for the class that should

--- a/flask/views.py
+++ b/flask/views.py
@@ -59,7 +59,7 @@ class View(object):
     #: You can place one or more decorators in this list and whenever the
     #: view function is created the result is automatically decorated.
     #:
-    #: .. versionadded:: 0.8
+    #: .. #versionadded:: 0.8
     decorators = ()
 
     def dispatch_request(self):

--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -42,7 +42,7 @@ class Request(RequestBase):
     #: useful to inspect which methods are allowed for the URL from
     #: a before/after handler (``request.url_rule.methods``) etc.
     #:
-    #: .. versionadded:: 0.6
+    #: .. #versionadded:: 0.6
     url_rule = None
 
     #: A dict of view arguments that matched the request.  If an exception
@@ -173,7 +173,7 @@ class Request(RequestBase):
            response.  If you want that behavior back you can trivially
            add it by subclassing.
 
-        .. versionadded:: 0.8
+        .. #versionadded:: 0.8
         """
         ctx = _request_ctx_stack.top
         if ctx is not None and ctx.app.config.get('DEBUG', False):


### PR DESCRIPTION
Comment out the "versionadded" and "versionchanged" tags by adding # in
the front. The line (or block) would be considered as comments.

This is another attempt at #1856 based on #1704 (comment)
