### PR TITLE
Collapse old changelog directives

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,14 @@ extensions = [
     'flaskdocext'
 ]
 
+try:
+    __import__('sphinxcontrib.log_cabinet')
+except ImportError:
+    print('sphinxcontrib-log-cabinet is not installed.')
+    print('Changelog directives will not be re-organized.')
+else:
+    extensions.append('sphinxcontrib.log_cabinet')
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
I created a Sphinx extension, [sphinxcontrib-log-cabinet](https://github.com/davidism/sphinxcontrib-log-cabinet), to handle #1704. It collects each group of changelog directives, sorts them newest to oldest, then collapses all logs older than the current version. Deprecations are never collapsed.

The extension is optional, a warning is printed if it's not installed but the build continues. The flask-docs build script needs to be updated to install this if we want it to actually take effect.

The collapse doesn't work on IE because they don't support `<details>`. A later version can add a polyfill for it, but I'm not too concerned.