### PR TITLE
Remove error handler cache

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -76,6 +76,9 @@ Major release, unreleased
 - Extract JSON handling to a mixin applied to both the request and response
   classes used by Flask. This adds the ``is_json`` and ``get_json`` methods to
   the response to make testing JSON response much easier. (`#2358`_)
+- Removed error handler caching because it caused unexpected results for some
+  exception inheritance hierarchies. Register handlers explicitly for each
+  exception if you don't want to traverse the MRO. (`#2362`_)
 
 .. _#1489: https://github.com/pallets/flask/pull/1489
 .. _#1621: https://github.com/pallets/flask/pull/1621
@@ -98,6 +101,7 @@ Major release, unreleased
 .. _#2352: https://github.com/pallets/flask/pull/2352
 .. _#2354: https://github.com/pallets/flask/pull/2354
 .. _#2358: https://github.com/pallets/flask/pull/2358
+.. _#2362: https://github.com/pallets/flask/pull/2362
 
 Version 0.12.2
 --------------

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -980,6 +980,39 @@ def test_http_error_subclass_handling(app, client):
     assert client.get('/3').data == b'apple'
 
 
+def test_errorhandler_precedence(app, client):
+    class E1(Exception):
+        pass
+
+    class E2(Exception):
+        pass
+
+    class E3(E1, E2):
+        pass
+
+    @app.errorhandler(E2)
+    def handle_e2(e):
+        return 'E2'
+
+    @app.errorhandler(Exception)
+    def handle_exception(e):
+        return 'Exception'
+
+    @app.route('/E1')
+    def raise_e1():
+        raise E1
+
+    @app.route('/E3')
+    def raise_e3():
+        raise E3
+
+    rv = client.get('/E1')
+    assert rv.data == b'Exception'
+
+    rv = client.get('/E3')
+    assert rv.data == b'E2'
+
+
 def test_trapping_of_bad_request_key_errors(app, client):
     @app.route('/fail')
     def fail():


### PR DESCRIPTION
Caching handlers for the exception MRO caused issues with some inheritance setups. I don't expect hierarchies to be deep enough for this to affect most cases, but if performance is an issues handlers should be explicitly registered for each class they apply to.

closes #2267, closes #1433