### PR TITLE
Added uWSGI and example usage to stand-alone WSGI containers documentation

### DIFF
--- a/docs/deploying/wsgi-standalone.rst
+++ b/docs/deploying/wsgi-standalone.rst
@@ -8,6 +8,23 @@ serve HTTP.  These servers stand alone when they run; you can proxy to them
 from your web server.  Note the section on :ref:`deploying-proxy-setups` if you
 run into issues.
 
+uWSGI
+--------
+
+`uWSGI`_ includes an HTTP/HTTPS router/proxy/load-balancer that can forward
+requests to uWSGI workers. The server can be used in two ways: embedded and
+standalone. In embedded mode, it will automatically spawn workers and setup the
+communication socket. In standalone mode you have to specify the address of a
+uwsgi socket to connect to.
+
+Example running `uWSGI HTTP Router`_ in Embedded Mode::
+
+    uwsgi --http 127.0.0.1:5000 --module myproject:app
+
+.. _uWSGI: http://uwsgi-docs.readthedocs.io/en/latest/
+.. _uWSGI HTTP Router: http://uwsgi-docs.readthedocs.io/en/latest/HTTP.html#the-uwsgi-http-https-router
+
+
 Gunicorn
 --------
 

--- a/docs/deploying/wsgi-standalone.rst
+++ b/docs/deploying/wsgi-standalone.rst
@@ -44,6 +44,22 @@ For example, to run a Flask application with 4 worker processes (``-w
 .. _eventlet: http://eventlet.net/
 .. _greenlet: https://greenlet.readthedocs.io/en/latest/
 
+uWSGI
+--------
+
+`uWSGI`_ is a fast application server written in C. It is very configurable
+which makes it more complicated to setup than gunicorn.
+
+Running `uWSGI HTTP Router`_::
+
+    uwsgi --http 127.0.0.1:5000 --module myproject:app
+
+For a more optimized setup, see `configuring uWSGI and NGINX`_.
+
+.. _uWSGI: http://uwsgi-docs.readthedocs.io/en/latest/
+.. _uWSGI HTTP Router: http://uwsgi-docs.readthedocs.io/en/latest/HTTP.html#the-uwsgi-http-https-router
+.. _configuring uWSGI and NGINX: uwsgi.html#starting-your-app-with-uwsgi
+
 Gevent
 -------
 

--- a/docs/deploying/wsgi-standalone.rst
+++ b/docs/deploying/wsgi-standalone.rst
@@ -8,23 +8,6 @@ serve HTTP.  These servers stand alone when they run; you can proxy to them
 from your web server.  Note the section on :ref:`deploying-proxy-setups` if you
 run into issues.
 
-uWSGI
---------
-
-`uWSGI`_ includes an HTTP/HTTPS router/proxy/load-balancer that can forward
-requests to uWSGI workers. The server can be used in two ways: embedded and
-standalone. In embedded mode, it will automatically spawn workers and setup the
-communication socket. In standalone mode you have to specify the address of a
-uwsgi socket to connect to.
-
-Example running `uWSGI HTTP Router`_ in Embedded Mode::
-
-    uwsgi --http 127.0.0.1:5000 --module myproject:app
-
-.. _uWSGI: http://uwsgi-docs.readthedocs.io/en/latest/
-.. _uWSGI HTTP Router: http://uwsgi-docs.readthedocs.io/en/latest/HTTP.html#the-uwsgi-http-https-router
-
-
 Gunicorn
 --------
 


### PR DESCRIPTION
Talked with @davidism and decided to add section for uWSGI HTTP router / server via embedded mode.