### PR TITLE
Use the yield syntax in pytest's fixtures

### DIFF
--- a/examples/minitwit/tests/test_minitwit.py
+++ b/examples/minitwit/tests/test_minitwit.py
@@ -15,18 +15,16 @@ from minitwit import minitwit
 
 
 @pytest.fixture
-def client(request):
+def client():
     db_fd, minitwit.app.config['DATABASE'] = tempfile.mkstemp()
     client = minitwit.app.test_client()
     with minitwit.app.app_context():
         minitwit.init_db()
 
-    def teardown():
-        """Get rid of the database again after each test."""
-        os.close(db_fd)
-        os.unlink(minitwit.app.config['DATABASE'])
-    request.addfinalizer(teardown)
-    return client
+    yield client
+
+    os.close(db_fd)
+    os.unlink(minitwit.app.config['DATABASE'])
 
 
 def register(client, username, password, password2=None, email=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,16 +22,17 @@ def test_apps(monkeypatch):
             os.path.dirname(__file__), 'test_apps'))
     )
 
+
 @pytest.fixture(autouse=True)
-def leak_detector(request):
-    def ensure_clean_request_context():
-        # make sure we're not leaking a request context since we are
-        # testing flask internally in debug mode in a few cases
-        leaks = []
-        while flask._request_ctx_stack.top is not None:
-            leaks.append(flask._request_ctx_stack.pop())
-        assert leaks == []
-    request.addfinalizer(ensure_clean_request_context)
+def leak_detector():
+    yield
+
+    # make sure we're not leaking a request context since we are
+    # testing flask internally in debug mode in a few cases
+    leaks = []
+    while flask._request_ctx_stack.top is not None:
+        leaks.append(flask._request_ctx_stack.pop())
+    assert leaks == []
 
 
 @pytest.fixture(params=(True, False))

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -21,19 +21,18 @@ from flask._compat import PY2
 
 
 @pytest.fixture(autouse=True)
-def disable_extwarnings(request, recwarn):
+def disable_extwarnings(recwarn):
     from flask.exthook import ExtDeprecationWarning
 
-    def inner():
-        assert set(w.category for w in recwarn.list) \
-            <= set([ExtDeprecationWarning])
-        recwarn.clear()
+    yield
 
-    request.addfinalizer(inner)
+    assert set(w.category for w in recwarn.list) \
+        <= set([ExtDeprecationWarning])
+    recwarn.clear()
 
 
 @pytest.fixture(autouse=True)
-def importhook_setup(monkeypatch, request):
+def importhook_setup(monkeypatch):
     # we clear this out for various reasons.  The most important one is
     # that a real flaskext could be in there which would disable our
     # fake package.  Secondly we want to make sure that the flaskext
@@ -58,12 +57,11 @@ def importhook_setup(monkeypatch, request):
             import_hooks += 1
     assert import_hooks == 1
 
-    def teardown():
-        from flask import ext
-        for key in ext.__dict__:
-            assert '.' not in key
+    yield
 
-    request.addfinalizer(teardown)
+    from flask import ext
+    for key in ext.__dict__:
+        assert '.' not in key
 
 
 @pytest.fixture


### PR DESCRIPTION
Hi,

Pytest's documentation recommends the use of the yield syntax over teardown functions.

I did not modify the flaskr example as it is being handled by #2307.
Also, I'm not familiar enough with Flask's tests to refactor the last two uses of `request.addfinalizer`:
- [tests/conftest.py#L126](https://github.com/pallets/flask/blob/master/tests/conftest.py#L126)
- [tests/test_instance_config.py#L131](https://github.com/pallets/flask/blob/master/tests/test_instance_config.py#L131)