### PR TITLE
py.test => pytest

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -38,7 +38,7 @@ Running the testsuite
 You probably want to set up a `virtualenv
 <https://virtualenv.readthedocs.io/en/latest/index.html>`_.
 
-The minimal requirement for running the testsuite is ``py.test``.  You can
+The minimal requirement for running the testsuite is ``pytest``.  You can
 install it with::
 
     pip install pytest
@@ -54,9 +54,9 @@ Install Flask as an editable package using the current source::
 
 Then you can run the testsuite with::
 
-    py.test
+    pytest
 
-With only py.test installed, a large part of the testsuite will get skipped
+With only pytest installed, a large part of the testsuite will get skipped
 though.  Whether this is relevant depends on which part of Flask you're working
 on.  Travis is set up to run the full testsuite when you submit your pull
 request anyways.
@@ -79,11 +79,11 @@ plugin.  This assumes you have already run the testsuite (see previous section):
 
 After this has been installed, you can output a report to the command line using this command::
 
-    py.test --cov=flask tests/
+    pytest --cov=flask tests/
 
 Generate a HTML report can be done using this command::
 
-    py.test --cov-report html --cov=flask tests/
+    pytest --cov-report html --cov=flask tests/
 
 Full docs on ``coverage.py`` are here: https://coverage.readthedocs.io
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -54,7 +54,7 @@ Install Flask as an editable package using the current source::
 
 Then you can run the testsuite with::
 
-    py.test
+    py.test tests/
 
 With only py.test installed, a large part of the testsuite will get skipped
 though.  Whether this is relevant depends on which part of Flask you're working

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -54,7 +54,7 @@ Install Flask as an editable package using the current source::
 
 Then you can run the testsuite with::
 
-    py.test tests/
+    py.test
 
 With only py.test installed, a large part of the testsuite will get skipped
 though.  Whether this is relevant depends on which part of Flask you're working

--- a/README
+++ b/README
@@ -33,9 +33,9 @@
 
       Good that you're asking.  The tests are in the
       tests/ folder.  To run the tests use the
-      `py.test` testing tool:
+      `pytest` testing tool:
 
-        $ py.test
+        $ pytest
 
       Details on contributing can be found in CONTRIBUTING.rst
 

--- a/README
+++ b/README
@@ -35,7 +35,7 @@
       tests/ folder.  To run the tests use the
       `py.test` testing tool:
 
-        $ py.test
+        $ py.test tests/
 
       Details on contributing can be found in CONTRIBUTING.rst
 

--- a/README
+++ b/README
@@ -35,7 +35,7 @@
       tests/ folder.  To run the tests use the
       `py.test` testing tool:
 
-        $ py.test tests/
+        $ py.test
 
       Details on contributing can be found in CONTRIBUTING.rst
 

--- a/docs/tutorial/testing.rst
+++ b/docs/tutorial/testing.rst
@@ -46,7 +46,7 @@ At this point you can run the tests. Here ``pytest`` will be used.
 Run and watch the tests pass, within the top-level :file:`flaskr/` 
 directory as::
 
-    py.test
+    pytest
 
 Testing + setuptools
 --------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@ universal = 1
 license_file = LICENSE
 
 [tool:pytest]
-norecursedirs = .* *.egg *.egg-info env* artwork docs
+norecursedirs = .* *.egg *.egg-info env* artwork docs examples

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands =
     pip install -e examples/flaskr
     pip install -e examples/minitwit
     pip install -e examples/patterns/largerapp
-    py.test --cov=flask --cov-report html []
+    pytest --cov=flask --cov-report html []
 deps=
     pytest
     pytest-cov


### PR DESCRIPTION
Really a minor thing, only experienced by a newcomer.
When following the README or CONTRIBUTE  docs, the first test run results in lots of failures.
This is because a simple `py.test` also discovers the tests in examples/

(My plan is to contribute more, this is just to get started ;)
