### PR TITLE
FLASK_APP doesn't require .py extension for local packages

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -52,6 +52,8 @@ Major release, unreleased
 - FLASK_APP=myproject.app:create_app('dev') support.
 - ``FLASK_APP`` can be set to an app factory, with arguments if needed, for
   example ``FLASK_APP=myproject.app:create_app('dev')``. (`#2326`_)
+- ``FLASK_APP`` can point to local packages that are not installed in dev mode,
+  although `pip install -e` should still be preferred. (`#2414`_)
 - ``View.provide_automatic_options = True`` is set on the view function from
   ``View.as_view``, to be detected in ``app.add_url_rule``. (`#2316`_)
 - Error handling will try handlers registered for ``blueprint, code``,
@@ -127,6 +129,7 @@ Major release, unreleased
 .. _#2373: https://github.com/pallets/flask/pull/2373
 .. _#2385: https://github.com/pallets/flask/issues/2385
 .. _#2412: https://github.com/pallets/flask/pull/2412
+.. _#2414: https://github.com/pallets/flask/pull/2414
 
 Version 0.12.2
 --------------

--- a/tests/test_apps/cliapp/factory.py
+++ b/tests/test_apps/cliapp/factory.py
@@ -4,12 +4,12 @@ from flask import Flask
 
 
 def create_app():
-    return Flask('create_app')
+    return Flask('app')
 
 
 def create_app2(foo, bar):
-    return Flask("_".join(['create_app2', foo, bar]))
+    return Flask('_'.join(['app2', foo, bar]))
 
 
-def create_app3(foo, bar, script_info):
-    return Flask("_".join(['create_app3', foo, bar]))
+def create_app3(foo, script_info):
+    return Flask('_'.join(['app3', foo, script_info.data['test']]))

--- a/tests/test_apps/cliapp/inner1/__init__.py
+++ b/tests/test_apps/cliapp/inner1/__init__.py
@@ -1,0 +1,3 @@
+from flask import Flask
+
+application = Flask(__name__)

--- a/tests/test_apps/cliapp/inner1/inner2/flask.py
+++ b/tests/test_apps/cliapp/inner1/inner2/flask.py
@@ -1,0 +1,3 @@
+from flask import Flask
+
+app = Flask(__name__)

--- a/tests/test_apps/cliapp/message.txt
+++ b/tests/test_apps/cliapp/message.txt
@@ -1,0 +1,1 @@
+So long, and thanks for all the fish.


### PR DESCRIPTION
This drops the requirement where `FLASK_APP` had to point to a `.py` file for packages that were not installed in develop mode. If the file is not importable, it will fail later in the loading process.

Also adds some more tests for the loading mechanism and refactors the tests with `pytest.mark.parametrize`.

Closes #2377 