### PR TITLE
Do not cause errors for unknown files for sendfile

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -54,8 +54,8 @@ misleading ``name`` attribute. Silently swallowing errors in such cases was not
 a satisfying solution.
 
 Additionally the default of falling back to ``application/octet-stream`` has
-been removed. If Flask can't guess one or the user didn't provide one, the
-function fails.
+been restricted. If Flask can't guess one or the user didn't provide one, the
+function fails if no filename information was provided.
 
 .. _upgrading-to-011:
 

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -517,11 +517,6 @@ def send_file(filename_or_fp, mimetype=None, as_attachment=False,
                 or 'application/octet-stream'
 
         if mimetype is None:
-            if attachment_filename is not None:
-                raise ValueError(
-                    'Unable to infer MIME-type from filename {0!r}, please '
-                    'pass one explicitly.'.format(attachment_filename)
-                )
             raise ValueError(
                 'Unable to infer MIME-type because no filename is available. '
                 'Please set either `attachment_filename`, pass a filepath to '

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -513,7 +513,8 @@ def send_file(filename_or_fp, mimetype=None, as_attachment=False,
 
     if mimetype is None:
         if attachment_filename is not None:
-            mimetype = mimetypes.guess_type(attachment_filename)[0]
+            mimetype = mimetypes.guess_type(attachment_filename)[0] \
+                or 'application/octet-stream'
 
         if mimetype is None:
             if attachment_filename is not None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -402,9 +402,7 @@ class TestSendfile(object):
             assert 'no filename is available' in str(excinfo)
 
         with app.test_request_context():
-            with pytest.raises(ValueError) as excinfo:
-                flask.send_file(StringIO("LOL"), attachment_filename='filename')
-            assert "Unable to infer MIME-type from filename 'filename'" in str(excinfo)
+            flask.send_file(StringIO("LOL"), attachment_filename='filename')
 
     def test_send_file_object(self):
         app = flask.Flask(__name__)


### PR DESCRIPTION
Unknown files must not raise errors when send with send-file if the
sending happens by filename.  This is particularly important for
send from directory which can send up loads of unknown files.

This regressed at one point in the last two weeks.  It came up
with woff2 files sent from static folders which are unknown in
the default mimetype database.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pallets/flask/2019)
<!-- Reviewable:end -->
