### PR TITLE
Fix config.from_pyfile on Python 3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,9 @@ Version 0.12.1
 
 Bugfix release, unreleased
 
+- Fix encoding behavior of ``app.config.from_pyfile`` for Python 3. Fix
+  ``#2118``.
+
 Version 0.12
 ------------
 

--- a/flask/config.py
+++ b/flask/config.py
@@ -126,7 +126,7 @@ class Config(dict):
         d = types.ModuleType('config')
         d.__file__ = filename
         try:
-            with open(filename) as config_file:
+            with open(filename, mode='rb') as config_file:
                 exec(compile(config_file.read(), filename, 'exec'), d.__dict__)
         except IOError as e:
             if silent and e.errno in (errno.ENOENT, errno.EISDIR):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,11 +7,13 @@
     :license: BSD, see LICENSE for more details.
 """
 
-import pytest
 
-import os
 from datetime import timedelta
+import os
+import textwrap
+
 import flask
+import pytest
 
 
 # config keys used for the TestConfig
@@ -187,3 +189,15 @@ def test_get_namespace():
     assert 2 == len(bar_options)
     assert 'bar stuff 1' == bar_options['BAR_STUFF_1']
     assert 'bar stuff 2' == bar_options['BAR_STUFF_2']
+
+
+@pytest.mark.parametrize('encoding', ['utf-8', 'iso-8859-15', 'latin-1'])
+def test_from_pyfile_weird_encoding(tmpdir, encoding):
+    f = tmpdir.join('my_config.py')
+    f.write_binary(textwrap.dedent(u'''
+    # -*- coding: {} -*-
+    TEST_VALUE = "föö"
+    '''.format(encoding)).encode(encoding))
+    app = flask.Flask(__name__)
+    app.config.from_pyfile(str(f))
+    assert app.config['TEST_VALUE'] == 'föö'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ import os
 import textwrap
 
 import flask
+from flask._compat import PY2
 import pytest
 
 
@@ -200,4 +201,7 @@ def test_from_pyfile_weird_encoding(tmpdir, encoding):
     '''.format(encoding)).encode(encoding))
     app = flask.Flask(__name__)
     app.config.from_pyfile(str(f))
-    assert app.config['TEST_VALUE'] == 'föö'
+    value = app.config['TEST_VALUE']
+    if PY2:
+        value = value.decode(encoding)
+    assert value == u'föö'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -195,7 +195,7 @@ def test_get_namespace():
 def test_from_pyfile_weird_encoding(tmpdir, encoding):
     f = tmpdir.join('my_config.py')
     f.write_binary(textwrap.dedent(u'''
-    # -*- coding: {} -*-
+    # -*- coding: {0} -*-
     TEST_VALUE = "föö"
     '''.format(encoding)).encode(encoding))
     app = flask.Flask(__name__)


### PR DESCRIPTION
Fix #2118