### PR TITLE
Add a link to Extension Development

### DIFF
--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -25,6 +25,13 @@ importable from ``flask_foo``::
 
     import flask_foo
 
+Building Extensions
+-------------------
+
+While `Flask Extension Registry`_ contains many Flask extensions, you may not find
+an extension that fits your need. If this is the case, you can always create your own. 
+Consider reading :ref:`extension-dev` to develop your own Flask extension.
+
 Flask Before 0.8
 ----------------
 


### PR DESCRIPTION
Provides a link to [Flask Extension Development][0] page from [Flask Extension page][1].
Flask Extension page talks about `finding`, `using` extensions, it might as well talk about `building` one too. Found #532 as the most relevant issue that is open.

[0]: http://flask.pocoo.org/docs/0.11/extensiondev
[1]: http://flask.pocoo.org/docs/0.11/extensions