### PR TITLE
Add the ability to combine MethodViews

### DIFF
--- a/flask/views.py
+++ b/flask/views.py
@@ -102,12 +102,16 @@ class View(object):
         return view
 
 
+def get_methods(cls):
+    return getattr(cls, 'methods', []) or []
+
+
 class MethodViewType(type):
 
     def __new__(cls, name, bases, d):
         rv = type.__new__(cls, name, bases, d)
         if 'methods' not in d:
-            methods = set(rv.methods or [])
+            methods = set(m for b in bases for m in get_methods(b))
             for key in d:
                 if key in http_method_funcs:
                     methods.add(key.upper())


### PR DESCRIPTION
I just had this bug on my application, let me give you this example:

``` python
class SingleObjectMixin(object):
    def get_object(self):
        # implementation detail

class ShowView(SingleObjectMixin, MethodView):
    def get(self):
        return self.render_response(obj=self.get_object())

class DeleteView(SingleObjectMixin, MethodView):
    def delete(self):
        orm.delete(self.get_object())
        return self.redirect_to_list()

class ShowDeleteView(ShowView, DeleteView):
    pass
```

Because the metaclass for `MethodView` defines a `methods` property on each view, inheriting from two `MethodView` doesn't combine the supported methods.

Right now you have to do:

``` python
class ShowDeleteView(ShowView, DeleteView):
    methods = ['GET', 'DELETE']
```

which is explicit, but which I think is not how `MethodView` was intended to work.

Of course this fix, does allows you to inherit from two `MethodView` and override the supported methods.