### PR TITLE
Fix static route when using host_matching = True

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -545,7 +545,6 @@ class Flask(_PackageBoundObject):
         # user may set app.url_map.host_matching to True after the app has
         # been initialized, and host_matching needs to be checked for at the
         # time the route is added for requests to be routed correctly.
-        self._should_add_static_route = self.has_static_folder
         def add_static_route():
             assert not static_host or self.url_map.host_matching, (
                 'Expected app.url_map.host_matching to be True when static_host provided')
@@ -1998,9 +1997,8 @@ class Flask(_PackageBoundObject):
                                exception context to start the response
         """
         with self._before_request_lock:
-            if not self._got_first_request and self._should_add_static_route:
+            if not self._got_first_request and self.has_static_folder:
                 self._add_static_route()
-                self._should_add_static_route = False
         ctx = self.request_context(environ)
         ctx.push()
         error = None

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1171,6 +1171,16 @@ def test_static_url_path():
         assert flask.url_for('static', filename='index.html') == '/foo/index.html'
 
 
+def test_static_route_with_host_matching():
+    app = flask.Flask(__name__, static_host='example.com')
+    assert app.url_map.host_matching, 'passing static_host implies host_matching = True'
+    c = app.test_client()
+    assert c.get('http://example.com/static/index.html').status_code == 200
+    with app.test_request_context():
+       rv = flask.url_for('static', filename='index.html', _external=True)
+       assert rv == 'http://example.com/static/index.html'
+
+
 def test_none_response():
     app = flask.Flask(__name__)
     app.testing = True

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1173,7 +1173,7 @@ def test_static_url_path():
 
 def test_static_route_with_host_matching():
     app = flask.Flask(__name__, static_host='example.com')
-    assert app.url_map.host_matching, 'passing static_host implies host_matching = True'
+    app.url_map.host_matching = True
     c = app.test_client()
     assert c.get('http://example.com/static/index.html').status_code == 200
     with app.test_request_context():


### PR DESCRIPTION
Change `Flask.__init__` to accept a new `static_host` keyword argument,
defaulting to None. <s>Passing this results in url_map.host_matching to be
set to True implicitly. This is because host_matching must be set by the
time the static route is added, or else it won't match.</s> (Edit: see updates below.)

Fixes #1559.
Subsumes #1560.