### PR TITLE
Correctly JSON-encode datetimes aware of non-UTC timezones

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -79,6 +79,7 @@ Major release, unreleased
 - Removed error handler caching because it caused unexpected results for some
   exception inheritance hierarchies. Register handlers explicitly for each
   exception if you don't want to traverse the MRO. (`#2362`_)
+- Fix incorrect JSON encoding of aware, non-UTC datetimes. (`#2374`_)
 
 .. _#1489: https://github.com/pallets/flask/pull/1489
 .. _#1621: https://github.com/pallets/flask/pull/1621
@@ -102,6 +103,7 @@ Major release, unreleased
 .. _#2354: https://github.com/pallets/flask/pull/2354
 .. _#2358: https://github.com/pallets/flask/pull/2358
 .. _#2362: https://github.com/pallets/flask/pull/2362
+.. _#2374: https://github.com/pallets/flask/pull/2374
 
 Version 0.12.2
 --------------

--- a/flask/json/__init__.py
+++ b/flask/json/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import io
 import uuid
-from datetime import date
+from datetime import date, datetime
 from flask.globals import current_app, request
 from flask._compat import text_type, PY2
 
@@ -62,6 +62,8 @@ class JSONEncoder(_json.JSONEncoder):
                     return list(iterable)
                 return JSONEncoder.default(self, o)
         """
+        if isinstance(o, datetime):
+            return http_date(o.utctimetuple())
         if isinstance(o, date):
             return http_date(o.timetuple())
         if isinstance(o, uuid.UUID):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -23,7 +23,12 @@ from werkzeug.http import parse_cache_control_header, parse_options_header
 from werkzeug.http import http_date
 from flask._compat import StringIO, text_type
 from flask.helpers import get_debug_flag, make_response
-from pytz import timezone
+try:
+    from pytz import timezone
+except ImportError:
+    has_pytz = False
+else:
+    has_pytz = True
 
 
 def has_encoding(name):
@@ -178,6 +183,7 @@ class TestJSON(object):
             assert rv.mimetype == 'application/json'
             assert flask.json.loads(rv.data)['x'] == http_date(d.timetuple())
 
+    @pytest.mark.skipif('not has_pytz')
     @pytest.mark.parametrize('tzname', ('UTC', 'PST8PDT', 'Asia/Seoul'))
     def test_jsonify_aware_datetimes(self, tzname):
         """Test if aware datetime.datetime objects are converted into GMT."""

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -23,7 +23,6 @@ from werkzeug.http import parse_cache_control_header, parse_options_header
 from werkzeug.http import http_date
 from flask._compat import StringIO, text_type
 from flask.helpers import get_debug_flag, make_response
-from pytz import timezone
 
 
 def has_encoding(name):
@@ -178,14 +177,14 @@ class TestJSON(object):
             assert rv.mimetype == 'application/json'
             assert flask.json.loads(rv.data)['x'] == http_date(d.timetuple())
 
-    @pytest.mark.parametrize('tzname', ('UTC', 'PST8PDT', 'Asia/Seoul'))
-    def test_jsonify_aware_datetimes(self, tzname):
+    @pytest.mark.parametrize('tz', (('UTC', 0), ('PST', -8), ('KST', 9)))
+    def test_jsonify_aware_datetimes(self, tz):
         """Test if aware datetime.datetime objects are converted into GMT."""
-        dt_naive = datetime.datetime(2017, 1, 1, 12, 34, 56)
-        dt_aware = timezone(tzname).localize(dt_naive)
-        dt_as_gmt = dt_aware.astimezone(timezone('GMT'))
-        expected = dt_as_gmt.strftime('"%a, %d %b %Y %H:%M:%S %Z"')
-        assert flask.json.JSONEncoder().encode(dt_aware) == expected
+        tzinfo = datetime.timezone(datetime.timedelta(hours=tz[1]), name=tz[0])
+        dt = datetime.datetime(2017, 1, 1, 12, 34, 56, tzinfo=tzinfo)
+        gmt = datetime.timezone(datetime.timedelta(), name='GMT')
+        expected = dt.astimezone(gmt).strftime('"%a, %d %b %Y %H:%M:%S %Z"')
+        assert flask.json.JSONEncoder().encode(dt) == expected
 
     def test_jsonify_uuid_types(self, app, client):
         """Test jsonify with uuid.UUID types"""

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -34,6 +34,27 @@ def has_encoding(name):
         return False
 
 
+class FixedOffset(datetime.tzinfo):
+    """Fixed offset in hours east from UTC.
+
+    This is a slight adaptation of the ``FixedOffset`` example found in
+    https://docs.python.org/2.7/library/datetime.html.
+    """
+
+    def __init__(self, hours, name):
+        self.__offset = datetime.timedelta(hours=hours)
+        self.__name = name
+
+    def utcoffset(self, dt):
+        return self.__offset
+
+    def tzname(self, dt):
+        return self.__name
+
+    def dst(self, dt):
+        return datetime.timedelta()
+
+
 class TestJSON(object):
     def test_ignore_cached_json(self, app):
         with app.test_request_context('/', method='POST', data='malformed',
@@ -180,9 +201,9 @@ class TestJSON(object):
     @pytest.mark.parametrize('tz', (('UTC', 0), ('PST', -8), ('KST', 9)))
     def test_jsonify_aware_datetimes(self, tz):
         """Test if aware datetime.datetime objects are converted into GMT."""
-        tzinfo = datetime.timezone(datetime.timedelta(hours=tz[1]), name=tz[0])
+        tzinfo = FixedOffset(hours=tz[1], name=tz[0])
         dt = datetime.datetime(2017, 1, 1, 12, 34, 56, tzinfo=tzinfo)
-        gmt = datetime.timezone(datetime.timedelta(), name='GMT')
+        gmt = FixedOffset(hours=0, name='GMT')
         expected = dt.astimezone(gmt).strftime('"%a, %d %b %Y %H:%M:%S %Z"')
         assert flask.json.JSONEncoder().encode(dt) == expected
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -23,6 +23,7 @@ from werkzeug.http import parse_cache_control_header, parse_options_header
 from werkzeug.http import http_date
 from flask._compat import StringIO, text_type
 from flask.helpers import get_debug_flag, make_response
+from pytz import timezone
 
 
 def has_encoding(name):
@@ -177,14 +178,14 @@ class TestJSON(object):
             assert rv.mimetype == 'application/json'
             assert flask.json.loads(rv.data)['x'] == http_date(d.timetuple())
 
-    @pytest.mark.parametrize('tz', (('UTC', 0), ('PST', -8), ('KST', 9)))
-    def test_jsonify_aware_datetimes(self, tz):
+    @pytest.mark.parametrize('tzname', ('UTC', 'PST8PDT', 'Asia/Seoul'))
+    def test_jsonify_aware_datetimes(self, tzname):
         """Test if aware datetime.datetime objects are converted into GMT."""
-        tzinfo = datetime.timezone(datetime.timedelta(hours=tz[1]), name=tz[0])
-        dt = datetime.datetime(2017, 1, 1, 12, 34, 56, tzinfo=tzinfo)
-        gmt = datetime.timezone(datetime.timedelta(), name='GMT')
-        expected = dt.astimezone(gmt).strftime('"%a, %d %b %Y %H:%M:%S %Z"')
-        assert flask.json.JSONEncoder().encode(dt) == expected
+        dt_naive = datetime.datetime(2017, 1, 1, 12, 34, 56)
+        dt_aware = timezone(tzname).localize(dt_naive)
+        dt_as_gmt = dt_aware.astimezone(timezone('GMT'))
+        expected = dt_as_gmt.strftime('"%a, %d %b %Y %H:%M:%S %Z"')
+        assert flask.json.JSONEncoder().encode(dt_aware) == expected
 
     def test_jsonify_uuid_types(self, app, client):
         """Test jsonify with uuid.UUID types"""

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ deps =
     coverage
     greenlet
     blinker
-    pytz
 
     lowest: Werkzeug==0.9
     lowest: Jinja2==2.4

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     coverage
     greenlet
     blinker
+    pytz
 
     lowest: Werkzeug==0.9
     lowest: Jinja2==2.4


### PR DESCRIPTION
http_date() requires timetuple in UTC, but JSONEncoder.default() was
passing a local timetuple instead.

This fixes #2372.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
