### PR TITLE
Don't rely on X-Requested-With for pretty print json response

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,9 @@ Major release, unreleased
 - Make `app.run()` into a noop if a Flask application is run from the
   development server on the command line.  This avoids some behavior that
   was confusing to debug for newcomers.
+- Change default configuration `JSONIFY_PRETTYPRINT_REGULAR=False`. jsonify()
+  method returns compressed response by default, and pretty response in
+  debug mode.
 
 Version 0.12.1
 --------------

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -178,7 +178,7 @@ The following configuration values are used internally by Flask:
                                   This is not recommended but might give
                                   you a performance improvement on the
                                   cost of cacheability.
-``JSONIFY_PRETTYPRINT_REGULAR``   If this is set to ``True`` or Flask app
+``JSONIFY_PRETTYPRINT_REGULAR``   If this is set to ``True`` or the Flask app
                                   is running in debug mode, jsonify responses
                                   will be pretty printed.
 ``JSONIFY_MIMETYPE``              MIME type used for jsonify responses.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -178,11 +178,9 @@ The following configuration values are used internally by Flask:
                                   This is not recommended but might give
                                   you a performance improvement on the
                                   cost of cacheability.
-``JSONIFY_PRETTYPRINT_REGULAR``   If this is set to ``True`` (the default)
-                                  jsonify responses will be pretty printed
-                                  if they are not requested by an
-                                  XMLHttpRequest object (controlled by
-                                  the ``X-Requested-With`` header)
+``JSONIFY_PRETTYPRINT_REGULAR``   If this is set to ``True`` or Flask app
+                                  is running in debug mode, jsonify responses
+                                  will be pretty printed.
 ``JSONIFY_MIMETYPE``              MIME type used for jsonify responses.
 ``TEMPLATES_AUTO_RELOAD``         Whether to check for modifications of
                                   the template source and reload it

--- a/flask/app.py
+++ b/flask/app.py
@@ -314,7 +314,7 @@ class Flask(_PackageBoundObject):
         'PREFERRED_URL_SCHEME':                 'http',
         'JSON_AS_ASCII':                        True,
         'JSON_SORT_KEYS':                       True,
-        'JSONIFY_PRETTYPRINT_REGULAR':          True,
+        'JSONIFY_PRETTYPRINT_REGULAR':          False,
         'JSONIFY_MIMETYPE':                     'application/json',
         'TEMPLATES_AUTO_RELOAD':                None,
     })

--- a/flask/json.py
+++ b/flask/json.py
@@ -248,7 +248,7 @@ def jsonify(*args, **kwargs):
     indent = None
     separators = (',', ':')
 
-    if current_app.config['JSONIFY_PRETTYPRINT_REGULAR'] and not request.is_xhr:
+    if current_app.config['JSONIFY_PRETTYPRINT_REGULAR'] or current_app.debug:
         indent = 2
         separators = (', ', ': ')
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -995,7 +995,7 @@ def test_make_response_with_response_instance():
         rv = flask.make_response(
             flask.jsonify({'msg': 'W00t'}), 400)
         assert rv.status_code == 400
-        assert rv.data == b'{\n  "msg": "W00t"\n}\n'
+        assert rv.data == b'{"msg":"W00t"}\n'
         assert rv.mimetype == 'application/json'
 
         rv = flask.make_response(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -289,6 +289,8 @@ class TestJSON(object):
     def test_json_key_sorting(self):
         app = flask.Flask(__name__)
         app.testing = True
+        app.debug = True
+
         assert app.config['JSON_SORT_KEYS'] == True
         d = dict.fromkeys(range(20), 'foo')
 


### PR DESCRIPTION
`X-Requested-With` is not reliable nowadays. We shouldn't rely on it any more.

Related issue: https://github.com/pallets/werkzeug/issues/1077