### PR TITLE
Error handler support for generic HttpException

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -1454,7 +1454,7 @@ class Flask(_PackageBoundObject):
             return handler
 
         # fall back to app handlers
-        handler_map = self.error_handler_spec.get(request.blueprint, {}).get(None)
+        handler_map = self.error_handler_spec.get(None, {}).get(code)
         if handler_map is None:
             self.error_handler_spec.get(None, {}).get(None)
         return find_handler(handler_map)

--- a/flask/app.py
+++ b/flask/app.py
@@ -1444,14 +1444,20 @@ class Flask(_PackageBoundObject):
                     return handler
 
         # try blueprint handlers
-        handler = find_handler(self.error_handler_spec
-                               .get(request.blueprint, {})
-                               .get(code))
+        handler_map = self.error_handler_spec.get(request.blueprint, {}).get(code)
+        if handler_map is None:
+            self.error_handler_spec.get(request.blueprint, {}).get(None)
+
+        handler = find_handler(handler_map)
+
         if handler is not None:
             return handler
 
         # fall back to app handlers
-        return find_handler(self.error_handler_spec[None].get(code))
+        handler_map = self.error_handler_spec.get(request.blueprint, {}).get(None)
+        if handler_map is None:
+            self.error_handler_spec.get(None, {}).get(None)
+        return find_handler(handler_map)
 
     def handle_http_exception(self, e):
         """Handles an HTTP exception.  By default this will invoke the


### PR DESCRIPTION
Flask supports setting HttpException as error handler class:

    app.register_error_handler(HTTPException, lambda error: jsonify(error=error.code, text=str(error)))

This fills `error_handler_spec` with something like this for any blueprint `{None: {None: lambda_function}}`

However, when finding the error handler it checks the error code which is e.g. 404 and ignores None, the error handler for any error, previously set by register_error_handler. It doesn't find 404, doesn't check for None in the dict and falls back to the default error handler which shouldn't happen.