### PR TITLE
Fix safe_join test behavior on Windows

### DIFF
--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -13,6 +13,7 @@ import os
 import sys
 import pkgutil
 import posixpath
+import ntpath
 import mimetypes
 from time import time
 from zlib import adler32
@@ -621,7 +622,10 @@ def safe_join(directory, *pathnames):
     """
     for filename in pathnames:
         if filename != '':
-            filename = posixpath.normpath(filename)
+            if sys.platform == 'win32':
+                filename = ntpath.normpath(filename)
+            else:
+                filename = posixpath.normpath(filename)
         for sep in _os_alt_seps:
             if sep in filename:
                 raise NotFound()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -903,9 +903,6 @@ class TestSafeJoin(object):
             ('/a', 'b/../b/../../c', ),
             ('/a', 'b', 'c/../..'),
             ('/a', 'b/../../c', ),
-
-            # base directories which are no longer considered safe in the windows env
-            ('..\\', 'a\\b\\c'),
         )
 
         for args in failing:


### PR DESCRIPTION
this is for resolution of https://github.com/pallets/flask/issues/2033

Base directory test is not extended to windows as not sure if they pose a security risk or not or what can the resolution be. Currentl base directory tests raise NotFound exception
