### PR TITLE
Fix fastcgi lighttpd example documentation.

### DIFF
--- a/docs/deploying/fastcgi.rst
+++ b/docs/deploying/fastcgi.rst
@@ -144,7 +144,7 @@ A basic FastCGI configuration for lighttpd looks like that::
     )
 
     alias.url = (
-        "/static/" => "/path/to/your/static"
+        "/static/" => "/path/to/your/static/"
     )
 
     url.rewrite-once = (


### PR DESCRIPTION
Add a trailing slash to the dummy static path alias in the fastcgi lighttpd setup
documentation. Omitting a trailing slash leads to unintended behavior.

Without the trailing slash, the result of the lighttpd alias looks like this(in debug mode):

    2017-01-02 02:25:11: (response.c.624) -- file not found
    2017-01-02 02:25:11: (response.c.625) Path : /var/www/myapp/staticfoo.txt

Instead of `/var/www/myapp/static/foo.txt`