### PR TITLE
Update docs that request is an object, not a class

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -66,7 +66,7 @@ Incoming Request Data
       ============= ======================================================
 
 
-.. class:: request
+.. attribute:: request
 
    To access incoming request data, you can use the global `request`
    object.  Flask parses incoming request data for you and gives you


### PR DESCRIPTION
Cleanup sphinx formatting to show that `request` is an object, not a class. The actual class name is `Request`.

Based on discussion [here](https://github.com/pallets/flask/pull/2151#issuecomment-272699147).