### PR TITLE
Clarify docs and tests for exception handling in Flask.teardown_appcontext()

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -1485,8 +1485,8 @@ class Flask(_PackageBoundObject):
         context it would also be called when you pop a request context.
 
         When a teardown function was called because of an unhandled exception
-        it will be passed an error object.  Note that if a :meth:`errorhandler`
-        is registered, it will handle the exception and the teardown will not
+        it will be passed an error object. If an :meth:`errorhandler` is
+        registered, it will handle the exception and the teardown will not
         receive it.
 
         The return values of teardown functions are ignored.

--- a/flask/app.py
+++ b/flask/app.py
@@ -1484,8 +1484,10 @@ class Flask(_PackageBoundObject):
         Since a request context typically also manages an application
         context it would also be called when you pop a request context.
 
-        When a teardown function was called because of an exception it will
-        be passed an error object.
+        When a teardown function was called because of an unhandled exception
+        it will be passed an error object.  Note that if a :meth:`errorhandler`
+        is registered, it will handle the exception and the teardown will not
+        receive it.
 
         The return values of teardown functions are ignored.
 

--- a/tests/test_appctx.py
+++ b/tests/test_appctx.py
@@ -81,7 +81,7 @@ def test_app_tearing_down_with_previous_exception(app):
     assert cleanup_stuff == [None]
 
 
-def test_app_tearing_down_with_handled_exception(app):
+def test_app_tearing_down_with_handled_exception_by_except_block(app):
     cleanup_stuff = []
 
     @app.teardown_appcontext
@@ -95,6 +95,57 @@ def test_app_tearing_down_with_handled_exception(app):
             pass
 
     assert cleanup_stuff == [None]
+
+
+def test_app_tearing_down_with_handled_exception_by_app_handler(app):
+    cleanup_stuff = []
+
+    class AppConfig():
+        PROPAGATE_EXCEPTIONS = True
+    app.config.from_object(AppConfig())
+
+    @app.teardown_appcontext
+    def cleanup(exception):
+        cleanup_stuff.append(exception)
+
+    @app.route('/')
+    def index():
+        raise Exception('dummy')
+
+    @app.errorhandler(Exception)
+    def handler(f):
+        return flask.jsonify(str(f))
+
+    test_client = app.test_client()
+    with app.app_context():
+        test_client.get('/')
+
+    assert cleanup_stuff == [None]
+
+
+def test_app_tearing_down_with_unhandled_exception(app):
+    cleanup_stuff = []
+
+    class AppConfig():
+        PROPAGATE_EXCEPTIONS = True
+    app.config.from_object(AppConfig())
+
+    @app.teardown_appcontext
+    def cleanup(exception):
+        cleanup_stuff.append(exception)
+
+    @app.route('/')
+    def index():
+        raise Exception('dummy')
+
+    test_client = app.test_client()
+    with pytest.raises(Exception):
+        with app.app_context():
+            test_client.get('/')
+
+    assert len(cleanup_stuff) == 1
+    assert isinstance(cleanup_stuff[0], Exception)
+    assert str(cleanup_stuff[0]) == 'dummy'
 
 
 def test_app_ctx_globals_methods(app, app_ctx):

--- a/tests/test_appctx.py
+++ b/tests/test_appctx.py
@@ -97,12 +97,9 @@ def test_app_tearing_down_with_handled_exception_by_except_block(app):
     assert cleanup_stuff == [None]
 
 
-def test_app_tearing_down_with_handled_exception_by_app_handler(app):
+def test_app_tearing_down_with_handled_exception_by_app_handler(app, client):
+    app.config['PROPAGATE_EXCEPTIONS'] = True
     cleanup_stuff = []
-
-    class AppConfig():
-        PROPAGATE_EXCEPTIONS = True
-    app.config.from_object(AppConfig())
 
     @app.teardown_appcontext
     def cleanup(exception):
@@ -116,19 +113,15 @@ def test_app_tearing_down_with_handled_exception_by_app_handler(app):
     def handler(f):
         return flask.jsonify(str(f))
 
-    test_client = app.test_client()
     with app.app_context():
-        test_client.get('/')
+        client.get('/')
 
     assert cleanup_stuff == [None]
 
 
-def test_app_tearing_down_with_unhandled_exception(app):
+def test_app_tearing_down_with_unhandled_exception(app, client):
+    app.config['PROPAGATE_EXCEPTIONS'] = True
     cleanup_stuff = []
-
-    class AppConfig():
-        PROPAGATE_EXCEPTIONS = True
-    app.config.from_object(AppConfig())
 
     @app.teardown_appcontext
     def cleanup(exception):
@@ -138,10 +131,9 @@ def test_app_tearing_down_with_unhandled_exception(app):
     def index():
         raise Exception('dummy')
 
-    test_client = app.test_client()
     with pytest.raises(Exception):
         with app.app_context():
-            test_client.get('/')
+            client.get('/')
 
     assert len(cleanup_stuff) == 1
     assert isinstance(cleanup_stuff[0], Exception)


### PR DESCRIPTION
I had asked to clarify the behavior for in the IRC channel on [2017-07-01](https://botbot.me/freenode/pocoo/2017-07-01/?tz=America/Los_Angeles) and [2017-07-03](https://botbot.me/freenode/pocoo/2017-07-03/?tz=America/Los_Angeles) but did not get a reply.

So I've updated the documentation and regression tests to prove and clarify that [Flask.teardown_appcontext()](http://flask.pocoo.org/docs/0.11/api/#flask.Flask.errorhandler) only receives **unhandled** exceptions.
- [x] Added tests that fail without the patch
- [x] Ensured all tests pass with ``pytest``
- [x] Added documentation to the relevant docstrings or pages

Since the application code was _not_ modified:
* No ``versionadded`` or ``versionchanged`` directives were added
* No changelog entry was added

