### PR TITLE
Be smarter about adding ".cli" to reloader command

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -22,7 +22,7 @@ from threading import Lock, Thread
 import click
 
 from . import __version__
-from ._compat import iteritems, reraise
+from ._compat import iteritems, reraise, PY2
 from .globals import current_app
 from .helpers import get_debug_flag
 from ._compat import getargspec
@@ -647,19 +647,19 @@ Example usage:
 
 
 def main(as_module=False):
-    this_module = __package__ + '.cli'
     args = sys.argv[1:]
 
     if as_module:
-        if sys.version_info >= (2, 7):
-            name = 'python -m ' + this_module.rsplit('.', 1)[0]
-        else:
-            name = 'python -m ' + this_module
+        this_module = 'flask'
 
-        # This module is always executed as "python -m flask.run" and as such
-        # we need to ensure that we restore the actual command line so that
-        # the reloader can properly operate.
-        sys.argv = ['-m', this_module] + sys.argv[1:]
+        if sys.version_info < (2, 7):
+            this_module += '.cli'
+
+        name = 'python -m ' + this_module
+
+        # Python rewrites "python -m flask" to the path to the file in argv.
+        # Restore the original command so that the reloader works.
+        sys.argv = ['-m', this_module] + args
     else:
         name = None
 

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -22,7 +22,7 @@ from threading import Lock, Thread
 import click
 
 from . import __version__
-from ._compat import iteritems, reraise, PY2
+from ._compat import iteritems, reraise
 from .globals import current_app
 from .helpers import get_debug_flag
 from ._compat import getargspec


### PR DESCRIPTION
`python -m flask.cli` raises an import warning on > 2.6. It's only needed on 2.6, `python -m flask` works otherwise.
closes #2357