### PR TITLE
Moved WSGI Standalone first in deployment documentation

### DIFF
--- a/docs/deploying/index.rst
+++ b/docs/deploying/index.rst
@@ -33,7 +33,7 @@ Self-hosted options
    :maxdepth: 2
 
    wsgi-standalone
-   mod_wsgi
    uwsgi
+   mod_wsgi
    fastcgi
    cgi

--- a/docs/deploying/index.rst
+++ b/docs/deploying/index.rst
@@ -32,8 +32,8 @@ Self-hosted options
 .. toctree::
    :maxdepth: 2
 
-   mod_wsgi
    wsgi-standalone
+   mod_wsgi
    uwsgi
    fastcgi
    cgi


### PR DESCRIPTION
This references “Reorder deploy docs to mention standalone wsgi first” in project sprint.