### PR TITLE
close <li> tag in lines (16,18)

### DIFF
--- a/examples/flaskr/flaskr/templates/show_entries.html
+++ b/examples/flaskr/flaskr/templates/show_entries.html
@@ -13,9 +13,9 @@
   {% endif %}
   <ul class="entries">
   {% for entry in entries %}
-    <li><h2>{{ entry.title }}</h2>{{ entry.text|safe }}
+    <li><h2>{{ entry.title }}</h2>{{ entry.text|safe }}</li>
   {% else %}
-    <li><em>Unbelievable.  No entries here so far</em>
+    <li><em>Unbelievable.  No entries here so far</em></li>
   {% endfor %}
   </ul>
 {% endblock %}


### PR DESCRIPTION
![screenshot from 2016-07-09 21-51-02](https://cloud.githubusercontent.com/assets/13125847/16709636/47f25eb0-461f-11e6-9fa5-885cba578f6b.png)
i noticed that <li> tag haven't closed in lines 15,18 
which is bad practice as if i put "some thing : h1> some text /h1>" in the text-area  all the other articles become h1> so big and color blue
