### PR TITLE
shorten output when ImportError due to app bug.

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -93,7 +93,9 @@ def locate_app(app_id):
         # Reraise the ImportError if it occurred within the imported module.
         # Determine this by checking whether the trace has a depth > 1.
         if sys.exc_info()[-1].tb_next:
-            raise
+            stack_trace = traceback.format_exc()
+            raise NoAppException('There was an error trying to import'
+                    ' the app (%s):\n%s' % (module, stack_trace))
         else:
             raise NoAppException('The file/path provided (%s) does not appear'
                                  ' to exist.  Please verify the path is '

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,7 +83,7 @@ def test_locate_app(test_apps):
     pytest.raises(NoAppException, locate_app, "notanpp.py")
     pytest.raises(NoAppException, locate_app, "cliapp/app")
     pytest.raises(RuntimeError, locate_app, "cliapp.app:notanapp")
-    pytest.raises(ImportError, locate_app, "cliapp.importerrorapp")
+    pytest.raises(NoAppException, locate_app, "cliapp.importerrorapp")
 
 
 def test_find_default_import_path(test_apps, monkeypatch, tmpdir):


### PR DESCRIPTION
Improves output for #2214 

Before:
```
C:\dev\tmp>py -2 -m flask run
Traceback (most recent call last):
  File "C:\Python27\lib\runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "C:\Python27\lib\runpy.py", line 72, in _run_code
    exec code in run_globals
  File "c:\dev\sourcetree\flask\flask\__main__.py", line 15, in <module>
    main(as_module=True)
  File "c:\dev\sourcetree\flask\flask\cli.py", line 523, in main
    cli.main(args=args, prog_name=name)
  File "c:\dev\sourcetree\flask\flask\cli.py", line 383, in main
    return AppGroup.main(self, *args, **kwargs)
  File "C:\Python27\lib\site-packages\click\core.py", line 697, in main
    rv = self.invoke(ctx)
  File "C:\Python27\lib\site-packages\click\core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Python27\lib\site-packages\click\core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Python27\lib\site-packages\click\core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "C:\Python27\lib\site-packages\click\decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args[1:], **kwargs)
  File "C:\Python27\lib\site-packages\click\core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "c:\dev\sourcetree\flask\flask\cli.py", line 433, in run_command
    app = DispatchingApp(info.load_app, use_eager_loading=eager_loading)
  File "c:\dev\sourcetree\flask\flask\cli.py", line 153, in __init__
    self._load_unlocked()
  File "c:\dev\sourcetree\flask\flask\cli.py", line 177, in _load_unlocked
    self._app = rv = self.loader()
  File "c:\dev\sourcetree\flask\flask\cli.py", line 238, in load_app
    rv = locate_app(self.app_import_path)
  File "c:\dev\sourcetree\flask\flask\cli.py", line 91, in locate_app
    __import__(module)
  File "C:\dev\tmp\error.py", line 1, in <module>
    import whatisthisidonteven
ImportError: No module named whatisthisidonteven
```

After:
```
C:\dev\tmp>py -2 -m flask run
Usage: python -m flask run [OPTIONS]

Error: There was an error trying to import the app (error):
Traceback (most recent call last):
  File "c:\dev\sourcetree\flask\flask\cli.py", line 91, in locate_app
    __import__(module)
  File "C:\dev\tmp\error.py", line 1, in <module>
    import whatisthisidonteven
ImportError: No module named whatisthisidonteven
```