### PR TITLE
Handle BaseExceptions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,9 @@ Major release, unreleased
 - Change default configuration `JSONIFY_PRETTYPRINT_REGULAR=False`. jsonify()
   method returns compressed response by default, and pretty response in
   debug mode.
+- Call `ctx.auto_pop` with the exception object instead of `None`, in the
+  event that a `BaseException` such as `KeyboardInterrupt` is raised in a
+  request handler.
 
 Version 0.12.1
 --------------

--- a/flask/app.py
+++ b/flask/app.py
@@ -1991,6 +1991,9 @@ class Flask(_PackageBoundObject):
             except Exception as e:
                 error = e
                 response = self.handle_exception(e)
+            except:
+                error = sys.exc_info()[1]
+                raise
             return response(environ, start_response)
         finally:
             if self.should_ignore_error(error):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -791,6 +791,26 @@ def test_error_handling_processing():
         assert resp.data == b'internal server error'
 
 
+def test_baseexception_error_handling():
+    app = flask.Flask(__name__)
+    app.config['LOGGER_HANDLER_POLICY'] = 'never'
+
+    @app.route('/')
+    def broken_func():
+        raise KeyboardInterrupt()
+
+    with app.test_client() as c:
+        try:
+            c.get('/')
+            raise AssertionError("KeyboardInterrupt should have been raised")
+        except KeyboardInterrupt:
+            pass
+
+        ctx = flask._request_ctx_stack.top
+        assert ctx.preserved
+        assert type(ctx._preserved_exc) is KeyboardInterrupt
+
+
 def test_before_request_and_routing_errors():
     app = flask.Flask(__name__)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -800,11 +800,8 @@ def test_baseexception_error_handling():
         raise KeyboardInterrupt()
 
     with app.test_client() as c:
-        try:
+        with pytest.raises(KeyboardInterrupt):
             c.get('/')
-            raise AssertionError("KeyboardInterrupt should have been raised")
-        except KeyboardInterrupt:
-            pass
 
         ctx = flask._request_ctx_stack.top
         assert ctx.preserved


### PR DESCRIPTION
This ensures that `auto_pop` is called with a non-`None` value in the case of a BaseException being thrown.