### PR TITLE
Remove `-a/--app` from Quickstart documentation

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -102,10 +102,10 @@ docs to see the alternative method for running a server.
 Invalid Import Name
 ```````````````````
 
-The ``-a`` argument to :command:`flask` is the name of the module to
-import.  In case that module is incorrectly named you will get an import
-error upon start (or if debug is enabled when you navigate to the
-application).  It will tell you what it tried to import and why it failed.
+The ``FLASK_APP`` environment variable is the name of the module to import at 
+:command:`flask run`. In case that module is incorrectly named you will get an 
+import error upon start (or if debug is enabled when you navigate to the 
+application). It will tell you what it tried to import and why it failed.
 
 The most common reason is a typo or because you did not actually create an
 ``app`` object.

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -469,7 +469,7 @@ def shell_command():
 cli = FlaskGroup(help="""\
 This shell command acts as general utility script for Flask applications.
 
-It loads the application configured (either through the FLASK_APP environment
+It loads the application configured (through the FLASK_APP environment
 variable) and then provides commands either provided by the application or
 Flask itself.
 


### PR DESCRIPTION
As mentioned in #2009, simplifying the CLI saw the removal of the `-a/--app` flag. Therefore, the only way to specify the module to import is by setting `FLASK_APP`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pallets/flask/2046)
<!-- Reviewable:end -->
