### PR TITLE
Add routes command to flask cli

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,11 +32,14 @@ Major release, unreleased
 - ``Flask.make_response`` raises ``TypeError`` instead of ``ValueError`` for
   bad response types. The error messages have been improved to describe why the
   type is invalid. (`#2256`_)
+- Add ``flask routes`` command to show a table of all routes registered on the
+  application. (`#2092`_)
 
 .. _#1489: https://github.com/pallets/flask/pull/1489
 .. _#1898: https://github.com/pallets/flask/pull/1898
 .. _#1936: https://github.com/pallets/flask/pull/1936
 .. _#2017: https://github.com/pallets/flask/pull/2017
+.. _#2092: https://github.com/pallets/flask/pull/2092
 .. _#2223: https://github.com/pallets/flask/pull/2223
 .. _#2254: https://github.com/pallets/flask/pull/2254
 .. _#2256: https://github.com/pallets/flask/pull/2256

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -479,7 +479,7 @@ def routes_command():
     sorted_rules = sorted(app.url_map.iter_rules(), key=lambda rule: rule.endpoint)
 
     for rule in sorted_rules:
-        methods = ', '.join(rule.methods.difference(ignored_methods))
+        methods = ', '.join(rule.methods - ignored_methods)
         routes.append([rule.endpoint, methods, rule.rule])
 
     cols = zip(*routes)

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -479,7 +479,8 @@ def routes_command():
     sorted_rules = sorted(app.url_map.iter_rules(), key=lambda rule: rule.endpoint)
 
     for rule in sorted_rules:
-        methods = ', '.join(rule.methods - ignored_methods)
+        sorted_methods = sorted(rule.methods - ignored_methods)
+        methods = ', '.join(sorted_methods)
         routes.append([rule.endpoint, methods, rule.rule])
 
     cols = zip(*routes)

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -13,6 +13,7 @@ import os
 import sys
 from threading import Lock, Thread
 from functools import update_wrapper
+from operator import attrgetter
 
 import click
 
@@ -476,7 +477,7 @@ def routes_command():
     app = _app_ctx_stack.top.app
     routes = []
     ignored_methods = set(['HEAD', 'OPTIONS'])
-    sorted_rules = sorted(app.url_map.iter_rules(), key=lambda rule: rule.endpoint)
+    sorted_rules = sorted(app.url_map.iter_rules(), key=attrgetter('endpoint'))
 
     for rule in sorted_rules:
         sorted_methods = sorted(rule.methods - ignored_methods)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -224,7 +224,7 @@ def test_routes():
     output = [line.strip() for line in result.output.split('\n')]
 
     assert result.exit_code == 0
-    assert output[0] == 'routes_blueprint.posts_routes  PUT, DELETE, GET /posts/<post_id>'
+    assert output[0] == 'routes_blueprint.posts_routes  DELETE, GET, PUT /posts/<post_id>'
     assert output[1] == 'routes_blueprint.user_id_route DELETE, GET      /users/<user_id>'
     assert output[2] == 'routes_blueprint.users_route   GET              /users'
     assert output[3] == 'static                         GET              /static/<path:filename>'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,7 @@ import sys
 import click
 import pytest
 from click.testing import CliRunner
-from flask import Flask, current_app
+from flask import Flask, current_app, Blueprint
 
 from flask.cli import AppGroup, FlaskGroup, NoAppException, ScriptInfo, \
     find_best_app, locate_app, with_appcontext, prepare_exec_for_file, \
@@ -190,3 +190,41 @@ def test_flaskgroup():
     result = runner.invoke(cli, ['test'])
     assert result.exit_code == 0
     assert result.output == 'flaskgroup\n'
+
+
+def test_routes():
+    """Test Routes"""
+    def create_app(info):
+        app = Flask('routes_app')
+        blueprint = Blueprint('routes_blueprint', __name__)
+
+        @blueprint.route('/users')
+        def users_route():
+            pass
+
+        @blueprint.route('/users/<user_id>', methods=['GET', 'DELETE'])
+        def user_id_route():
+            pass
+
+        @blueprint.route('/posts/<post_id>', methods=['GET', 'DELETE', 'PUT'])
+        def posts_routes():
+            pass
+
+        app.register_blueprint(blueprint)
+
+        return app
+
+    @click.group(cls=FlaskGroup, create_app=create_app)
+    def cli(**params):
+        pass
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ['routes'])
+
+    output = [line.strip() for line in result.output.split('\n')]
+
+    assert result.exit_code == 0
+    assert output[0] == 'routes_blueprint.posts_routes  PUT, DELETE, GET /posts/<post_id>'
+    assert output[1] == 'routes_blueprint.user_id_route DELETE, GET      /users/<user_id>'
+    assert output[2] == 'routes_blueprint.users_route   GET              /users'
+    assert output[3] == 'static                         GET              /static/<path:filename>'


### PR DESCRIPTION
Running `flask routes` will list all registered routes for a given app, sorted by endpoint

Inspired by [`mix phoenix.routes`](http://www.phoenixframework.org/docs/routing), this will display a list of all registered routes in an application. This is basically #1446, but I have updated it and made it "dumber". 

NB: I know that the other PR is old and there doesn't seem to be much enthusiasm for it, but I do think this is useful to have to get a high level overview of application routes, especially if they are being generated programmatically. 

Example output:

```sh
$ flask routes
api.me                    GET              /api/users/me/
api.users                 GET              /api/users/
                          POST             /api/users/
                          PUT, DELETE, GET /api/users/<pk>
api.users_schema          GET              /api/users/schema/
auth_blueprint.authorized GET              /login/authorized
auth_blueprint.do_login   GET              /do-login
auth_blueprint.login      GET              /login
auth_blueprint.logout     GET              /logout
auth_blueprint.lr_test    GET              /lr
static                    GET              /static/<path:filename>
```