### PR TITLE
Add license_file to setup.cfg metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,5 +4,8 @@ release = egg_info -RDb ''
 [wheel]
 universal = 1
 
+[metadata]
+license_file = LICENSE
+
 [tool:pytest]
 norecursedirs = .* *.egg *.egg-info env* artwork docs examples


### PR DESCRIPTION
Without this, the LICENSE file is never included in the built wheels: this makes it harder for users to comply with the license.
With this addition a file LICENSE.txt will be created in the `xxx.dist-info` directory with the content of the `license_file` file, e.g. the top level LICENSE.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pallets/flask/2024)

<!-- Reviewable:end -->
