### PR TITLE
fixed deprecated syntax in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,5 +4,5 @@ release = egg_info -RDb ''
 [wheel]
 universal = 1
 
-[pytest]
+[tool:pytest]
 norecursedirs = .* *.egg *.egg-info env* artwork docs examples


### PR DESCRIPTION
I was inspired to fix this by the following warning in pytest:
"[pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pallets/flask/2015)
<!-- Reviewable:end -->
