### PR TITLE
filename can be latin-1, not just ascii

### DIFF
--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -484,7 +484,7 @@ def send_file(filename_or_fp, mimetype=None, as_attachment=False,
         
     .. _RFC 2231: https://tools.ietf.org/html/rfc2231#section-4
 
-    :param filename_or_fp: the filename of the file to send in `latin-1`.
+    :param filename_or_fp: the filename of the file to send.
                            This is relative to the :attr:`~Flask.root_path`
                            if a relative path is specified.
                            Alternatively a file object might be provided in
@@ -541,15 +541,12 @@ def send_file(filename_or_fp, mimetype=None, as_attachment=False,
             raise TypeError('filename unavailable, required for '
                             'sending as attachment')
 
-        normalized = unicodedata.normalize(
-            'NFKD', text_type(attachment_filename)
-        )
-
         try:
-            normalized.encode('ascii')
+            attachment_filename = attachment_filename.encode('latin-1')
         except UnicodeEncodeError:
             filenames = {
-                'filename': normalized.encode('ascii', 'ignore'),
+                'filename': unicodedata.normalize(
+                    'NFKD', attachment_filename).encode('latin-1', 'ignore'),
                 'filename*': "UTF-8''%s" % url_quote(attachment_filename),
             }
         else:


### PR DESCRIPTION
* The filename header, being a header, can include Latin-1 characters, not just ASCII.
* Don't normalize the unicode name until we know the UTF-8 version needs to be sent. Otherwise you create situations where the name *could* be sent as just the single field, but the normalized form doesn't encode to Latin-1.

ref #2223