### PR TITLE
Enhance code coverage for Blueprint.endpoint

### DIFF
--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -355,6 +355,25 @@ def test_route_decorator_custom_endpoint_with_dots():
     rv = c.get('/py/bar/123')
     assert rv.status_code == 404
 
+
+def test_endpoint_decorator():
+    from werkzeug.routing import Rule
+    app = flask.Flask(__name__)
+    app.url_map.add(Rule('/foo', endpoint='bar'))
+
+    bp = flask.Blueprint('bp', __name__)
+
+    @bp.endpoint('bar')
+    def foobar():
+        return flask.request.endpoint
+
+    app.register_blueprint(bp, url_prefix='/bp_prefix')
+
+    c = app.test_client()
+    assert c.get('/foo').data == b'bar'
+    assert c.get('/bp_prefix/bar').status_code == 404
+
+
 def test_template_filter():
     bp = flask.Blueprint('bp', __name__)
     @bp.app_template_filter()


### PR DESCRIPTION
Add basic test for the endpoint decorator for the Blueprint object.

Mentioned on the API [docs](http://flask.pocoo.org/docs/0.11/api/#flask.Blueprint.endpoint): 

> ...If the endpoint is prefixed with a . it will be registered to the current blueprint, otherwise it’s an application independent endpoint.

This commit only added test for the _without-prefixed-dot_ endpoint
