### PR TITLE
fix pypy3-3.3 alpha usage

### DIFF
--- a/flask/_compat.py
+++ b/flask/_compat.py
@@ -75,7 +75,10 @@ if hasattr(sys, 'pypy_version_info'):
         def __enter__(self):
             return self
         def __exit__(self, *args):
-            sys.exc_clear()
+            try:
+                sys.exc_clear()
+            except:
+                pass
     try:
         try:
             with _Mgr():


### PR DESCRIPTION
fix pypy3-3.3 have error

  File "/opt/pypy3/site-packages/flask/__init__.py", line 21, in <module>
    from .app import Flask, Request, Response
  File "/opt/pypy3/site-packages/flask/app.py", line 24, in <module>
    from .helpers import _PackageBoundObject, url_for, get_flashed_messages, \
  File "/opt/pypy3/site-packages/flask/helpers.py", line 42, in <module>
    from ._compat import string_types, text_type
  File "/opt/pypy3/site-packages/flask/_compat.py", line 82, in <module>
    raise AssertionError()
  File "/opt/pypy3/site-packages/flask/_compat.py", line 78, in __exit__
    sys.exc_clear()
AttributeError: 'module' object has no attribute 'exc_clear'
