### PR TITLE
Fixes import statement in flaskr

### DIFF
--- a/docs/tutorial/packaging.rst
+++ b/docs/tutorial/packaging.rst
@@ -55,7 +55,7 @@ into this file, :file:`flaskr/__init__.py`:
 
 .. sourcecode:: python
 
-    from flaskr import app
+    from .flaskr import app
 
 This import statement brings the application instance into the top-level 
 of the application package.  When it is time to run the application, the 

--- a/examples/flaskr/flaskr/__init__.py
+++ b/examples/flaskr/flaskr/__init__.py
@@ -1,1 +1,1 @@
-from flaskr import app
+from .flaskr import app

--- a/examples/flaskr/setup.cfg
+++ b/examples/flaskr/setup.cfg
@@ -1,2 +1,2 @@
-[aliases]
+[tool:pytest]
 test=pytest


### PR DESCRIPTION
- `from flaskr.flaskr import app` in flaskr/__init__.py
  causes an import error with Python 2
- The relative import now used works for py2 and py3

Ref: https://github.com/pallets/flask/issues/2058 

The issue was that the absolute import `from flaskr.flaskr import app` works in python 3 but not python 2. While there is probably a simple answer why, for now, this relative import works on both.