### PR TITLE
Print a stacktrace on CLI error (closes #2208)

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -11,6 +11,7 @@
 
 import os
 import sys
+import traceback
 from threading import Lock, Thread
 from functools import update_wrapper
 
@@ -368,6 +369,9 @@ class FlaskGroup(AppGroup):
             # want the help page to break if the app does not exist.
             # If someone attempts to use the command we try to create
             # the app again and this will give us the error.
+            # However, we will not do so silently because that would confuse
+            # users.
+            traceback.print_exc()
             pass
         return sorted(rv)
 

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -372,7 +372,6 @@ class FlaskGroup(AppGroup):
             # However, we will not do so silently because that would confuse
             # users.
             traceback.print_exc()
-            pass
         return sorted(rv)
 
     def main(self, *args, **kwargs):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -191,3 +191,20 @@ def test_flaskgroup():
     result = runner.invoke(cli, ['test'])
     assert result.exit_code == 0
     assert result.output == 'flaskgroup\n'
+
+
+def test_print_exceptions():
+    """Print the stacktrace if the CLI."""
+    def create_app(info):
+        raise Exception("oh no")
+        return Flask("flaskgroup")
+
+    @click.group(cls=FlaskGroup, create_app=create_app)
+    def cli(**params):
+        pass
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ['--help'])
+    assert result.exit_code == 0
+    assert 'Exception: oh no' in result.output
+    assert 'Traceback' in result.output


### PR DESCRIPTION
I've been bitten by this a few times and I believe silently swallowing errors without any debug output is a bad thing to do. This at least prints the resulting stacktrace.