### PR TITLE
Updated mod_wsgi.rst to point to new mod_wsgi repo

### DIFF
--- a/docs/deploying/mod_wsgi.rst
+++ b/docs/deploying/mod_wsgi.rst
@@ -130,12 +130,12 @@ to httpd 2.4 syntax
     Require all granted
 
 
-For more information consult the `mod_wsgi wiki`_.
+For more information consult the `mod_wsgi documentation`_.
 
-.. _mod_wsgi: http://code.google.com/p/modwsgi/
-.. _installation instructions: http://code.google.com/p/modwsgi/wiki/QuickInstallationGuide
+.. _mod_wsgi: https://github.com/GrahamDumpleton/mod_wsgi
+.. _installation instructions: http://modwsgi.readthedocs.io/en/develop/installation.html
 .. _virtual python: https://pypi.python.org/pypi/virtualenv
-.. _mod_wsgi wiki: http://code.google.com/p/modwsgi/w/list
+.. _mod_wsgi documentation: http://modwsgi.readthedocs.io/en/develop/index.html
 
 Troubleshooting
 ---------------


### PR DESCRIPTION
The http://flask.pocoo.org/docs/0.11/deploying/mod_wsgi/ site currently uses the old Google Code page for `mod_wsgi`. This PR updates the urls for `mod_wsgi` to point to the new [GitHub repo](https://github.com/GrahamDumpleton/mod_wsgi) and [documentation](http://modwsgi.readthedocs.io/en/develop/index.html).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pallets/flask/2038)
<!-- Reviewable:end -->
