### PR TITLE
spelling fix

### DIFF
--- a/docs/patterns/packages.rst
+++ b/docs/patterns/packages.rst
@@ -65,7 +65,7 @@ that tells Flask where to find the application instance::
     export FLASK_APP=yourapplication
 
 If you are outside of the project directory make sure to provide the exact 
-path to your application directory. Similiarly you can turn on "debug 
+path to your application directory. Similarly you can turn on "debug 
 mode" with this environment variable:: 
 
     export FLASK_DEBUG=true 


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.