### PR TITLE
Default environ

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,8 +19,8 @@ Version 0.12
   well as error handlers.
 - Disable logger propagation by default for the app logger.
 - Add support for range requests in ``send_file``.
-- Default environment can be set in ``app.test_client`` instead of per
-  ``app.test_client.get`` request
+- ``app.test_client`` includes preset default environment, which can now be
+  directly set, instead of per ``client.get``.
 
 Version 0.11.2
 --------------

--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,8 @@ Version 0.12
   well as error handlers.
 - Disable logger propagation by default for the app logger.
 - Add support for range requests in ``send_file``.
+- Default environment can be set in ``app.test_client`` instead of per
+  ``app.test_client.get`` request
 
 Version 0.11.2
 --------------

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -114,9 +114,7 @@ class FlaskClient(Client):
         as_tuple = kwargs.pop('as_tuple', False)
         buffered = kwargs.pop('buffered', False)
         follow_redirects = kwargs.pop('follow_redirects', False)
-        builder = make_test_environ_builder(self.application,
-                                            environ_base=environ_base,
-                                            *args, **kwargs)
+        builder = make_test_environ_builder(self.application, *args, **kwargs)
 
         return Client.open(self, builder,
                            as_tuple=as_tuple,

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -48,6 +48,11 @@ class FlaskClient(Client):
 
     preserve_context = False
 
+    def __init__(self, *args, **kwargs):
+        environ_base = kwargs.pop("environ_base", None)
+        super(FlaskClient, self).__init__(*args, **kwargs)
+        self.environ_base = environ_base
+
     @contextmanager
     def session_transaction(self, *args, **kwargs):
         """When used in combination with a ``with`` statement this opens a

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -110,7 +110,10 @@ class FlaskClient(Client):
         as_tuple = kwargs.pop('as_tuple', False)
         buffered = kwargs.pop('buffered', False)
         follow_redirects = kwargs.pop('follow_redirects', False)
-        builder = make_test_environ_builder(self.application, *args, **kwargs)
+        environ_base = kwargs.get(environ_base, None) or self.environ_base
+        builder = make_test_environ_builder(self.application,
+                                            environ_base=environ_base,
+                                            *args, **kwargs)
 
         return Client.open(self, builder,
                            as_tuple=as_tuple,

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -110,7 +110,7 @@ class FlaskClient(Client):
         as_tuple = kwargs.pop('as_tuple', False)
         buffered = kwargs.pop('buffered', False)
         follow_redirects = kwargs.pop('follow_redirects', False)
-        environ_base = kwargs.get(environ_base, None) or self.environ_base
+        environ_base = kwargs.get("environ_base", None) or self.environ_base
         builder = make_test_environ_builder(self.application,
                                             environ_base=environ_base,
                                             *args, **kwargs)

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -10,6 +10,7 @@
     :license: BSD, see LICENSE for more details.
 """
 
+import werkzeug
 from contextlib import contextmanager
 from werkzeug.test import Client, EnvironBuilder
 from flask import _request_ctx_stack
@@ -49,9 +50,11 @@ class FlaskClient(Client):
     preserve_context = False
 
     def __init__(self, *args, **kwargs):
-        environ_base = kwargs.pop("environ_base", None)
         super(FlaskClient, self).__init__(*args, **kwargs)
-        self.environ_base = environ_base
+        self.environ_base = {
+            "REMOTE_ADDR": "127.0.0.1",
+            "HTTP_USER_AGENT": "werkzeug/" + werkzeug.__version__
+        }
 
     @contextmanager
     def session_transaction(self, *args, **kwargs):

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -44,8 +44,10 @@ class FlaskClient(Client):
     information about how to use this class refer to
     :class:`werkzeug.test.Client`.
 
-    Default environment values can be set after instantiation of the
-    `app.test_client()` object in `client.environ_base`.
+    .. versionchanged:: 0.12
+       `app.test_client()` includes preset default environment, which can be
+       set after instantiation of the `app.test_client()` object in
+       `client.environ_base`.
 
     Basic usage is outlined in the :ref:`testing` chapter.
     """

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -44,21 +44,8 @@ class FlaskClient(Client):
     information about how to use this class refer to
     :class:`werkzeug.test.Client`.
 
-    Uses default environment values
-
-    ::
-    
-        {
-            "REMOTE_ADDR": "127.0.0.1",
-            "HTTP_USER_AGENT": "werkzeug/" + werkzeug.__version__
-        }
-
-    that can be set after instantiation of the `FlaskClient` object
-
-    ::
-
-        client = FlaskClient()
-        client.environ_base = ...
+    Default environment values can be set after instantiation of the
+    `app.test_client()` object in `client.environ_base`.
 
     Basic usage is outlined in the :ref:`testing` chapter.
     """

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -44,6 +44,22 @@ class FlaskClient(Client):
     information about how to use this class refer to
     :class:`werkzeug.test.Client`.
 
+    Uses default environment values
+
+    ::
+    
+        {
+            "REMOTE_ADDR": "127.0.0.1",
+            "HTTP_USER_AGENT": "werkzeug/" + werkzeug.__version__
+        }
+
+    that can be set after instantiation of the `FlaskClient` object
+
+    ::
+
+        client = FlaskClient()
+        client.environ_base = ...
+
     Basic usage is outlined in the :ref:`testing` chapter.
     """
 

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -109,11 +109,11 @@ class FlaskClient(Client):
     def open(self, *args, **kwargs):
         kwargs.setdefault('environ_overrides', {}) \
             ['flask._preserve_context'] = self.preserve_context
+        kwargs.setdefault('environ_base', self.environ_base)
 
         as_tuple = kwargs.pop('as_tuple', False)
         buffered = kwargs.pop('buffered', False)
         follow_redirects = kwargs.pop('follow_redirects', False)
-        environ_base = kwargs.get("environ_base", None) or self.environ_base
         builder = make_test_environ_builder(self.application,
                                             environ_base=environ_base,
                                             *args, **kwargs)


### PR DESCRIPTION
Addresses #1467. Now you can pass `environ_base` dictionary into `app.test_client`. This also allows overriding per `open` call (or `make_test_environ_builder` call).

Perhaps a better solution would be to edit werkzeug directly and add it to that init (which, in turn, would allow us to remove the subclass init). I don't believe that would cause any unintended behavior, but I'm open to further conversation on it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pallets/flask/2047)
<!-- Reviewable:end -->
