### PR TITLE
Updating url in errorhandling.rst to a valid link

### DIFF
--- a/docs/errorhandling.rst
+++ b/docs/errorhandling.rst
@@ -36,7 +36,7 @@ overwhelming if enough users are hitting the error and log files are
 typically never looked at. This is why we recommend using `Sentry
 <http://www.getsentry.com/>`_ for dealing with application errors.  It's
 available as an Open Source project `on GitHub
-<github.com/getsentry/sentry>`__ and is also available as a `hosted version
+<https://github.com/getsentry/sentry>`__ and is also available as a `hosted version
 <https://getsentry.com/signup/>`_ which you can try for free. Sentry
 aggregates duplicate errors, captures the full stack trace and local
 variables for debugging, and sends you mails based on new errors or


### PR DESCRIPTION
Was originally set to github.com/getsentry/sentry, which was a relative link to a page that doesn't exist. I prepended https:// to fix this problem.