### PR TITLE
adding in try around __import__ to catch invalid files/paths

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -86,7 +86,13 @@ def locate_app(app_id):
         module = app_id
         app_obj = None
 
-    __import__(module)
+    try:
+        __import__(module)
+    except ImportError:
+        raise NoAppException('The file/path provided (%s) does not appear to '
+                             'exist.  Please verify the path is correct.  If '
+                             'app is not on PYTHONPATH, ensure the extension '
+                             'is .py' % module)
     mod = sys.modules[module]
     if app_obj is None:
         app = find_best_app(mod)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,6 +80,8 @@ def test_locate_app(test_apps):
     assert locate_app("cliapp.app").name == "testapp"
     assert locate_app("cliapp.app:testapp").name == "testapp"
     assert locate_app("cliapp.multiapp:app1").name == "app1"
+    pytest.raises(NoAppException, locate_app, "notanpp.py")
+    pytest.raises(NoAppException, locate_app, "cliapp/app")
     pytest.raises(RuntimeError, locate_app, "cliapp.app:notanapp")
 
 


### PR DESCRIPTION
I'll start this off by saying this may be a naive approach to what appears to be a common thread between a few recent issues (#1926, #1902, #1829). I'm attempting to solve the issue of mistyped or improperly defined app paths reaching the __import__ call for the flask app server. Given the way `cli.py` is currently structured, I can't find a bulletproof way to ensure only correct paths/module names reach the import. 

If that's the case, I believe the best response is to simply catch the error and return something more descriptive than `ImportError: Import by filename is not supported.` for debugging purposes.