### PR TITLE
Add http headers security notes 

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -105,49 +105,33 @@ vulnerabilities
 this behavior was changed and :func:`~flask.jsonify` now supports serializing
 arrays.
 
-
-SSL/HTTPS
----------
-
-For implementing HTTPS on your server.
-
-Below are some packages that implement this protocol:
-
-* `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
-* `flask-sslify <https://github.com/kennethreitz/flask-sslify>`_
-* `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
-
 Security Headers
 ----------------
 
-This section contains a list of headers supported by Flask and some packages that implements them.
+This section contains a list of headers supported by Flask.
+To configure HTTPS and handle the headers listed below we suggest the package `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`. 
 
 Content Security Policy (CSP)
------------------------------------------------------------------------------
+-----------------------------
 
 Enhance security and prevents common web vulnerabilities such as cross-site scripting and MITM related attacks.
 
 Example:
 
-.. sourcecode:: html
+.. sourcecode:: none
    
    Content-Security-Policy: default-src https:; script-src 'nonce-{random}'; object-src 'none'
 
-
 See also `Content Security Policy <https://csp.withgoogle.com/docs/index.html>`_.
 
-* `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
-* `flask-csp <https://github.com/twaldear/flask-csp>`_
-* `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
-
 HTTP Strict Transport Security (HSTS)
-------------------------------------------------------------------------------------------------------------------------------
+-------------------------------------
 
 Redirects http requests to https on all urls, preventing MITM attacks.
 
 Example:
 
-.. sourcecode:: html
+.. sourcecode:: none
    
    Strict-Transport-Security: max-age=<expire-time 
    Strict-Transport-Security: max-age=<expire-time>; includeSubDomains 
@@ -155,16 +139,12 @@ Example:
 
 See also `Strict Transport Security <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security>`_. 
 
-* `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
-* `flask-sslify <https://github.com/kennethreitz/flask-sslify>`_
-* `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
-
 X-FRAME-OPTIONS (Clickjacking protection)
--------------------------------------------------------------------------------------------------------------------------
+-----------------------------------------
 
 Prevents the client from clicking page elements outside of the website, avoiding hijacking or UI redress attacks.
 
-.. sourcecode:: html
+.. sourcecode:: none
    
    X-Frame-Options: DENY 
    X-Frame-Options: SAMEORIGIN
@@ -172,59 +152,39 @@ Prevents the client from clicking page elements outside of the website, avoiding
 
 See also `X-Frame-Options <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options>`_. 
 
-* `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
-* `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
-
 X-Content-Type-Options
--------------------------------------------------------------------------------------------------------------
+----------------------
 
 Prevents XSS by blocking requests on clients and forcing them to read the content type instead of first opening it.
 
-.. sourcecode:: html
+.. sourcecode:: none
    
    X-Content-Type-Options: nosniff
 
 See also `X-Content-Type-Options <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options>`_. 
 
-* `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
-* `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
-
 Cookie options
-----------------------------------------------------------------------------------------------------------
+--------------
 
 For setting cookies on client-side storage.
 
 Example:
 
-.. sourcecode:: html
+.. sourcecode:: none
    
    Set-Cookie: [cookie-name]=[cookie-value] 
 
 See also `HTTP cookies <https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Secure_and_HttpOnly_cookies>`_ .
 
-* `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
-* `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
-
 HTTP Public Key Pinning (HPKP)
--------------------------------------------------------------------------------------------------------
+------------------------------
 
 For associating clients with web servers through a certificate key and prevent MITM attacks.
 
 Example:
 
-.. sourcecode:: html
+.. sourcecode:: none
 
    Public-Key-Pins: pin-sha256="base64=="; max-age=expireTime [; includeSubDomains][; report-uri="reportURI"] 
 
 See also `Public Key Pinning <https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning>`_.
-
-* `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
-* `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
-
-References
------------
-
-* https://docs.djangoproject.com/en/1.11/topics/security/
-* https://blog.appcanary.com/2017/http-security-headers.html
-* https://developer.mozilla.org
-* https://csp.withgoogle.com/docs/index.html

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -108,13 +108,13 @@ arrays.
 Security Headers
 ----------------
 
-This section contains a list of headers supported by Flask.
+This section contains a list of HTTP security headers supported by Flask.
 To configure HTTPS and handle the headers listed below we suggest the package `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_. 
 
 HTTP Strict Transport Security (HSTS)
 -------------------------------------
 
-Redirects http requests to https on all urls, preventing Man-in-the-middle (MITM) attacks.
+Redirects HTTP requests to HTTPS on all URLs, preventing man-in-the-middle (MITM) attacks.
 
 Example:
 
@@ -129,7 +129,7 @@ See also `Strict Transport Security <https://developer.mozilla.org/en-US/docs/We
 HTTP Public Key Pinning (HPKP)
 ------------------------------
 
-This enables your web server to authenticate with a client browser using a specific certificate key to prevent Man-in-the-middle (MITM) attacks.
+This enables your web server to authenticate with a client browser using a specific certificate key to prevent man-in-the-middle (MITM) attacks.
 
 Example:
 
@@ -139,7 +139,7 @@ Example:
 
 See also `Public Key Pinning <https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning>`_.
 
-X-Frame-Options (Clickjacking protection)
+X-Frame-Options (Clickjacking Protection)
 -----------------------------------------
 
 Prevents the client from clicking page elements outside of the website, avoiding hijacking or UI redress attacks.
@@ -166,7 +166,7 @@ See also `X-Content-Type-Options <https://developer.mozilla.org/en-US/docs/Web/H
 Content Security Policy (CSP)
 -----------------------------
 
-Enhances security and prevents common web vulnerabilities such as cross-site scripting (XSS) and Man-in-the-middle (MITM) related attacks.
+Enhances security and prevents common web vulnerabilities such as cross-site scripting (XSS) and man-in-the-middle (MITM) related attacks.
 
 Example:
 
@@ -176,10 +176,10 @@ Example:
 
 See also `Content Security Policy <https://csp.withgoogle.com/docs/index.html>`_.
 
-Cookie options
+Cookie Options
 --------------
 
-While these headers are not directly security related, they have important options that may affect your flask application.
+While these headers are not directly security related, they have important options that may affect your Flask application.
 
 - ``Secure`` limits your cookies to HTTPS traffic only.
 - ``HttpOnly`` protects the contents of your cookie from being visible to XSS.

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -109,9 +109,9 @@ arrays.
 SSL/HTTPS
 ---------
 
-For implementing HTTPS on your server
+For implementing HTTPS on your server.
 
-Below some packages in suggestion order that implements this protocol:
+Below are some packages that implement this protocol:
 
 * `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
 * `flask-sslify <https://github.com/kennethreitz/flask-sslify>`_
@@ -120,21 +120,21 @@ Below some packages in suggestion order that implements this protocol:
 Security Headers
 ----------------
 
-This sections contains sections headers supported by Flask and a list of packages in suggestion order that implements it
+This section contains a list of headers supported by Flask and some packages that implements them.
 
 `Content Security Policy <https://csp.withgoogle.com/docs/index.html>`_ (CSP)
 -----------------------------------------------------------------------------
 
-For enhancing security and preventing common web vulnerabilities such as cross-site scripting and MITM related attacks
+Enhance security and prevents common web vulnerabilities such as cross-site scripting and MITM related attacks.
 
-Example
+Example:
 
 .. sourcecode:: html
    
    Content-Security-Policy: default-src https:; script-src 'nonce-{random}'; object-src 'none'
 
 
-To learn more check `this  <https://csp.withgoogle.com/docs/index.html>`_
+See also `Content Security Policy <https://csp.withgoogle.com/docs/index.html>`_.
 
 * `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
 * `flask-csp <https://github.com/twaldear/flask-csp>`_
@@ -143,10 +143,9 @@ To learn more check `this  <https://csp.withgoogle.com/docs/index.html>`_
 `HTTP Strict Transport Security <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security>`_ (HSTS)
 ------------------------------------------------------------------------------------------------------------------------------
 
+Redirects http requests to https on all urls, preventing MITM attacks.
 
-For automatically redirect HTTP to HTTPS on all the website url's and prevent MITM attacks
-
-Example
+Example:
 
 .. sourcecode:: html
    
@@ -154,8 +153,7 @@ Example
    Strict-Transport-Security: max-age=<expire-time>; includeSubDomains 
    Strict-Transport-Security: max-age=<expire-time>; preload 
 
-To learn more check `this  <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security>`_ 
-
+See also `Strict Transport Security <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security>`_. 
 
 * `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
 * `flask-sslify <https://github.com/kennethreitz/flask-sslify>`_
@@ -163,8 +161,8 @@ To learn more check `this  <https://developer.mozilla.org/en-US/docs/Web/HTTP/He
 
 `X-FRAME-OPTIONS  <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options>`_ (Clickjacking protection)
 -------------------------------------------------------------------------------------------------------------------------
-Prevents the client clicking page elements outside of the website avoiding hijacking or UI redress attacks
 
+Prevents the client from clicking page elements outside of the website, avoiding hijacking or UI redress attacks.
 
 .. sourcecode:: html
    
@@ -172,7 +170,7 @@ Prevents the client clicking page elements outside of the website avoiding hijac
    X-Frame-Options: SAMEORIGIN
    X-Frame-Options: ALLOW-FROM https://example.com/
 
-To learn more check `this  <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security>`_ 
+See also `X-Frame-Options <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options>`_. 
 
 * `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
 * `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
@@ -180,14 +178,13 @@ To learn more check `this  <https://developer.mozilla.org/en-US/docs/Web/HTTP/He
 `X-Content-Type-Options <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options>`_
 -------------------------------------------------------------------------------------------------------------
 
-Prevents XSS by blocking requests on clients and forcing then to read the content type instead of first opening it.
+Prevents XSS by blocking requests on clients and forcing them to read the content type instead of first opening it.
 
 .. sourcecode:: html
    
    X-Content-Type-Options: nosniff
 
-To learn more check `this  <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options>`_ 
-
+See also `X-Content-Type-Options <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options>`_. 
 
 * `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
 * `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
@@ -195,15 +192,15 @@ To learn more check `this  <https://developer.mozilla.org/en-US/docs/Web/HTTP/He
 `Cookie options <https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Secure_and_HttpOnly_cookies>`_
 ----------------------------------------------------------------------------------------------------------
 
-For setting cookies on client-side storage
+For setting cookies on client-side storage.
 
-Example
+Example:
 
 .. sourcecode:: html
    
    Set-Cookie: [cookie-name]=[cookie-value] 
 
-To learn more check `this <https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Secure_and_HttpOnly_cookies>`_
+See also `HTTP cookies <https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Secure_and_HttpOnly_cookies>`_ .
 
 * `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
 * `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
@@ -211,20 +208,20 @@ To learn more check `this <https://developer.mozilla.org/en-US/docs/Web/HTTP/Coo
 `HTTP Public Key Pinning <https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning>`_ (HPKP)
 -------------------------------------------------------------------------------------------------------
 
-For associating clients with web servers throught a certificate key and prevent MITM attacks
+For associating clients with web servers through a certificate key and prevent MITM attacks.
 
-Example
+Example:
 
 .. sourcecode:: html
 
    Public-Key-Pins: pin-sha256="base64=="; max-age=expireTime [; includeSubDomains][; report-uri="reportURI"] 
 
-To learn more check `this  <https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning>`_
+See also `Public Key Pinning <https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning>`_.
 
 * `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
 * `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
 
-References:
+References
 -----------
 
 * https://docs.djangoproject.com/en/1.11/topics/security/

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -109,25 +109,12 @@ Security Headers
 ----------------
 
 This section contains a list of headers supported by Flask.
-To configure HTTPS and handle the headers listed below we suggest the package `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`. 
-
-Content Security Policy (CSP)
------------------------------
-
-Enhance security and prevents common web vulnerabilities such as cross-site scripting and MITM related attacks.
-
-Example:
-
-.. sourcecode:: none
-   
-   Content-Security-Policy: default-src https:; script-src 'nonce-{random}'; object-src 'none'
-
-See also `Content Security Policy <https://csp.withgoogle.com/docs/index.html>`_.
+To configure HTTPS and handle the headers listed below we suggest the package `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_. 
 
 HTTP Strict Transport Security (HSTS)
 -------------------------------------
 
-Redirects http requests to https on all urls, preventing MITM attacks.
+Redirects http requests to https on all urls, preventing Man-in-the-middle (MITM) attacks.
 
 Example:
 
@@ -139,7 +126,20 @@ Example:
 
 See also `Strict Transport Security <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security>`_. 
 
-X-FRAME-OPTIONS (Clickjacking protection)
+HTTP Public Key Pinning (HPKP)
+------------------------------
+
+This enables your web server to authenticate with a client browser using a specific certificate key to prevent Man-in-the-middle (MITM) attacks.
+
+Example:
+
+.. sourcecode:: none
+
+   Public-Key-Pins: pin-sha256="base64=="; max-age=expireTime [; includeSubDomains][; report-uri="reportURI"] 
+
+See also `Public Key Pinning <https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning>`_.
+
+X-Frame-Options (Clickjacking protection)
 -----------------------------------------
 
 Prevents the client from clicking page elements outside of the website, avoiding hijacking or UI redress attacks.
@@ -155,7 +155,7 @@ See also `X-Frame-Options <https://developer.mozilla.org/en-US/docs/Web/HTTP/Hea
 X-Content-Type-Options
 ----------------------
 
-Prevents XSS by blocking requests on clients and forcing them to read the content type instead of first opening it.
+This header prevents Cross-site scripting (XSS) by blocking requests on clients and forcing them to first read and validate the content-type before reading any of the contents of the request.
 
 .. sourcecode:: none
    
@@ -163,10 +163,27 @@ Prevents XSS by blocking requests on clients and forcing them to read the conten
 
 See also `X-Content-Type-Options <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options>`_. 
 
+Content Security Policy (CSP)
+-----------------------------
+
+Enhances security and prevents common web vulnerabilities such as cross-site scripting (XSS) and Man-in-the-middle (MITM) related attacks.
+
+Example:
+
+.. sourcecode:: none
+   
+   Content-Security-Policy: default-src https:; script-src 'nonce-{random}'; object-src 'none'
+
+See also `Content Security Policy <https://csp.withgoogle.com/docs/index.html>`_.
+
 Cookie options
 --------------
 
-For setting cookies on client-side storage.
+While these headers are not directly security related, they have important options that may affect your flask application.
+
+- ``Secure`` limits your cookies to HTTPS traffic only.
+- ``HttpOnly`` protects the contents of your cookie from being visible to XSS.
+- ``SameSite`` ensures that cookies can only be requested from the same domain that created them but this feature is not yet fully supported across all browsers.  
 
 Example:
 
@@ -174,17 +191,7 @@ Example:
    
    Set-Cookie: [cookie-name]=[cookie-value] 
 
-See also `HTTP cookies <https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Secure_and_HttpOnly_cookies>`_ .
+See also:
 
-HTTP Public Key Pinning (HPKP)
-------------------------------
-
-For associating clients with web servers through a certificate key and prevent MITM attacks.
-
-Example:
-
-.. sourcecode:: none
-
-   Public-Key-Pins: pin-sha256="base64=="; max-age=expireTime [; includeSubDomains][; report-uri="reportURI"] 
-
-See also `Public Key Pinning <https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning>`_.
+-  Mozilla guide to `HTTP cookies <https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Secure_and_HttpOnly_cookies>`_.
+- `OWASP HTTP Only <https://www.owasp.org/index.php/HttpOnly>`_. 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -104,3 +104,130 @@ vulnerabilities
 <https://github.com/pallets/flask/issues/248#issuecomment-59934857>`_, so
 this behavior was changed and :func:`~flask.jsonify` now supports serializing
 arrays.
+
+
+SSL/HTTPS
+---------
+
+For implementing HTTPS on your server
+
+Below some packages in suggestion order that implements this protocol:
+
+* `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
+* `flask-sslify <https://github.com/kennethreitz/flask-sslify>`_
+* `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
+
+Security Headers
+----------------
+
+This sections contains sections headers supported by Flask and a list of packages in suggestion order that implements it
+
+`Content Security Policy <https://csp.withgoogle.com/docs/index.html>`_ (CSP)
+-----------------------------------------------------------------------------
+
+For enhancing security and preventing common web vulnerabilities such as cross-site scripting and MITM related attacks
+
+Example
+
+.. sourcecode:: html
+   
+   Content-Security-Policy: default-src https:; script-src 'nonce-{random}'; object-src 'none'
+
+
+To learn more check `this  <https://csp.withgoogle.com/docs/index.html>`_
+
+* `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
+* `flask-csp <https://github.com/twaldear/flask-csp>`_
+* `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
+
+`HTTP Strict Transport Security <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security>`_ (HSTS)
+------------------------------------------------------------------------------------------------------------------------------
+
+
+For automatically redirect HTTP to HTTPS on all the website url's and prevent MITM attacks
+
+Example
+
+.. sourcecode:: html
+   
+   Strict-Transport-Security: max-age=<expire-time 
+   Strict-Transport-Security: max-age=<expire-time>; includeSubDomains 
+   Strict-Transport-Security: max-age=<expire-time>; preload 
+
+To learn more check `this  <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security>`_ 
+
+
+* `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
+* `flask-sslify <https://github.com/kennethreitz/flask-sslify>`_
+* `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
+
+`X-FRAME-OPTIONS  <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options>`_ (Clickjacking protection)
+-------------------------------------------------------------------------------------------------------------------------
+Prevents the client clicking page elements outside of the website avoiding hijacking or UI redress attacks
+
+
+.. sourcecode:: html
+   
+   X-Frame-Options: DENY 
+   X-Frame-Options: SAMEORIGIN
+   X-Frame-Options: ALLOW-FROM https://example.com/
+
+To learn more check `this  <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security>`_ 
+
+* `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
+* `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
+
+`X-Content-Type-Options <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options>`_
+-------------------------------------------------------------------------------------------------------------
+
+Prevents XSS by blocking requests on clients and forcing then to read the content type instead of first opening it.
+
+.. sourcecode:: html
+   
+   X-Content-Type-Options: nosniff
+
+To learn more check `this  <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options>`_ 
+
+
+* `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
+* `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
+
+`Cookie options <https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Secure_and_HttpOnly_cookies>`_
+----------------------------------------------------------------------------------------------------------
+
+For setting cookies on client-side storage
+
+Example
+
+.. sourcecode:: html
+   
+   Set-Cookie: [cookie-name]=[cookie-value] 
+
+To learn more check `this <https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Secure_and_HttpOnly_cookies>`_
+
+* `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
+* `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
+
+`HTTP Public Key Pinning <https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning>`_ (HPKP)
+-------------------------------------------------------------------------------------------------------
+
+For associating clients with web servers throught a certificate key and prevent MITM attacks
+
+Example
+
+.. sourcecode:: html
+
+   Public-Key-Pins: pin-sha256="base64=="; max-age=expireTime [; includeSubDomains][; report-uri="reportURI"] 
+
+To learn more check `this  <https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning>`_
+
+* `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
+* `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
+
+References:
+-----------
+
+* https://docs.djangoproject.com/en/1.11/topics/security/
+* https://blog.appcanary.com/2017/http-security-headers.html
+* https://developer.mozilla.org
+* https://csp.withgoogle.com/docs/index.html

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -122,7 +122,7 @@ Security Headers
 
 This section contains a list of headers supported by Flask and some packages that implements them.
 
-`Content Security Policy <https://csp.withgoogle.com/docs/index.html>`_ (CSP)
+Content Security Policy (CSP)
 -----------------------------------------------------------------------------
 
 Enhance security and prevents common web vulnerabilities such as cross-site scripting and MITM related attacks.
@@ -140,7 +140,7 @@ See also `Content Security Policy <https://csp.withgoogle.com/docs/index.html>`_
 * `flask-csp <https://github.com/twaldear/flask-csp>`_
 * `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
 
-`HTTP Strict Transport Security <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security>`_ (HSTS)
+HTTP Strict Transport Security (HSTS)
 ------------------------------------------------------------------------------------------------------------------------------
 
 Redirects http requests to https on all urls, preventing MITM attacks.
@@ -159,7 +159,7 @@ See also `Strict Transport Security <https://developer.mozilla.org/en-US/docs/We
 * `flask-sslify <https://github.com/kennethreitz/flask-sslify>`_
 * `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
 
-`X-FRAME-OPTIONS  <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options>`_ (Clickjacking protection)
+X-FRAME-OPTIONS (Clickjacking protection)
 -------------------------------------------------------------------------------------------------------------------------
 
 Prevents the client from clicking page elements outside of the website, avoiding hijacking or UI redress attacks.
@@ -175,7 +175,7 @@ See also `X-Frame-Options <https://developer.mozilla.org/en-US/docs/Web/HTTP/Hea
 * `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
 * `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
 
-`X-Content-Type-Options <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options>`_
+X-Content-Type-Options
 -------------------------------------------------------------------------------------------------------------
 
 Prevents XSS by blocking requests on clients and forcing them to read the content type instead of first opening it.
@@ -189,7 +189,7 @@ See also `X-Content-Type-Options <https://developer.mozilla.org/en-US/docs/Web/H
 * `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
 * `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
 
-`Cookie options <https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Secure_and_HttpOnly_cookies>`_
+Cookie options
 ----------------------------------------------------------------------------------------------------------
 
 For setting cookies on client-side storage.
@@ -205,7 +205,7 @@ See also `HTTP cookies <https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookie
 * `flask-talisman <https://github.com/GoogleCloudPlatform/flask-talisman>`_
 * `flask-secure-headers <https://github.com/twaldear/flask-secure-headers>`_
 
-`HTTP Public Key Pinning <https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning>`_ (HPKP)
+HTTP Public Key Pinning (HPKP)
 -------------------------------------------------------------------------------------------------------
 
 For associating clients with web servers through a certificate key and prevent MITM attacks.


### PR DESCRIPTION
Add notes about the following http headers and protocols:

 
- SSL/HTTPS
- Security Headers
- Content Security Policy (CSP)
- HTTP Strict Transport Security (HSTS)
- X-FRAME-OPTIONS (Clickjacking protection)
- X-Content-Type-Options
- Cookie options
- HTTP Public Key Pinning (HPKP)