### PR TITLE
Fix unbound error

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -503,7 +503,7 @@ class Flask(_PackageBoundObject):
         #:        def to_python(self, value):
         #:            return value.split(',')
         #:        def to_url(self, values):
-        #:            return ','.join(BaseConverter.to_url(value)
+        #:            return ','.join(super(ListConverter, self).to_url(value)
         #:                            for value in values)
         #:
         #:    app = Flask(__name__)


### PR DESCRIPTION
I create a converter, this copied from docs:

```
import urllib

from flask import Flask, url_for
from werkzeug.routing import BaseConverter


class ListConverter(BaseConverter):
    def to_python(self, value):
        return value.split(',')

    def to_url(self, values):
        return ','.join(BaseConverter.to_url(value)
                        for value in values)


app = Flask(__name__)
app.url_map.converters['list'] = ListConverter


@app.route('/<list:lst>/')
def test(lst):
    return str(lst)


@app.route('/')
def index():
    return url_for('test', lst='a,b')


if __name__ == '__main__':
    app.run(host='0.0.0.0', port=4000, debug=True)
```

I visit `http://localhost:4000/a,b`, it works. but can not visit `http://localhost:4000/`:

```
TypeError: unbound method to_url() must be called with BaseConverter instance as first argument (got str instance instead)
```

Python 3 also raise error:

```
TypeError: to_url() missing 1 required positional argument: 'value'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pallets/flask/2039)
<!-- Reviewable:end -->
