### PR TITLE
Add scheme to url_build error handler parameters

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,7 +19,10 @@ Major release, unreleased
   time the constructor adds the static route, and enables the static route to
   be properly associated with the required host. (``#1559``)
 - ``send_file`` supports Unicode in ``attachment_filename``. (`#2223`_)
+- Pass ``_scheme`` argument from ``url_for`` to ``handle_build_error``.
+  (`#2017`_)
 
+.. _#2017: https://github.com/pallets/flask/pull/2017
 .. _#2223: https://github.com/pallets/flask/pull/2223
 
 Version 0.12.1

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -331,6 +331,7 @@ def url_for(endpoint, **values):
         values['_external'] = external
         values['_anchor'] = anchor
         values['_method'] = method
+        values['_scheme'] = scheme
         return appctx.app.handle_url_build_error(error, endpoint, values)
 
     if anchor is not None:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1131,6 +1131,23 @@ def test_build_error_handler_reraise():
         pytest.raises(BuildError, flask.url_for, 'not.existing')
 
 
+def test_url_for_passes_special_values_to_build_error_handler():
+    app = flask.Flask(__name__)
+
+    @app.url_build_error_handlers.append
+    def handler(error, endpoint, values):
+        assert values == {
+            '_external': False,
+            '_anchor': None,
+            '_method': None,
+            '_scheme': None,
+        }
+        return 'handled'
+
+    with app.test_request_context():
+        flask.url_for('/')
+
+
 def test_custom_converters():
     from werkzeug.routing import BaseConverter
 


### PR DESCRIPTION
`_scheme` is passed to `url_for` but is not forwarded to error handlers if an exception is raised