### PR TITLE
Better workflow for flaskr and other basic apps

### DIFF
--- a/examples/flaskr/README
+++ b/examples/flaskr/README
@@ -19,7 +19,7 @@
 
       3. Instruct flask to use the right application
 
-         export FLASK_APP=flaskr.flaskr
+         export FLASK_APP=flaskr
 
       4. initialize the database with this command:
 

--- a/examples/flaskr/flaskr/__init__.py
+++ b/examples/flaskr/flaskr/__init__.py
@@ -1,0 +1,1 @@
+from flaskr import app


### PR DESCRIPTION
- adds `from flaskr import app` to top-level in flaskr module
- effect is that `export FLASK_APP=flaskr` works over the more verbose
  `export FLASK_APP=flaskr.flask`
- see the readme for how to run
- all tests are passing with `py.test` or `python setup.py test` (in
  venv)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pallets/flask/2000)
<!-- Reviewable:end -->
