### PR TITLE
Remove unused import from test_basic.

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -9,7 +9,6 @@
     :license: BSD, see LICENSE for more details.
 """
 
-import pickle
 import re
 import time
 import uuid


### PR DESCRIPTION
Describe what this patch does to fix the issue.
Removed the unused import of `pickle` in `tests/test_basic`.

Link to any relevant issues or pull requests.

Pickle isn't used explicitly in the file, and I ran the tests and they all still pass.
