### PR TITLE
Update for python3

### DIFF
--- a/docs/tutorial/dbinit.rst
+++ b/docs/tutorial/dbinit.rst
@@ -35,7 +35,7 @@ just below the `connect_db` function in :file:`flaskr.py`::
     def initdb_command():
         """Initializes the database."""
         init_db()
-        print 'Initialized the database.'
+        print('Initialized the database.')
 
 The ``app.cli.command()`` decorator registers a new command with the
 :command:`flask` script.  When the command executes, Flask will automatically


### PR DESCRIPTION
Just updated print 'Initialized the database.' with print('Initialized the database.') to be python3 compliant.