### PR TITLE
Disable logger propagation by default

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@ Version 0.12
   See pull request ``#1849``.
 - Make ``flask.safe_join`` able to join multiple paths like ``os.path.join``
   (pull request ``#1730``).
+- Disable logger propagation by default for the app logger.
 
 Version 0.11.2
 --------------

--- a/flask/logging.py
+++ b/flask/logging.py
@@ -87,4 +87,8 @@ def create_logger(app):
     logger.__class__ = DebugLogger
     logger.addHandler(debug_handler)
     logger.addHandler(prod_handler)
+
+    # Disable propagation by default
+    logger.propagate = False
+
     return logger


### PR DESCRIPTION
Main motivation for this is that `logging.basicConfig()` otherwise logs
all things twice by default since the logger propagates upwards to the
default handler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pallets/flask/1993)
<!-- Reviewable:end -->
