### PR TITLE
Added python3.6 support for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 env:
   - REQUIREMENTS=lowest
@@ -32,7 +33,10 @@ matrix:
       env: REQUIREMENTS=lowest
     - python: "3.5"
       env: REQUIREMENTS=lowest-simplejson
-
+    - python: "3.6"
+      env: REQUIREMENTS=lowest
+    - python: "3.6"
+      env: REQUIREMENTS=lowest-simplejson
 
 install:
     - pip install tox

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -333,7 +333,7 @@ def test_session_expiration():
     client = app.test_client()
     rv = client.get('/')
     assert 'set-cookie' in rv.headers
-    match = re.search(r'\bexpires=([^;]+)(?i)', rv.headers['set-cookie'])
+    match = re.search(r'(?i)\bexpires=([^;]+)', rv.headers['set-cookie'])
     expires = parse_date(match.group())
     expected = datetime.utcnow() + app.permanent_session_lifetime
     assert expires.year == expected.year

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -179,8 +179,8 @@ def test_flaskext_broken_package_no_module_caching(flaskext_broken):
 def test_no_error_swallowing(flaskext_broken):
     with pytest.raises(ImportError) as excinfo:
         import flask.ext.broken
-
-    assert excinfo.type is ImportError
+    # python3.6 raises a subclass of ImportError: 'ModuleNotFoundError'
+    assert issubclass(excinfo.type, ImportError)
     if PY2:
         message = 'No module named missing_module'
     else:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py26,py27,pypy}-{lowest,release,devel}{,-simplejson}, {py33,py34,py35}-{release,devel}{,-simplejson}
+envlist = {py26,py27,pypy}-{lowest,release,devel}{,-simplejson}, {py33,py34,py35,py36}-{release,devel}{,-simplejson}
 
 
 


### PR DESCRIPTION

python 3.6 has deprecated the use of flags not at the start of regular expression,
plans for 3.7 is to rasie an exception: [http://bugs.python.org/issue22493](http://bugs.python.org/issue22493)

new on 3.6  [ModuleNotFoundError](https://docs.python.org/3/library/exceptions.html#ModuleNotFoundError)