### PR TITLE
Enable template auto-reloading in app.run()

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -839,6 +839,8 @@ class Flask(_PackageBoundObject):
         options.setdefault('use_reloader', self.debug)
         options.setdefault('use_debugger', self.debug)
         options.setdefault('passthrough_errors', True)
+        if debug:
+            self.jinja_env.auto_reload = True
         try:
             run_simple(host, port, self, **options)
         finally:

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -349,11 +349,9 @@ def test_templates_auto_reload():
 
 def test_templates_auto_reload_debug_run(monkeypatch):
     # debug is None in config, config option is None, app.run(debug=True)
-    rv = {}
-
     # Mocks werkzeug.serving.run_simple method
     def run_simple_mock(*args, **kwargs):
-        rv['passthrough_errors'] = kwargs.get('passthrough_errors')
+        pass
 
     app = flask.Flask(__name__)
     monkeypatch.setattr(werkzeug.serving, 'run_simple', run_simple_mock)

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -14,6 +14,7 @@ import pytest
 import flask
 import logging
 from jinja2 import TemplateNotFound
+import werkzeug.serving
 
 
 def test_context_processing():
@@ -344,6 +345,22 @@ def test_templates_auto_reload():
     app = flask.Flask(__name__)
     app.config['DEBUG'] = True
     app.config['TEMPLATES_AUTO_RELOAD'] = True
+    assert app.jinja_env.auto_reload is True
+
+def test_templates_auto_reload_debug_run(monkeypatch):
+    # debug is None in config, config option is None, app.run(debug=True)
+    rv = {}
+
+    # Mocks werkzeug.serving.run_simple method
+    def run_simple_mock(*args, **kwargs):
+        rv['passthrough_errors'] = kwargs.get('passthrough_errors')
+
+    app = flask.Flask(__name__)
+    monkeypatch.setattr(werkzeug.serving, 'run_simple', run_simple_mock)
+
+    assert app.config['TEMPLATES_AUTO_RELOAD'] is None
+    assert app.jinja_env.auto_reload is False
+    app.run(debug=True)
     assert app.jinja_env.auto_reload is True
 
 def test_template_loader_debugging(test_apps):


### PR DESCRIPTION
When Flask app debugging is enabled (app.debug==True), and Jinja2
template auto-reloading is not explicitly disbaled, template
auto-reloading should be enabled.

If the app is instantiated, the jinja_env object is accessed (thereby
initialising the Jinja2 environment) and the server is then started with
app.run(debug=True), template auto-reloading is _not_ enabled.

This is because reading the jinja_env object causes the environment
initialisation function to set auto_reload to app.debug (which isn't yet
True). Calling app.run(debug=True) should correct this in order to
remain consistent with Flask code reloading (which is enabled within
app.run() if debug == True).
