### PR TITLE
Per blueprint jsoncoding #1710

### DIFF
--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -89,6 +89,13 @@ class Blueprint(_PackageBoundObject):
     warn_on_modifications = False
     _got_registered_once = False
 
+    #: Blueprint local JSON decoder class to use.
+    # Set to None to use the :class:`~flask.app.Flask.json_encoder`.
+    json_encoder = None
+    #: Blueprint local JSON decoder class to use.
+    # Set to None to use the :class:`~flask.app.Flask.json_decoder`.
+    json_decoder = None
+
     def __init__(self, name, import_name, static_folder=None,
                  static_url_path=None, template_folder=None,
                  url_prefix=None, subdomain=None, url_defaults=None,

--- a/flask/json.py
+++ b/flask/json.py
@@ -94,7 +94,8 @@ class JSONDecoder(_json.JSONDecoder):
 def _dump_arg_defaults(kwargs):
     """Inject default arguments for dump functions."""
     if current_app:
-        kwargs.setdefault('cls', current_app.json_encoder)
+        bp = current_app.blueprints.get(request.blueprint, None)
+        kwargs.setdefault('cls', bp.json_encoder if bp else current_app.json_encoder)
         if not current_app.config['JSON_AS_ASCII']:
             kwargs.setdefault('ensure_ascii', False)
         kwargs.setdefault('sort_keys', current_app.config['JSON_SORT_KEYS'])
@@ -106,7 +107,8 @@ def _dump_arg_defaults(kwargs):
 def _load_arg_defaults(kwargs):
     """Inject default arguments for load functions."""
     if current_app:
-        kwargs.setdefault('cls', current_app.json_decoder)
+        bp = current_app.blueprints.get(request.blueprint, None)
+        kwargs.setdefault('cls', bp.json_decoder if bp else current_app.json_decoder)
     else:
         kwargs.setdefault('cls', JSONDecoder)
 

--- a/flask/json.py
+++ b/flask/json.py
@@ -13,6 +13,7 @@ import uuid
 from datetime import date
 from .globals import current_app, request
 from ._compat import text_type, PY2
+from .ctx import has_request_context
 
 from werkzeug.http import http_date
 from jinja2 import Markup
@@ -94,8 +95,11 @@ class JSONDecoder(_json.JSONDecoder):
 def _dump_arg_defaults(kwargs):
     """Inject default arguments for dump functions."""
     if current_app:
-        bp = current_app.blueprints.get(request.blueprint, None)
-        kwargs.setdefault('cls', bp.json_encoder if bp else current_app.json_encoder)
+        bp = current_app.blueprints.get(request.blueprint,
+                                        None) if has_request_context() else None
+        kwargs.setdefault('cls',
+                          bp.json_encoder if bp and bp.json_encoder
+                          else current_app.json_encoder)
         if not current_app.config['JSON_AS_ASCII']:
             kwargs.setdefault('ensure_ascii', False)
         kwargs.setdefault('sort_keys', current_app.config['JSON_SORT_KEYS'])
@@ -107,8 +111,11 @@ def _dump_arg_defaults(kwargs):
 def _load_arg_defaults(kwargs):
     """Inject default arguments for load functions."""
     if current_app:
-        bp = current_app.blueprints.get(request.blueprint, None)
-        kwargs.setdefault('cls', bp.json_decoder if bp else current_app.json_decoder)
+        bp = current_app.blueprints.get(request.blueprint,
+                                        None) if has_request_context() else None
+        kwargs.setdefault('cls',
+                          bp.json_decoder if bp and bp.json_decoder
+                          else current_app.json_decoder)
     else:
         kwargs.setdefault('cls', JSONDecoder)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -90,12 +90,12 @@ class TestJSON(object):
         app = flask.Flask(__name__)
 
         app.config['JSON_AS_ASCII'] = True
-        with app.test_request_context():
+        with app.app_context():
             rv = flask.json.dumps(u'\N{SNOWMAN}')
             assert rv == '"\\u2603"'
 
         app.config['JSON_AS_ASCII'] = False
-        with app.test_request_context():
+        with app.app_context():
             rv = flask.json.dumps(u'\N{SNOWMAN}')
             assert rv == u'"\u2603"'
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -90,12 +90,12 @@ class TestJSON(object):
         app = flask.Flask(__name__)
 
         app.config['JSON_AS_ASCII'] = True
-        with app.app_context():
+        with app.test_request_context():
             rv = flask.json.dumps(u'\N{SNOWMAN}')
             assert rv == '"\\u2603"'
 
         app.config['JSON_AS_ASCII'] = False
-        with app.app_context():
+        with app.test_request_context():
             rv = flask.json.dumps(u'\N{SNOWMAN}')
             assert rv == u'"\u2603"'
 
@@ -230,6 +230,41 @@ class TestJSON(object):
             return flask.json.dumps(flask.request.get_json()['x'])
         c = app.test_client()
         rv = c.post('/', data=flask.json.dumps({
+            'x': {'_foo': 42}
+        }), content_type='application/json')
+        assert rv.data == b'"<42>"'
+
+    def test_blueprint_json_customization(self):
+        class X(object):
+            def __init__(self, val):
+                self.val = val
+        class MyEncoder(flask.json.JSONEncoder):
+            def default(self, o):
+                if isinstance(o, X):
+                    return '<%d>' % o.val
+                return flask.json.JSONEncoder.default(self, o)
+        class MyDecoder(flask.json.JSONDecoder):
+            def __init__(self, *args, **kwargs):
+                kwargs.setdefault('object_hook', self.object_hook)
+                flask.json.JSONDecoder.__init__(self, *args, **kwargs)
+            def object_hook(self, obj):
+                if len(obj) == 1 and '_foo' in obj:
+                    return X(obj['_foo'])
+                return obj
+
+        blue = flask.Blueprint('blue', __name__)
+        blue.json_encoder = MyEncoder
+        blue.json_decoder = MyDecoder
+        @blue.route('/bp', methods=['POST'])
+        def index():
+            return flask.json.dumps(flask.request.get_json()['x'])
+
+        app = flask.Flask(__name__)
+        app.testing = True
+        app.register_blueprint(blue)
+
+        c = app.test_client()
+        rv = c.post('/bp', data=flask.json.dumps({
             'x': {'_foo': 42}
         }), content_type='application/json')
         assert rv.data == b'"<42>"'


### PR DESCRIPTION
#1710

This patch adds support for custom `JSONEncoder`, `JSONDecoder` functionality for blueprints, modeled after `Flask.json_encoder`, `Flask.json_decoder` and has minimal amount of changes. 
Still no docs or corner case tests.
