### PR TITLE
fix variable substitution in error message

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -203,9 +203,10 @@ def locate_app(script_info, app_id, raise_if_not_found=True):
             )
         elif raise_if_not_found:
             raise NoAppException(
-                'The file/path provided (%s) does not appear to exist. Please'
-                ' verify the path is correct. If app is not on PYTHONPATH,'
-                ' ensure the extension is .py.'.format(module=module)
+                'The file/path provided ({module}) does not appear to exist.'
+                ' Please verify the path is correct. If app is not on'
+                ' PYTHONPATH, ensure the extension is .py.'.format(
+                    module=module)
             )
         else:
             return


### PR DESCRIPTION
@davidism looks like you've made a small mistake in how the module variable is replaced in the error message when you edited my commit from a few days ago. This should address it.