### PR TITLE
Set __qualname__ on class-based view function

### DIFF
--- a/flask/views.py
+++ b/flask/views.py
@@ -84,7 +84,7 @@ class View(object):
             return self.dispatch_request(*args, **kwargs)
 
         if cls.decorators:
-            view.__name__ = name
+            view.__qualname__ = view.__name__ = name
             view.__module__ = cls.__module__
             for decorator in cls.decorators:
                 view = decorator(view)
@@ -95,7 +95,7 @@ class View(object):
         # the view class so you can actually replace it with something else
         # for testing purposes and debugging.
         view.view_class = cls
-        view.__name__ = name
+        view.__qualname__ = view.__name__ = name
         view.__doc__ = cls.__doc__
         view.__module__ = cls.__module__
         view.methods = cls.methods

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -160,3 +160,16 @@ def test_endpoint_override():
 
     # But these tests should still pass. We just log a warning.
     common_test(app)
+
+def test_view_name():
+    app = flask.Flask(__name__)
+
+    class Index(flask.views.View):
+        methods = ['GET', 'POST']
+        def dispatch_request(self):
+            return flask.request.method
+
+    view_func = Index.as_view('index')
+
+    assert view_func.__name__ == 'index'
+    assert view_func.__qualname__ == 'index'


### PR DESCRIPTION
On Python 3, New Relic uses `__qualname__` to trace transactions. Without setting `__qualname__` in `as_view()`, I don't get meaningful accounting of transactions in New Relic on my class-based views.

`__qualname__` is meaningless in Python 2, but I think it's just a harmless no-op in this context.