### PR TITLE
refactor make_response to be easier to follow

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,9 @@ Major release, unreleased
   handled by the app's error handlers. (`#2254`_)
 - Blueprints gained ``json_encoder`` and ``json_decoder`` attributes to
   override the app's encoder and decoder. (`#1898`_)
+- ``Flask.make_response`` raises ``TypeError`` instead of ``ValueError`` for
+  bad response types. The error messages have been improved to describe why the
+  type is invalid. (`#2256`_)
 
 .. _#1489: https://github.com/pallets/flask/pull/1489
 .. _#1898: https://github.com/pallets/flask/pull/1898
@@ -36,6 +39,7 @@ Major release, unreleased
 .. _#2017: https://github.com/pallets/flask/pull/2017
 .. _#2223: https://github.com/pallets/flask/pull/2223
 .. _#2254: https://github.com/pallets/flask/pull/2254
+.. _#2256: https://github.com/pallets/flask/pull/2256
 
 Version 0.12.1
 --------------


### PR DESCRIPTION
* be explicit about how tuples are unpacked
* allow `bytes` for status value
* allow `Headers` for headers value
* use `TypeError` instead of `ValueError`
* errors are more descriptive
* document that view must not return `None`
* update documentation about return values
* test more response types
* test error messages

closes #1676

`TypeError` is more correct by definition (wrong type to function), and I don't think anyone should be catching that error anyway (what would it mean to do that?), so I'm ok if this somehow breaks some code. This is also consistent with what `force_type` returns for bad input.

I had to get a bit creative with displaying the error from `force_type` while injecting a new descriptive message. It would be nice if we could just use `raise new_error from original_error`, but that's Python 3 only.

These error messages will hopefully help avoid a class of questions that are frequently asked on Stack Overflow. In particular, there was no error about incorrect types that made it to `force_type`, so users trying to return JSON with something like `return True` would get a mysterious "bool object is not callable" error.