### PR TITLE
Fix a small oversight in the testing docs

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -54,7 +54,7 @@ the application for testing and initializes a new database.::
 
 
     @pytest.fixture
-    def client(request):
+    def client():
         db_fd, flaskr.app.config['DATABASE'] = tempfile.mkstemp()
         flaskr.app.config['TESTING'] = True
         client = flaskr.app.test_client()

--- a/examples/flaskr/tests/test_flaskr.py
+++ b/examples/flaskr/tests/test_flaskr.py
@@ -16,7 +16,7 @@ from flaskr import flaskr
 
 
 @pytest.fixture
-def client(request):
+def client():
     db_fd, flaskr.app.config['DATABASE'] = tempfile.mkstemp()
     flaskr.app.config['TESTING'] = True
     client = flaskr.app.test_client()


### PR DESCRIPTION
The `request` fixture is not needed anymore.