### PR TITLE
deprecate app session methods in favor of session_interface

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -10,6 +10,7 @@
 """
 import os
 import sys
+import warnings
 from datetime import timedelta
 from functools import update_wrapper
 from itertools import chain
@@ -925,8 +926,17 @@ class Flask(_PackageBoundObject):
         :attr:`secret_key` is set.  Instead of overriding this method
         we recommend replacing the :class:`session_interface`.
 
+        .. deprecated: 1.0
+            Will be removed in 1.1. Use ``session_interface.open_session``
+            instead.
+
         :param request: an instance of :attr:`request_class`.
         """
+
+        warnings.warn(DeprecationWarning(
+            '"open_session" is deprecated and will be removed in 1.1. Use'
+            ' "session_interface.open_session" instead.'
+        ))
         return self.session_interface.open_session(self, request)
 
     def save_session(self, session, response):
@@ -934,19 +944,37 @@ class Flask(_PackageBoundObject):
         implementation, check :meth:`open_session`.  Instead of overriding this
         method we recommend replacing the :class:`session_interface`.
 
+        .. deprecated: 1.0
+            Will be removed in 1.1. Use ``session_interface.save_session``
+            instead.
+
         :param session: the session to be saved (a
                         :class:`~werkzeug.contrib.securecookie.SecureCookie`
                         object)
         :param response: an instance of :attr:`response_class`
         """
+
+        warnings.warn(DeprecationWarning(
+            '"save_session" is deprecated and will be removed in 1.1. Use'
+            ' "session_interface.save_session" instead.'
+        ))
         return self.session_interface.save_session(self, session, response)
 
     def make_null_session(self):
         """Creates a new instance of a missing session.  Instead of overriding
         this method we recommend replacing the :class:`session_interface`.
 
+        .. deprecated: 1.0
+            Will be removed in 1.1. Use ``session_interface.make_null_session``
+            instead.
+
         .. versionadded:: 0.7
         """
+
+        warnings.warn(DeprecationWarning(
+            '"make_null_session" is deprecated and will be removed in 1.1. Use'
+            ' "session_interface.make_null_session" instead.'
+        ))
         return self.session_interface.make_null_session(self)
 
     @setupmethod
@@ -1932,7 +1960,7 @@ class Flask(_PackageBoundObject):
         for handler in funcs:
             response = handler(response)
         if not self.session_interface.is_null_session(ctx.session):
-            self.save_session(ctx.session, response)
+            self.session_interface.save_session(self, ctx.session, response)
         return response
 
     def do_teardown_request(self, exc=_sentinel):

--- a/flask/ctx.py
+++ b/flask/ctx.py
@@ -329,9 +329,11 @@ class RequestContext(object):
         # available. This allows a custom open_session method to use the
         # request context (e.g. code that access database information
         # stored on `g` instead of the appcontext).
-        self.session = self.app.open_session(self.request)
+        session_interface = self.app.session_interface
+        self.session = session_interface.open_session(self.app, self.request)
+
         if self.session is None:
-            self.session = self.app.make_null_session()
+            self.session = session_interface.make_null_session(self.app)
 
     def pop(self, exc=_sentinel):
         """Pops the request context and unbinds it by doing that.  This will

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -105,7 +105,8 @@ class FlaskClient(Client):
         self.cookie_jar.inject_wsgi(environ_overrides)
         outer_reqctx = _request_ctx_stack.top
         with app.test_request_context(*args, **kwargs) as c:
-            sess = app.open_session(c.request)
+            session_interface = app.session_interface
+            sess = session_interface.open_session(app, c.request)
             if sess is None:
                 raise RuntimeError('Session backend did not open a session. '
                                    'Check the configuration')
@@ -124,8 +125,8 @@ class FlaskClient(Client):
                 _request_ctx_stack.pop()
 
             resp = app.response_class()
-            if not app.session_interface.is_null_session(sess):
-                app.save_session(sess, resp)
+            if not session_interface.is_null_session(sess):
+                session_interface.save_session(app, sess, resp)
             headers = resp.get_wsgi_headers(c.request.environ)
             self.cookie_jar.extract_wsgi(c.request.environ, headers)
 


### PR DESCRIPTION
`Flask.save_session`, `open_, and `make_null_` are deprecated in favor of using a custom `session_interface`. Their docs already recommended doing that. Marked as deprecated in 1.0, removed in 1.1.

ref #1182