### PR TITLE
APPLICATION_ROOT defaults to '/'

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -49,6 +49,7 @@ Major release, unreleased
   work with the ``flask`` command. If they take a single parameter or a
   parameter named ``script_info``, the ``ScriptInfo`` object will be passed.
   (`#2319`_)
+- FLASK_APP=myproject.app:create_app('dev') support. 
 - ``FLASK_APP`` can be set to an app factory, with arguments if needed, for
   example ``FLASK_APP=myproject.app:create_app('dev')``. (`#2326`_)
 - ``View.provide_automatic_options = True`` is set on the view function from
@@ -59,6 +60,8 @@ Major release, unreleased
   accessed at all during the request (and it wasn't deleted). (`#2288`_)
 - ``app.test_request_context()`` take ``subdomain`` and ``url_scheme``
   parameters for use when building base URL. (`#1621`_)
+- Set ``APPLICATION_ROOT = '/'`` by default. This was already the implicit
+  default when it was set to ``None``.
 
 .. _#1489: https://github.com/pallets/flask/pull/1489
 .. _#1621: https://github.com/pallets/flask/pull/1621

--- a/flask/app.py
+++ b/flask/app.py
@@ -307,7 +307,7 @@ class Flask(_PackageBoundObject):
         'LOGGER_NAME':                          None,
         'LOGGER_HANDLER_POLICY':               'always',
         'SERVER_NAME':                          None,
-        'APPLICATION_ROOT':                     None,
+        'APPLICATION_ROOT':                     '/',
         'SESSION_COOKIE_NAME':                  'session',
         'SESSION_COOKIE_DOMAIN':                None,
         'SESSION_COOKIE_PATH':                  None,
@@ -1845,7 +1845,7 @@ class Flask(_PackageBoundObject):
         if self.config['SERVER_NAME'] is not None:
             return self.url_map.bind(
                 self.config['SERVER_NAME'],
-                script_name=self.config['APPLICATION_ROOT'] or '/',
+                script_name=self.config['APPLICATION_ROOT'],
                 url_scheme=self.config['PREFERRED_URL_SCHEME'])
 
     def inject_url_defaults(self, endpoint, values):

--- a/flask/sessions.py
+++ b/flask/sessions.py
@@ -288,8 +288,8 @@ class SessionInterface(object):
         config var if it's set, and falls back to ``APPLICATION_ROOT`` or
         uses ``/`` if it's ``None``.
         """
-        return app.config['SESSION_COOKIE_PATH'] or \
-               app.config['APPLICATION_ROOT'] or '/'
+        return app.config['SESSION_COOKIE_PATH'] \
+               or app.config['APPLICATION_ROOT']
 
     def get_cookie_httponly(self, app):
         """Returns True if the session cookie should be httponly.  This

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -34,13 +34,13 @@ def make_test_environ_builder(
 
     if base_url is None:
         http_host = app.config.get('SERVER_NAME') or 'localhost'
-        app_root = app.config.get('APPLICATION_ROOT') or '/'
+        app_root = app.config['APPLICATION_ROOT']
 
         if subdomain:
             http_host = '{0}.{1}'.format(subdomain, http_host)
 
         if url_scheme is None:
-            url_scheme = app.config.get('PREFERRED_URL_SCHEME') or 'http'
+            url_scheme = app.config['PREFERRED_URL_SCHEME']
 
         url = url_parse(path)
         base_url = '{0}://{1}/{2}'.format(


### PR DESCRIPTION
All places that use `APPLICATION_ROOT` were using the pattern `app.config.get('APPLICATION_ROOT') or '/'`. This sets the default config to `'/'` to simplify things, since it was the implicit default and didn't do anything special if it wasn't set.