### PR TITLE
Ensure error while opening session pops context

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,11 +25,14 @@ Major release, unreleased
   adding OPTIONS method when the ``view_func`` argument is not a class.
   (`#1489`_).
 - ``MethodView`` can inherit method handlers from base classes. (`#1936`_)
+- Errors caused while opening the session at the beginning of the request are
+  handled by the app's error handlers. (`#2254`_)
 
 .. _#1489: https://github.com/pallets/flask/pull/1489
 .. _#1936: https://github.com/pallets/flask/pull/1936
 .. _#2017: https://github.com/pallets/flask/pull/2017
 .. _#2223: https://github.com/pallets/flask/pull/2223
+.. _#2254: https://github.com/pallets/flask/pull/2254
 
 Version 0.12.1
 --------------

--- a/flask/app.py
+++ b/flask/app.py
@@ -2002,10 +2002,10 @@ class Flask(_PackageBoundObject):
                                exception context to start the response
         """
         ctx = self.request_context(environ)
-        ctx.push()
         error = None
         try:
             try:
+                ctx.push()
                 response = self.full_dispatch_request()
             except Exception as e:
                 error = e


### PR DESCRIPTION
Reported in #1528. #1538 provided a solution, but can be simplified by only moving `ctx.push()` into the `try` block. Errors raised by `SessionInterface.open_session` and `.make_null_session` will be handled by the normal app error handling mechanism, and the context will be popped at the end of the request.