### PR TITLE
Document the rest arguments of abort function

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -316,11 +316,12 @@ Useful Functions and Classes
 
 .. autofunction:: url_for
 
-.. function:: abort(code)
+.. function:: abort(code, \*args, \*\*kwargs)
 
    Raises an :exc:`~werkzeug.exceptions.HTTPException` for the given
-   status code.  For example to abort request handling with a page not
-   found exception, you would call ``abort(404)``.
+   status code.  The rest of the arguments are forwarded to the
+   exception constructor.  For example to abort request handling
+   with a page not found exception, you would call ``abort(404)``.
 
    :param code: the HTTP error code.
 


### PR DESCRIPTION
Updated abort function in api.rst, to document the ability to use
args and kwargs for HTTPException. Forwarding the rest of the arguments to the exception was not documented, even when it is possible by abort (Aborter).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pallets/flask/1960)
<!-- Reviewable:end -->
