### PR TITLE
support passing environ to test client

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -97,6 +97,8 @@ Major release, unreleased
     - ``Request.module`` - use ``Request.blueprint`` instead.
 
 - The ``request.json`` property is no longer deprecated. (`#1421`_)
+- Support passing an existing ``EnvironBuilder`` or ``dict`` to
+  ``test_client.open``. (`#2412`_)
 
 .. _#1421: https://github.com/pallets/flask/issues/1421
 .. _#1489: https://github.com/pallets/flask/pull/1489
@@ -124,6 +126,7 @@ Major release, unreleased
 .. _#2374: https://github.com/pallets/flask/pull/2374
 .. _#2373: https://github.com/pallets/flask/pull/2373
 .. _#2385: https://github.com/pallets/flask/issues/2385
+.. _#2412: https://github.com/pallets/flask/pull/2412
 
 Version 0.12.2
 --------------


### PR DESCRIPTION
This allows passing an `EnvironBuilder` or `dict` as the only argument to `flask.testing.FlaskClient.open`, similar to `werkzeug.test.Client.open`. Since `FlaskClient` does some other configuration for the environ, this makes sure that a passed environ is copied and modified appropriately.

closes #2411
