### PR TITLE
Fix non-working  setup.cfg in tutorial docs with working copy from sa…

### DIFF
--- a/docs/tutorial/testing.rst
+++ b/docs/tutorial/testing.rst
@@ -77,7 +77,7 @@ update the :file:`setup.py` file to contain::
 Now create :file:`setup.cfg` in the project root (alongside
 :file:`setup.py`)::
 
-    [aliases]
+    [tool:pytest]
     test=pytest
 
 Now you can run::


### PR DESCRIPTION
I worked through the tutorial today, but ended up with code that wouldn't run.
The provided example code in the repo does run.  
This pull matches the code in the docs to the example code