### PR TITLE
Refactor session cookie domain

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -34,6 +34,12 @@ Major release, unreleased
   type is invalid. (`#2256`_)
 - Add ``routes`` CLI command to output routes registered on the application.
   (`#2259`_)
+- Show warning when session cookie domain is a bare hostname or an IP
+  address, as these may not behave properly in some browsers, such as Chrome.
+  (`#2282`_)
+- Allow IP address as exact session cookie domain. (`#2282`_)
+- ``SESSION_COOKIE_DOMAIN`` is set if it is detected through ``SERVER_NAME``.
+  (`#2282`_)
 
 .. _#1489: https://github.com/pallets/flask/pull/1489
 .. _#1898: https://github.com/pallets/flask/pull/1898
@@ -43,6 +49,7 @@ Major release, unreleased
 .. _#2254: https://github.com/pallets/flask/pull/2254
 .. _#2256: https://github.com/pallets/flask/pull/2256
 .. _#2259: https://github.com/pallets/flask/pull/2259
+.. _#2282: https://github.com/pallets/flask/pull/2282
 
 Version 0.12.1
 --------------

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -10,6 +10,7 @@
 """
 
 import os
+import socket
 import sys
 import pkgutil
 import posixpath
@@ -977,22 +978,23 @@ def total_seconds(td):
     """
     return td.days * 60 * 60 * 24 + td.seconds
 
-def is_ip(ip):
-    """Returns the if the string received is an IP or not.
 
-    :param string: the string to check if it an IP or not
-    :param var_name: the name of the string that is being checked
+def is_ip(value):
+    """Determine if the given string is an IP address.
 
-    :returns: True if string is an IP, False if not
-    :rtype: boolean
+    :param value: value to check
+    :type value: str
+
+    :return: True if string is an IP address
+    :rtype: bool
     """
-    import socket
 
     for family in (socket.AF_INET, socket.AF_INET6):
         try:
-            socket.inet_pton(family, ip)
+            socket.inet_pton(family, value)
         except socket.error:
             pass
         else:
             return True
+
     return False

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -976,3 +976,23 @@ def total_seconds(td):
     :rtype: int
     """
     return td.days * 60 * 60 * 24 + td.seconds
+
+def is_ip(ip):
+    """Returns the if the string received is an IP or not.
+
+    :param string: the string to check if it an IP or not
+    :param var_name: the name of the string that is being checked
+
+    :returns: True if string is an IP, False if not
+    :rtype: boolean
+    """
+    import socket
+
+    for family in (socket.AF_INET, socket.AF_INET6):
+        try:
+            socket.inet_pton(family, ip)
+        except socket.error:
+            pass
+        else:
+            return True
+    return False

--- a/flask/sessions.py
+++ b/flask/sessions.py
@@ -11,13 +11,14 @@
 
 import uuid
 import hashlib
+from warnings import warn
 from base64 import b64encode, b64decode
 from datetime import datetime
 from werkzeug.http import http_date, parse_date
 from werkzeug.datastructures import CallbackDict
 from . import Markup, json
 from ._compat import iteritems, text_type
-from .helpers import total_seconds
+from .helpers import total_seconds, is_ip
 
 from itsdangerous import URLSafeTimedSerializer, BadSignature
 
@@ -336,6 +337,9 @@ class SecureCookieSessionInterface(SessionInterface):
 
     def save_session(self, app, session, response):
         domain = self.get_cookie_domain(app)
+        if domain is not None:
+            if is_ip(domain):
+                warnings.warn("IP introduced in SESSION_COOKIE_DOMAIN", RuntimeWarning)
         path = self.get_cookie_path(app)
 
         # Delete case.  If there is no session we bail early.

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -351,6 +351,42 @@ def test_session_using_session_settings():
     assert 'httponly' not in cookie
 
 
+def test_session_localhost_warning(recwarn):
+    app = flask.Flask(__name__)
+    app.config.update(
+        SECRET_KEY='testing',
+        SERVER_NAME='localhost:5000',
+    )
+
+    @app.route('/')
+    def index():
+        flask.session['testing'] = 42
+        return 'testing'
+
+    rv = app.test_client().get('/', 'http://localhost:5000/')
+    assert 'domain' not in rv.headers['set-cookie'].lower()
+    w = recwarn.pop(UserWarning)
+    assert '"localhost" is not a valid cookie domain' in str(w.message)
+
+
+def test_session_ip_warning(recwarn):
+    app = flask.Flask(__name__)
+    app.config.update(
+        SECRET_KEY='testing',
+        SERVER_NAME='127.0.0.1:5000',
+    )
+
+    @app.route('/')
+    def index():
+        flask.session['testing'] = 42
+        return 'testing'
+
+    rv = app.test_client().get('/', 'http://127.0.0.1:5000/')
+    assert 'domain=127.0.0.1' in rv.headers['set-cookie'].lower()
+    w = recwarn.pop(UserWarning)
+    assert 'cookie domain is an IP' in str(w.message)
+
+
 def test_missing_session():
     app = flask.Flask(__name__)
 


### PR DESCRIPTION
* Show a warning when the domain is dropped because the domain does not contain a `.`, for example for `localhost`.
* Show a warning when the domain is an IP address.
* Allow IP addresses in Chrome by not prepending `.`.
* Cache result of `SERVER_NAME` detection in `SESSION_COOKIE_DOMAIN` so it won't run every request (at least within a given process).

Continues #2105.