### PR TITLE
Allow default Errorhandler for HTTPException

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -1451,7 +1451,16 @@ class Flask(_PackageBoundObject):
             return handler
 
         # fall back to app handlers
-        return find_handler(self.error_handler_spec[None].get(code))
+        handler = find_handler(self.error_handler_spec[None].get(code))
+        if handler is not None:
+            return handler
+
+        try:
+            handler = find_handler(self.error_handler_spec[None][None])
+        except KeyError:
+            handler = None
+
+        return handler
 
     def handle_http_exception(self, e):
         """Handles an HTTP exception.  By default this will invoke the

--- a/tests/test_user_error_handler.py
+++ b/tests/test_user_error_handler.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from werkzeug.exceptions import Forbidden, InternalServerError
+from werkzeug.exceptions import Forbidden, InternalServerError, HTTPException, NotFound
 import flask
 
 
@@ -30,6 +30,29 @@ def test_error_handler_no_match():
 
     assert c.get('/custom').data == b'custom'
     assert c.get('/keyerror').data == b'KeyError'
+
+
+def test_default_error_handler():
+    app = flask.Flask(__name__)
+
+    @app.errorhandler(HTTPException)
+    def catchall_errorhandler(e):
+        assert isinstance(e, HTTPException)
+        assert isinstance(e, NotFound)
+        return 'default'
+
+    @app.errorhandler(Forbidden)
+    def catchall_errorhandler(e):
+        assert isinstance(e, Forbidden)
+        return 'forbidden'
+
+    @app.route('/forbidden')
+    def forbidden():
+        raise Forbidden()
+
+    c = app.test_client()
+    assert c.get('/undefined').data == b'default'
+    assert c.get('/forbidden').data == b'forbidden'
 
 
 def test_error_handler_subclass():


### PR DESCRIPTION
Allow an default errorhandler for all HTTPException.

This will come handy when building a REST API where you want all Errors return JSON instead of the default behaviour.

PR https://github.com/pallets/flask/pull/2082 solves the same problem, but it didn't work in my environment. Tests are included.