### PR TITLE
Edit debug mode attention for new version Werkzeug

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -142,9 +142,9 @@ There are more parameters that are explained in the :ref:`server` docs.
 .. admonition:: Attention
 
    Even though the interactive debugger does not work in forking environments
-   (which makes it nearly impossible to use on production servers), it still
-   allows the execution of arbitrary code. This makes it a major security risk
-   and therefore it **must never be used on production machines**.
+   (which makes it nearly impossible to use on production servers), and it is 
+   additionally protected (not 100%) by a PIN (Werkzeug>=0.11), it still has a 
+   huge security risk. **Never enable the debugger in production.**
 
 Screenshot of the debugger in action:
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -143,8 +143,8 @@ There are more parameters that are explained in the :ref:`server` docs.
 
    Even though the interactive debugger does not work in forking environments
    (which makes it nearly impossible to use on production servers), and it is 
-   additionally protected (not 100%) by a PIN (Werkzeug>=0.11), it still has a 
-   huge security risk. **Never enable the debugger in production.**
+   additionally protected by a PIN, it still has a huge security risk. Therefore,
+   **never enable the debugger in production.**
 
 Screenshot of the debugger in action:
 


### PR DESCRIPTION
Starting from Werkzeug 0.11, the debugger was protected by a PIN.