### PR TITLE
re-add passthrough_errors to cli runner

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -423,7 +423,8 @@ def run_command(info, host, port, reload, debugger, eager_loading,
             print(' * Forcing debug mode %s' % (debug and 'on' or 'off'))
 
     run_simple(host, port, app, use_reloader=reload,
-               use_debugger=debugger, threaded=with_threads)
+               use_debugger=debugger, threaded=with_threads,
+               passthrough_exceptions=True)
 
 
 @click.command('shell', short_help='Runs a shell in the app context.')

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -424,7 +424,7 @@ def run_command(info, host, port, reload, debugger, eager_loading,
 
     run_simple(host, port, app, use_reloader=reload,
                use_debugger=debugger, threaded=with_threads,
-               passthrough_exceptions=True)
+               passthrough_errors=True)
 
 
 @click.command('shell', short_help='Runs a shell in the app context.')


### PR DESCRIPTION
This got dropped during the cli simplification.  Re: #1679