### PR TITLE
Use recwarn everywhere

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@
     :license: BSD, see LICENSE for more details.
 """
 import flask
+import gc
 import os
 import sys
 import pkgutil
@@ -129,4 +130,5 @@ def purge_module(request):
 @pytest.yield_fixture(autouse=True)
 def catch_deprecation_warnings(recwarn):
     yield
+    gc.collect()
     assert not recwarn.list

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,8 +126,7 @@ def purge_module(request):
     return inner
 
 
-@pytest.fixture
-def catch_deprecation_warnings():
-    import warnings
-    warnings.simplefilter('default', category=DeprecationWarning)
-    return lambda: warnings.catch_warnings(record=True)
+@pytest.yield_fixture(autouse=True)
+def catch_deprecation_warnings(recwarn):
+    yield
+    assert not recwarn.list

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1116,9 +1116,10 @@ def test_static_files():
     rv.close()
 
 
-def test_static_path_deprecated():
-    with pytest.deprecated_call():
-        app = flask.Flask(__name__, static_path='/foo')
+def test_static_path_deprecated(recwarn):
+    app = flask.Flask(__name__, static_path='/foo')
+    recwarn.pop(DeprecationWarning)
+
     app.testing = True
     rv = app.test_client().get('/foo/index.html')
     assert rv.status_code == 200

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1123,6 +1123,8 @@ def test_static_path_deprecated(recwarn):
     app.testing = True
     rv = app.test_client().get('/foo/index.html')
     assert rv.status_code == 200
+    rv.close()
+
     with app.test_request_context():
         assert flask.url_for('static', filename='index.html') == '/foo/index.html'
 
@@ -1132,6 +1134,8 @@ def test_static_url_path():
     app.testing = True
     rv = app.test_client().get('/foo/index.html')
     assert rv.status_code == 200
+    rv.close()
+
     with app.test_request_context():
         assert flask.url_for('static', filename='index.html') == '/foo/index.html'
 

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -16,7 +16,7 @@ import flask
 
 class TestRequestDeprecation(object):
 
-    def test_request_json(self, catch_deprecation_warnings):
+    def test_request_json(self, recwarn):
         """Request.json is deprecated"""
         app = flask.Flask(__name__)
         app.testing = True
@@ -27,13 +27,11 @@ class TestRequestDeprecation(object):
             print(flask.request.json)
             return 'OK'
 
-        with catch_deprecation_warnings() as captured:
-            c = app.test_client()
-            c.post('/', data='{"spam": 42}', content_type='application/json')
+        c = app.test_client()
+        c.post('/', data='{"spam": 42}', content_type='application/json')
+        recwarn.pop(DeprecationWarning)
 
-        assert len(captured) == 1
-
-    def test_request_module(self, catch_deprecation_warnings):
+    def test_request_module(self, recwarn):
         """Request.module is deprecated"""
         app = flask.Flask(__name__)
         app.testing = True
@@ -43,8 +41,6 @@ class TestRequestDeprecation(object):
             assert flask.request.module is None
             return 'OK'
 
-        with catch_deprecation_warnings() as captured:
-            c = app.test_client()
-            c.get('/')
-
-        assert len(captured) == 1
+        c = app.test_client()
+        c.get('/')
+        recwarn.pop(DeprecationWarning)

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -21,6 +21,18 @@ from flask._compat import PY2
 
 
 @pytest.fixture(autouse=True)
+def disable_extwarnings(request, recwarn):
+    from flask.exthook import ExtDeprecationWarning
+
+    def inner():
+        assert set(w.category for w in recwarn.list) \
+            <= set([ExtDeprecationWarning])
+        recwarn.clear()
+
+    request.addfinalizer(inner)
+
+
+@pytest.fixture(autouse=True)
 def importhook_setup(monkeypatch, request):
     # we clear this out for various reasons.  The most important one is
     # that a real flaskext could be in there which would disable our

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -362,8 +362,8 @@ class TestSendfile(object):
             rv.close()
 
         # mimetypes + etag
-        assert len(recwarn.list) == 2
-        recwarn.clear()
+        recwarn.pop(DeprecationWarning)
+        recwarn.pop(DeprecationWarning)
 
         app.use_x_sendfile = True
 
@@ -377,8 +377,8 @@ class TestSendfile(object):
             rv.close()
 
         # mimetypes + etag
-        recwarn.pop()
-        recwarn.pop()
+        recwarn.pop(DeprecationWarning)
+        recwarn.pop(DeprecationWarning)
 
         app.use_x_sendfile = False
         with app.test_request_context():
@@ -390,7 +390,7 @@ class TestSendfile(object):
             rv.close()
 
             # etags
-            recwarn.pop()
+            recwarn.pop(DeprecationWarning)
 
             class PyStringIO(object):
                 def __init__(self, *args, **kwargs):
@@ -406,9 +406,9 @@ class TestSendfile(object):
             rv.close()
 
             # attachment_filename and etags
-            recwarn.pop()
-            recwarn.pop()
-            recwarn.pop()
+            a = recwarn.pop(DeprecationWarning)
+            b = recwarn.pop(DeprecationWarning)
+            c = recwarn.pop(UserWarning)  # file not found
 
             f = StringIO('Test')
             rv = flask.send_file(f, mimetype='text/plain')
@@ -418,7 +418,7 @@ class TestSendfile(object):
             rv.close()
 
             # etags
-            recwarn.pop()
+            recwarn.pop(DeprecationWarning)
 
         app.use_x_sendfile = True
 
@@ -429,7 +429,7 @@ class TestSendfile(object):
             rv.close()
 
         # etags
-        recwarn.pop()
+        recwarn.pop(DeprecationWarning)
 
     def test_attachment(self, recwarn):
         app = flask.Flask(__name__)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -337,7 +337,7 @@ class TestSendfile(object):
                 assert rv.data == f.read()
             rv.close()
 
-    def test_send_file_xsendfile(self):
+    def test_send_file_xsendfile(self, catch_deprecation_warnings):
         app = flask.Flask(__name__)
         app.use_x_sendfile = True
         with app.test_request_context():
@@ -349,90 +349,100 @@ class TestSendfile(object):
             assert rv.mimetype == 'text/html'
             rv.close()
 
-    def test_send_file_object(self, catch_deprecation_warnings):
+    def test_send_file_object(self, recwarn):
         app = flask.Flask(__name__)
-        with catch_deprecation_warnings() as captured:
-            with app.test_request_context():
-                f = open(os.path.join(app.root_path, 'static/index.html'), mode='rb')
-                rv = flask.send_file(f)
-                rv.direct_passthrough = False
-                with app.open_resource('static/index.html') as f:
-                    assert rv.data == f.read()
-                assert rv.mimetype == 'text/html'
-                rv.close()
-            # mimetypes + etag
-            assert len(captured) == 2
+
+        with app.test_request_context():
+            f = open(os.path.join(app.root_path, 'static/index.html'), mode='rb')
+            rv = flask.send_file(f)
+            rv.direct_passthrough = False
+            with app.open_resource('static/index.html') as f:
+                assert rv.data == f.read()
+            assert rv.mimetype == 'text/html'
+            rv.close()
+
+        # mimetypes + etag
+        assert len(recwarn.list) == 2
+        recwarn.clear()
 
         app.use_x_sendfile = True
-        with catch_deprecation_warnings() as captured:
-            with app.test_request_context():
-                f = open(os.path.join(app.root_path, 'static/index.html'))
-                rv = flask.send_file(f)
-                assert rv.mimetype == 'text/html'
-                assert 'x-sendfile' in rv.headers
-                assert rv.headers['x-sendfile'] == \
-                    os.path.join(app.root_path, 'static/index.html')
-                rv.close()
-            # mimetypes + etag
-            assert len(captured) == 2
+
+        with app.test_request_context():
+            f = open(os.path.join(app.root_path, 'static/index.html'))
+            rv = flask.send_file(f)
+            assert rv.mimetype == 'text/html'
+            assert 'x-sendfile' in rv.headers
+            assert rv.headers['x-sendfile'] == \
+                os.path.join(app.root_path, 'static/index.html')
+            rv.close()
+
+        # mimetypes + etag
+        recwarn.pop()
+        recwarn.pop()
 
         app.use_x_sendfile = False
         with app.test_request_context():
-            with catch_deprecation_warnings() as captured:
-                f = StringIO('Test')
-                rv = flask.send_file(f)
-                rv.direct_passthrough = False
-                assert rv.data == b'Test'
-                assert rv.mimetype == 'application/octet-stream'
-                rv.close()
+            f = StringIO('Test')
+            rv = flask.send_file(f)
+            rv.direct_passthrough = False
+            assert rv.data == b'Test'
+            assert rv.mimetype == 'application/octet-stream'
+            rv.close()
+
             # etags
-            assert len(captured) == 1
-            with catch_deprecation_warnings() as captured:
-                class PyStringIO(object):
-                    def __init__(self, *args, **kwargs):
-                        self._io = StringIO(*args, **kwargs)
-                    def __getattr__(self, name):
-                        return getattr(self._io, name)
-                f = PyStringIO('Test')
-                f.name = 'test.txt'
-                rv = flask.send_file(f)
-                rv.direct_passthrough = False
-                assert rv.data == b'Test'
-                assert rv.mimetype == 'text/plain'
-                rv.close()
+            recwarn.pop()
+
+            class PyStringIO(object):
+                def __init__(self, *args, **kwargs):
+                    self._io = StringIO(*args, **kwargs)
+                def __getattr__(self, name):
+                    return getattr(self._io, name)
+            f = PyStringIO('Test')
+            f.name = 'test.txt'
+            rv = flask.send_file(f)
+            rv.direct_passthrough = False
+            assert rv.data == b'Test'
+            assert rv.mimetype == 'text/plain'
+            rv.close()
+
             # attachment_filename and etags
-            assert len(captured) == 3
-            with catch_deprecation_warnings() as captured:
-                f = StringIO('Test')
-                rv = flask.send_file(f, mimetype='text/plain')
-                rv.direct_passthrough = False
-                assert rv.data == b'Test'
-                assert rv.mimetype == 'text/plain'
-                rv.close()
+            recwarn.pop()
+            recwarn.pop()
+            recwarn.pop()
+
+            f = StringIO('Test')
+            rv = flask.send_file(f, mimetype='text/plain')
+            rv.direct_passthrough = False
+            assert rv.data == b'Test'
+            assert rv.mimetype == 'text/plain'
+            rv.close()
+
             # etags
-            assert len(captured) == 1
+            recwarn.pop()
 
         app.use_x_sendfile = True
-        with catch_deprecation_warnings() as captured:
-            with app.test_request_context():
-                f = StringIO('Test')
-                rv = flask.send_file(f)
-                assert 'x-sendfile' not in rv.headers
-                rv.close()
-            # etags
-            assert len(captured) == 1
 
-    def test_attachment(self, catch_deprecation_warnings):
+        with app.test_request_context():
+            f = StringIO('Test')
+            rv = flask.send_file(f)
+            assert 'x-sendfile' not in rv.headers
+            rv.close()
+
+        # etags
+        recwarn.pop()
+
+    def test_attachment(self, recwarn):
         app = flask.Flask(__name__)
-        with catch_deprecation_warnings() as captured:
-            with app.test_request_context():
-                f = open(os.path.join(app.root_path, 'static/index.html'))
-                rv = flask.send_file(f, as_attachment=True)
-                value, options = parse_options_header(rv.headers['Content-Disposition'])
-                assert value == 'attachment'
-                rv.close()
-            # mimetypes + etag
-            assert len(captured) == 2
+        with app.test_request_context():
+            f = open(os.path.join(app.root_path, 'static/index.html'))
+            rv = flask.send_file(f, as_attachment=True)
+            value, options = parse_options_header(rv.headers['Content-Disposition'])
+            assert value == 'attachment'
+            rv.close()
+
+        # mimetypes + etag
+        assert len(recwarn.list) == 2
+        recwarn.clear()
 
         with app.test_request_context():
             assert options['filename'] == 'index.html'

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -353,13 +353,13 @@ class TestSendfile(object):
         app = flask.Flask(__name__)
 
         with app.test_request_context():
-            f = open(os.path.join(app.root_path, 'static/index.html'), mode='rb')
-            rv = flask.send_file(f)
-            rv.direct_passthrough = False
-            with app.open_resource('static/index.html') as f:
-                assert rv.data == f.read()
-            assert rv.mimetype == 'text/html'
-            rv.close()
+            with open(os.path.join(app.root_path, 'static/index.html'), mode='rb') as f:
+                rv = flask.send_file(f)
+                rv.direct_passthrough = False
+                with app.open_resource('static/index.html') as f:
+                    assert rv.data == f.read()
+                assert rv.mimetype == 'text/html'
+                rv.close()
 
         # mimetypes + etag
         recwarn.pop(DeprecationWarning)
@@ -368,13 +368,13 @@ class TestSendfile(object):
         app.use_x_sendfile = True
 
         with app.test_request_context():
-            f = open(os.path.join(app.root_path, 'static/index.html'))
-            rv = flask.send_file(f)
-            assert rv.mimetype == 'text/html'
-            assert 'x-sendfile' in rv.headers
-            assert rv.headers['x-sendfile'] == \
-                os.path.join(app.root_path, 'static/index.html')
-            rv.close()
+            with open(os.path.join(app.root_path, 'static/index.html')) as f:
+                rv = flask.send_file(f)
+                assert rv.mimetype == 'text/html'
+                assert 'x-sendfile' in rv.headers
+                assert rv.headers['x-sendfile'] == \
+                    os.path.join(app.root_path, 'static/index.html')
+                rv.close()
 
         # mimetypes + etag
         recwarn.pop(DeprecationWarning)
@@ -434,11 +434,12 @@ class TestSendfile(object):
     def test_attachment(self, recwarn):
         app = flask.Flask(__name__)
         with app.test_request_context():
-            f = open(os.path.join(app.root_path, 'static/index.html'))
-            rv = flask.send_file(f, as_attachment=True)
-            value, options = parse_options_header(rv.headers['Content-Disposition'])
-            assert value == 'attachment'
-            rv.close()
+            with open(os.path.join(app.root_path, 'static/index.html')) as f:
+                rv = flask.send_file(f, as_attachment=True)
+                value, options = \
+                    parse_options_header(rv.headers['Content-Disposition'])
+                assert value == 'attachment'
+                rv.close()
 
         # mimetypes + etag
         assert len(recwarn.list) == 2


### PR DESCRIPTION
...instead of custom fixture. Also assert that no warnings are left over
after the test.