### PR TITLE
Remove unused Redbaron dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ commands =
 deps=
     pytest
     greenlet
-    redbaron
 
     lowest: Werkzeug==0.7
     lowest: Jinja2==2.4


### PR DESCRIPTION
Dependency was added for the ext migration script in #1342 but now that we've moved the script to its own [repo](https://github.com/pallets/flask-ext-migrate), Redbaron is no longer a dependency for the main repo.

See also https://github.com/pallets/flask/pull/1627