### PR TITLE
log a clickable url to home page when listening 0.0.0.0, more beginne…

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -858,6 +858,9 @@ class Flask(_PackageBoundObject):
         options.setdefault('use_reloader', self.debug)
         options.setdefault('use_debugger', self.debug)
         try:
+            if self.debug is True and host == '0.0.0.0':
+                from werkzeug._internal import _log
+                _log('info', ' * You can visit %s://%s:%d/', "http", 'localhost', port)
             run_simple(host, port, self, **options)
         finally:
             # reset the first request information if the development server


### PR DESCRIPTION
Hello, I'm a novice.  I use pycharm for development, when I ran my application to listen on 0.0.0.0, I needed to type “http://localhost:5000" to webbroswer to visit my website. It's a bit inconvenient! So I add a some codes to the app.py file to render the url.

```
 * Restarting with stat
 * You can visit http://localhost:5000/
 * Debugger is active!
 * Debugger pin code: 294-762-868
 * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
```

 In my opinion, it's convenient than before. 

Thanks you very much!
