### PR TITLE
Process responses generated by exceptions

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -1994,6 +1994,7 @@ class Flask(_PackageBoundObject):
             except Exception as e:
                 error = e
                 response = self.handle_exception(e)
+                response = self.finalize_request(response, from_error_handler=True)
             return response(environ, start_response)
         finally:
             if self.should_ignore_error(error):


### PR DESCRIPTION
When handling exceptions, some post processing on requests are not being called, such as `after_request` and `request_finished`.
This can be quite a problem in production environments when things such as logging and consistant headers are required.

For example, let's take this simple application:

```python
from flask import Flask, request

from mysite.business_logic import do_work
from mysite.logging import log_req_res

app = Flask(__name__)

@app.route('/')
def index():
    return do_work(request)


@app.errorhandler(500)
def error_handler(exception):
    # Render a nice error message here
    pass


@app.after_request
def add_response_headers(response):
    response.headers['P3P'] = 'CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"'


@app.after_request
def log_request_response(response)
    from flask import request

    log_req_res(request, response)
    return response
```

One day, a change is made within `mysite.business_logic:do_work` that causes it to raise an exception to some users. Because of the current way things are working, the req/res will not be logged as well as not be applied the P3P header.
Currently there is no way to intercept ALL requests and responses for these use cases.

A simple solution, proposd in this PR is to process exception responses similarly to successful responses. This could be a breaking change to some library consumers so I'm putting it up as an RFC.

[tests to come soon]