### PR TITLE
Improve the layout example

### DIFF
--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -191,13 +191,14 @@ To further reiterate this: if you have a blueprint named ``admin`` and you
 want to render a template called :file:`index.html` which is specific to this
 blueprint, the best idea is to lay out your templates like this::
 
-    yourpackage/
-        blueprints/
-            admin/
-                templates/
-                    admin/
-                        index.html
-                __init__.py
+    /yourpackage
+        /blueprints
+            /__init__.py
+            /admin
+                /__init__.py
+                /templates
+                    /admin
+                        /index.html
 
 And then when you want to render the template, use :file:`admin/index.html` as
 the name to look up the template by.  If you encounter problems loading


### PR DESCRIPTION
#There should be two `__init__.py` files in the layout example, one under the folder "blueprints" and the other one under folder "admin".

like this:

```
yourpackage/
    blueprints/
        admin/
            templates/
                admin/
                    index.html
                __init__.py
            __init__.py
```

However, I think this might confuse people about which folder each `__init__.py` is in.

So, I think put the slash at front can make the example easier to understand.