### PR TITLE
Added a link to instructions for PythonAnywhere

### DIFF
--- a/docs/deploying/index.rst
+++ b/docs/deploying/index.rst
@@ -23,6 +23,7 @@ Hosted options
 - `Deploying Flask on Google App Engine <https://github.com/kamalgill/flask-appengine-template>`_
 - `Sharing your Localhost Server with Localtunnel <http://flask.pocoo.org/snippets/89/>`_
 - `Deploying on Azure (IIS) <https://azure.microsoft.com/documentation/articles/web-sites-python-configure/>`_
+- `Deploying on PythonAnywhere <https://help.pythonanywhere.com/pages/Flask/>`_
 
 Self-hosted options
 -------------------


### PR DESCRIPTION
The linked page is the normal help docs for people who know at least roughly how WSGI works.  We also have a tutorial at http://blog.pythonanywhere.com/121/ that explains (for beginners) how to build a web app using Flask and MySQL (plus git) but that's probably not the best fit for this page.