### PR TITLE
Python 3 syntax error in Quickstart docs

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -264,10 +264,10 @@ some examples::
     ... def profile(username): pass
     ...
     >>> with app.test_request_context():
-    ...  print url_for('index')
-    ...  print url_for('login')
-    ...  print url_for('login', next='/')
-    ...  print url_for('profile', username='John Doe')
+    ...  print(url_for('index'))
+    ...  print(url_for('login'))
+    ...  print(url_for('login', next='/'))
+    ...  print(url_for('profile', username='John Doe'))
     ...
     /
     /login


### PR DESCRIPTION
I was going through Quickstart examples and I found syntax error in URL Building section.
Examples uses old Python 2 syntax for printing `url_for` results and crashes if run on Python 3.