### PR TITLE
Add support for custom console-scripts

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,8 @@ Major release, unreleased
 - Make `app.run()` into a noop if a Flask application is run from the
   development server on the command line.  This avoids some behavior that
   was confusing to debug for newcomers.
+- Add support for custom cli scripts which automatically create an app without
+  the need for an environment variable.  ``#2163``
 
 Version 0.12.1
 --------------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -147,6 +147,46 @@ pick it up::
 
 From this point onwards :command:`flask` will find your application.
 
+Custom Script Names
+-------------------
+
+Especially in bigger applications it may be preferable to provide a CLI script
+named like the app. While :ref:`custom-scripts` already allow doing this, it is
+somewhat complicated and when using the dev server it is also easy to end up
+with a script that does not survive reloading code which has a syntax error or
+any other exception raised while importing/creating the app.
+
+However, there is a much easier way to define a custom script using nothing but
+:file:`setup.py` features. Additionally, this way lets you tell flask how to
+load the app for this script instead of having to set ``FLASK_APP``::
+
+    setup(
+        name='Fancy App',
+        ...,
+        entry_points={
+            'console_scripts': [
+                'fancyapp = flask.cli:main'
+            ],
+            'flask.cli_apps': [
+                'fancyapp = fancyapp.app:make_app'
+            ]
+        }
+    )
+
+The ``console_scripts`` entry point creates the :command:`fancyapp` command in
+the environment's bin dir and points to Flask's cli endpoint. While this could
+also be achieved with a symlink, using the entry point ensures the script is
+created when the package is installed.
+
+In ``flask.cli_apps`` you define the location of your app or app factory.  The
+name of the entry must match the name in ``console_scripts``. The import path
+can reference anything inside your package, after the ``:`` the app or app
+factory is specified. In case of a factory (anything that is not a
+:class:`Flask` instance is considered a factory), it is called with no
+arguments.
+
+
+
 .. _custom-scripts:
 
 Custom Scripts

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -501,10 +501,14 @@ Example usage:
 })
 
 
+custom_cli = FlaskGroup()
+
+
 def main(as_module=False):
     this_module = __package__ + '.cli'
     args = sys.argv[1:]
     obj = None
+    cli_instance = cli
 
     if as_module:
         if sys.version_info >= (2, 7):
@@ -522,8 +526,9 @@ def main(as_module=False):
         if cli_name != 'flask':
             loader = _lookup_app_loader(cli_name)
             obj = ScriptInfo(create_app=lambda si: loader())
+            cli_instance = custom_cli
 
-    cli.main(args=args, prog_name=name, obj=obj)
+    cli_instance.main(args=args, prog_name=name, obj=obj)
 
 
 def _lookup_app_loader(cli_name):


### PR DESCRIPTION
For an installed app there is currently no clean way to provide a custom (e.g. `testapp`) console script instead of using the `flask` script (which needs FLASK_APP to be set) - using any entry point that resides within the app's package would stop the reloader from surviving import-time errors in the app's package.

With this PR it's easy to define a custom console script and also specify its app or app factory, making `FLASK_APP` unnecessary when using that script.

The application's setup.py would simply have to add this to the `setup()` call:

```python
    entry_points={
        'console_scripts': [
            'testapp = flask.cli:main'
        ],
        'flask.cli_apps': [
            'testapp = testapp.app:make_app'
        ]
    }
```

---

### TODO

- [x] Override default FlaskGroup help for custom commands (do not mention `FLASK_APP`)
- [x] Changelog
- [x] Docs
- [ ] Tests?