### PR TITLE
Added missing testing config

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -98,8 +98,10 @@ test method to our class, like this::
 
         def setUp(self):
             self.db_fd, flaskr.app.config['DATABASE'] = tempfile.mkstemp()
+            flaskr.app.config['TESTING'] = True
             self.app = flaskr.app.test_client()
-            flaskr.init_db()
+            with flaskr.app.app_context():
+                flaskr.init_db()
 
         def tearDown(self):
             os.close(self.db_fd)

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -41,7 +41,7 @@ In order to test the application, we add a second module
 
         def setUp(self):
             self.db_fd, flaskr.app.config['DATABASE'] = tempfile.mkstemp()
-            flaskr.app.config['TESTING'] = True
+            flaskr.app.testing = True
             self.app = flaskr.app.test_client()
             with flaskr.app.app_context():
                 flaskr.init_db()
@@ -98,7 +98,7 @@ test method to our class, like this::
 
         def setUp(self):
             self.db_fd, flaskr.app.config['DATABASE'] = tempfile.mkstemp()
-            flaskr.app.config['TESTING'] = True
+            flaskr.app.testing = True
             self.app = flaskr.app.test_client()
             with flaskr.app.app_context():
                 flaskr.init_db()
@@ -210,7 +210,7 @@ temporarily.  With this you can access the :class:`~flask.request`,
 functions.  Here is a full example that demonstrates this approach::
 
     import flask
-    
+
     app = flask.Flask(__name__)
 
     with app.test_request_context('/?name=Peter'):


### PR DESCRIPTION
This PR contains an update to docs/testing.rst:

The testing documentation was missing `TESTING` config from one of the examples.

fixes #1302 
