### PR TITLE
Correcting Custom Test Client class docs

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -879,7 +879,7 @@ class Flask(_PackageBoundObject):
 
             class CustomClient(FlaskClient):
                 def __init__(self, *args, **kwargs):
-                    self._authorization = kwargs.pop("authorization")
+                    self._authentication = kwargs.pop("authentication")
                     super(CustomClient,self).__init__( *args, **kwargs)
 
             app.test_client_class = CustomClient

--- a/flask/app.py
+++ b/flask/app.py
@@ -878,9 +878,9 @@ class Flask(_PackageBoundObject):
             from flask.testing import FlaskClient
 
             class CustomClient(FlaskClient):
-                def __init__(self, authentication=None, *args, **kwargs):
-                    FlaskClient.__init__(*args, **kwargs)
-                    self._authentication = authentication
+                def __init__(self, *args, **kwargs):
+                    self._authorization = kwargs.pop("authorization")
+                    super(CustomClient,self).__init__( *args, **kwargs)
 
             app.test_client_class = CustomClient
             client = app.test_client(authentication='Basic ....')


### PR DESCRIPTION
As it was written, that init could not work as Flask was still trying to call it with no authorization parameter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pallets/flask/2004)
<!-- Reviewable:end -->
