### PR TITLE
Ignore cache on request.get_json(cache=False) call

### DIFF
--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -137,7 +137,8 @@ class Request(RequestBase):
                       on the request.
         """
         rv = getattr(self, '_cached_json', _missing)
-        if rv is not _missing:
+        # We return cached JSON only when the cache is enabled.
+        if cache and rv is not _missing:
             return rv
 
         if not (force or self.is_json):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -35,6 +35,14 @@ def has_encoding(name):
 
 class TestJSON(object):
 
+    def test_ignore_cached_json(self):
+        app = flask.Flask(__name__)
+        with app.test_request_context('/', method='POST', data='malformed',
+                                      content_type='application/json'):
+            assert flask.request.get_json(silent=True, cache=True) is None
+            with pytest.raises(BadRequest):
+                flask.request.get_json(silent=False, cache=False)
+
     def test_post_empty_json_adds_exception_to_response_content_in_debug(self):
         app = flask.Flask(__name__)
         app.config['DEBUG'] = True


### PR DESCRIPTION
Removes usage of `_cached_json` property when `get_json` is called with
disabled cache argument. (closes #2087)