### PR TITLE
fix docs: name of url_value_preprocessor method

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -1804,7 +1804,7 @@ class Flask(_PackageBoundObject):
         if it was the return value from the view and further
         request handling is stopped.
 
-        This also triggers the :meth:`url_value_processor` functions before
+        This also triggers the :meth:`url_value_preprocessor` functions before
         the actual :meth:`before_request` functions are called.
         """
         bp = _request_ctx_stack.top.request.blueprint


### PR DESCRIPTION
This typo got introduced in 5da1fc22153032923b1560a34a0f346d6517a12d,
the original commit for the url_value_preprocessor decorator.