### PR TITLE
prevent NoAppException when ImportError occurs within imported module

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,8 @@ Version 0.12.1
 
 Bugfix release, unreleased
 
+- Prevent `flask run` from showing a NoAppException when an ImportError occurs
+  within the imported application module.
 - Fix encoding behavior of ``app.config.from_pyfile`` for Python 3. Fix
   ``#2118``.
 

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -89,10 +89,16 @@ def locate_app(app_id):
     try:
         __import__(module)
     except ImportError:
-        raise NoAppException('The file/path provided (%s) does not appear to '
-                             'exist.  Please verify the path is correct.  If '
-                             'app is not on PYTHONPATH, ensure the extension '
-                             'is .py' % module)
+        # Reraise the ImportError if it occurred within the imported module.
+        # Determine this by checking whether the trace has a depth > 1.
+        if sys.exc_info()[-1].tb_next:
+            raise
+        else:
+            raise NoAppException('The file/path provided (%s) does not appear'
+                                 ' to exist.  Please verify the path is '
+                                 'correct.  If app is not on PYTHONPATH, '
+                                 'ensure the extension is .py' % module)
+
     mod = sys.modules[module]
     if app_obj is None:
         app = find_best_app(mod)

--- a/tests/test_apps/cliapp/importerrorapp.py
+++ b/tests/test_apps/cliapp/importerrorapp.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import, print_function
+
+from flask import Flask
+
+raise ImportError()
+
+testapp = Flask('testapp')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,6 +83,7 @@ def test_locate_app(test_apps):
     pytest.raises(NoAppException, locate_app, "notanpp.py")
     pytest.raises(NoAppException, locate_app, "cliapp/app")
     pytest.raises(RuntimeError, locate_app, "cliapp.app:notanapp")
+    pytest.raises(ImportError, locate_app, "cliapp.importerrorapp")
 
 
 def test_find_default_import_path(test_apps, monkeypatch, tmpdir):


### PR DESCRIPTION
Currently this will cause `flask run` to show a `NoAppException` error:
```
from flask import Flask

raise ImportError()

testapp = Flask('testapp')
``` 

The expected behavior is to see the `ImportError` when you visit the page instead of the  `NoAppException` error.

This happens because the code does not differentiate between an `ImportError` when `flask run` tries to import the module and an `ImportError` from the module after it is imported.

The fix came from here: http://stackoverflow.com/a/24262408