### PR TITLE
Reduce test envs, add coverage reports, other test fixups

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+branch = True
+source =
+    flask
+    tests
+
+[paths]
+source =
+    flask
+    .tox/*/lib/python*/site-packages/flask
+    .tox/pypy/site-packages/flask

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,52 +1,61 @@
 sudo: false
 language: python
 
-python:
-  - "2.6"
-  - "2.7"
-  - "pypy"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-
-env:
-  - REQUIREMENTS=lowest
-  - REQUIREMENTS=lowest-simplejson
-  - REQUIREMENTS=release
-  - REQUIREMENTS=release-simplejson
-  - REQUIREMENTS=devel
-  - REQUIREMENTS=devel-simplejson
-
 matrix:
-  exclude:
-    # Python 3 support currently does not work with lowest requirements
-    - python: "3.3"
-      env: REQUIREMENTS=lowest
-    - python: "3.3"
-      env: REQUIREMENTS=lowest-simplejson
-    - python: "3.4"
-      env: REQUIREMENTS=lowest
-    - python: "3.4"
-      env: REQUIREMENTS=lowest-simplejson
-    - python: "3.5"
-      env: REQUIREMENTS=lowest
-    - python: "3.5"
-      env: REQUIREMENTS=lowest-simplejson
-    - python: "3.6"
-      env: REQUIREMENTS=lowest
-    - python: "3.6"
-      env: REQUIREMENTS=lowest-simplejson
+  include:
+    - python: 3.6
+      env: TOXENV=py-release,codecov
+    - python: 3.5
+      env: TOXENV=py-release,codecov
+    - python: 3.4
+      env: TOXENV=py-release,codecov
+    - python: 3.3
+      env: TOXENV=py-release,codecov
+    - python: 2.7
+      env: TOXENV=py-release,codecov
+    - python: 2.6
+      env: TOXENV=py-release,codecov
+    - python: pypy
+      env: TOXENV=py-release,codecov
+    - python: nightly
+      env: TOXENV=py-release
+    - python: 3.6
+      env: TOXENV=docs-html
+    - python: 3.6
+      env: TOXENV=py-release-simplejson,codecov
+    - python: 2.7
+      env: TOXENV=py-release-simplejson,codecov
+    - python: pypy
+      env: TOXENV=py-release-simplejson,codecov
+    - python: 3.6
+      env: TOXENV=py-devel,codecov
+    - python: 3.3
+      env: TOXENV=py-devel,codecov
+    - python: 2.7
+      env: TOXENV=py-devel,codecov
+    - python: 2.6
+      env: TOXENV=py-devel,codecov
+    - python: pypy
+      env: TOXENV=py-devel,codecov
+    - python: 3.6
+      env: TOXENV=py-lowest,codecov
+    - python: 3.3
+      env: TOXENV=py-lowest,codecov
+    - python: 2.7
+      env: TOXENV=py-lowest,codecov
+    - python: 2.6
+      env: TOXENV=py-lowest,codecov
+    - python: pypy
+      env: TOXENV=py-lowest,codecov
 
 install:
-    - pip install tox
+  - pip install tox
 
 script:
-    - tox -e py-$REQUIREMENTS
+  - tox
 
-branches:
-  except:
-    - website
+cache:
+  - pip
 
 notifications:
   email: false

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,5 @@ universal = 1
 license_file = LICENSE
 
 [tool:pytest]
-norecursedirs = .* *.egg *.egg-info env* artwork docs
+minversion = 3.0
+testpaths = tests

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'Werkzeug>=0.7',
+        'Werkzeug>=0.9',
         'Jinja2>=2.4',
         'itsdangerous>=0.21',
         'click>=4.0',

--- a/tox.ini
+++ b/tox.ini
@@ -1,37 +1,65 @@
 [tox]
-envlist = {py26,py27,pypy}-{lowest,release,devel}{,-simplejson}, {py33,py34,py35,py36}-{release,devel}{,-simplejson}
+envlist =
+    py{36,35,34,33,27,26,py}-release
+    py{36,27,py}-release-simplejson
+    py{36,33,27,26,py}-devel
+    py{36,33,27,26,py}-lowest
+    docs-html
+    coverage-report
 
 [testenv]
 passenv = LANG
-usedevelop=true
-commands =
-    # We need to install those after Flask is installed.
-    pip install -e examples/flaskr
-    pip install -e examples/minitwit
-    pip install -e examples/patterns/largerapp
-    pytest --cov=flask --cov-report html []
-deps=
-    pytest
-    pytest-cov
+usedevelop = true
+deps =
+    pytest>=3
+    coverage
     greenlet
+    blinker
 
-    lowest: Werkzeug==0.7
+    lowest: Werkzeug==0.9
     lowest: Jinja2==2.4
     lowest: itsdangerous==0.21
     lowest: Click==4.0
-    lowest: blinker==1.0
 
-    release: blinker
-
-    devel: git+https://github.com/pallets/werkzeug.git
-    devel: git+https://github.com/pallets/markupsafe.git
-    devel: git+https://github.com/pallets/jinja.git
-    devel: git+https://github.com/pallets/itsdangerous.git
-    devel: git+https://github.com/pallets/click.git
-    devel: git+https://github.com/jek/blinker.git
+    devel: https://github.com/pallets/werkzeug/archive/master.tar.gz
+    devel: https://github.com/pallets/markupsafe/archive/master.tar.gz
+    devel: https://github.com/pallets/jinja/archive/master.tar.gz
+    devel: https://github.com/pallets/itsdangerous/archive/master.tar.gz
+    devel: https://github.com/pallets/click/archive/master.tar.gz
 
     simplejson: simplejson
+commands =
+    # the examples need to be installed to test successfully
+    pip install -e examples/flaskr -q
+    pip install -e examples/minitwit -q
+    pip install -e examples/patterns/largerapp -q
 
-[testenv:docs]
+    # pytest-cov doesn't seem to play nice with -p
+    coverage run -p -m pytest
+
+[testenv:docs-html]
+deps =
+    sphinx
+    flask-sphinx-themes
+commands = sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
+
+[testenv:docs-linkcheck]
 deps = sphinx
 commands = sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees docs docs/_build/linkcheck
+
+[testenv:coverage-report]
+deps = coverage
+skip_install = true
+commands =
+    coverage combine
+    coverage report
+    coverage html
+
+[testenv:codecov]
+passenv = CI TRAVIS TRAVIS_*
+deps = codecov
+skip_install = true
+commands =
+    coverage combine
+    coverage report
+    codecov


### PR DESCRIPTION
* reduce number of tox and travis envs, was taking way too long to run (~50 minutes)
* bump minimum werkzeug version to fix tests. I don't find this particularly controversial, but someone else can bump it back down if 0.9 from 2013 is too recent.
* use archive packages from github for devel, cloning was taking too long
* cache pip pacakges on travis
* collect branch coverage
* collect coverage of test code
* report coverage across envs
* test building docs, don't linktest by default
* enable codecov integration