### PR TITLE
changing ip address to string for localhost

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -75,8 +75,7 @@ class Flask(_PackageBoundObject):
     The name of the package is used to resolve resources from inside the
     package or the folder the module is contained in depending on if the
     package parameter resolves to an actual python package (a folder with
-    an :file:`__init__.py` file inside) or a standard module
-    (just a ``.py`` file).
+    an :file:`__init__.py` file inside) or a standard module (just a ``.py`` file).
 
     For more information about resource loading, see :func:`open_resource`.
 
@@ -98,7 +97,7 @@ class Flask(_PackageBoundObject):
         using a package, it's usually recommended to hardcode the name of
         your package there.
 
-        e.g. if your application is defined in :file:`yourapplication/app.py`
+        For example if your application is defined in :file:`yourapplication/app.py`
         you should create it with one of the two versions below::
 
             app = Flask('yourapplication')
@@ -183,7 +182,6 @@ class Flask(_PackageBoundObject):
     # Backwards compatibility support
     def _get_request_globals_class(self):
         return self.app_ctx_globals_class
-
     def _set_request_globals_class(self, value):
         from warnings import warn
         warn(DeprecationWarning('request_globals_class attribute is now '
@@ -275,7 +273,7 @@ class Flask(_PackageBoundObject):
     #: .. versionadded:: 0.4
     logger_name = ConfigAttribute('LOGGER_NAME')
 
-    #: The JSON encoder class to use. Defaults to :class:`~flask.json.JSONEncoder`.
+    #: The JSON encoder class to use.  Defaults to :class:`~flask.json.JSONEncoder`.
     #:
     #: .. versionadded:: 0.10
     json_encoder = json.JSONEncoder
@@ -816,7 +814,7 @@ class Flask(_PackageBoundObject):
 
         :param host: the hostname to listen on. Set this to ``'0.0.0.0'`` to
                      have the server available externally as well. Defaults to
-                     ``'127.0.0.1'``.
+                     ``'localhost'``.
         :param port: the port of the webserver. Defaults to ``5000`` or the
                      port defined in the ``SERVER_NAME`` config variable if
                      present.

--- a/flask/app.py
+++ b/flask/app.py
@@ -75,7 +75,8 @@ class Flask(_PackageBoundObject):
     The name of the package is used to resolve resources from inside the
     package or the folder the module is contained in depending on if the
     package parameter resolves to an actual python package (a folder with
-    an :file:`__init__.py` file inside) or a standard module (just a ``.py`` file).
+    an :file:`__init__.py` file inside) or a standard module
+    (just a ``.py`` file).
 
     For more information about resource loading, see :func:`open_resource`.
 
@@ -97,7 +98,7 @@ class Flask(_PackageBoundObject):
         using a package, it's usually recommended to hardcode the name of
         your package there.
 
-        For example if your application is defined in :file:`yourapplication/app.py`
+        e.g. if your application is defined in :file:`yourapplication/app.py`
         you should create it with one of the two versions below::
 
             app = Flask('yourapplication')
@@ -182,6 +183,7 @@ class Flask(_PackageBoundObject):
     # Backwards compatibility support
     def _get_request_globals_class(self):
         return self.app_ctx_globals_class
+
     def _set_request_globals_class(self, value):
         from warnings import warn
         warn(DeprecationWarning('request_globals_class attribute is now '
@@ -273,7 +275,7 @@ class Flask(_PackageBoundObject):
     #: .. versionadded:: 0.4
     logger_name = ConfigAttribute('LOGGER_NAME')
 
-    #: The JSON encoder class to use.  Defaults to :class:`~flask.json.JSONEncoder`.
+    #: The JSON encoder class to use. Defaults to :class:`~flask.json.JSONEncoder`.
     #:
     #: .. versionadded:: 0.10
     json_encoder = json.JSONEncoder
@@ -827,7 +829,7 @@ class Flask(_PackageBoundObject):
         """
         from werkzeug.serving import run_simple
         if host is None:
-            host = '127.0.0.1'
+            host = 'localhost'
         if port is None:
             server_name = self.config['SERVER_NAME']
             if server_name and ':' in server_name:


### PR DESCRIPTION
For https://github.com/pallets/flask/issues/2007

which now is more inline with docs in the home page of http://flask.pocoo.org/

Before the change:
```
python hello_flask.py
 * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
127.0.0.1 - - [07/Sep/2016 11:08:55] "GET / HTTP/1.1" 200 -
127.0.0.1 - - [07/Sep/2016 11:08:55] "GET /favicon.ico HTTP/1.1" 404 -
127.0.0.1 - - [07/Sep/2016 11:09:14] "GET / HTTP/1.1" 200 -
127.0.0.1 - - [07/Sep/2016 11:09:14] "GET /favicon.ico HTTP/1.1" 404 -
```

After the change:
```
python hello_flask.py
 * Running on http://localhost:5000/ (Press CTRL+C to quit)
127.0.0.1 - - [07/Sep/2016 11:09:42] "GET / HTTP/1.1" 200 -
127.0.0.1 - - [07/Sep/2016 11:09:59] "GET / HTTP/1.1" 200 -
```

As you can see its not "getting" the favicon. Is that an issue?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pallets/flask/2010)
<!-- Reviewable:end -->
