### PR TITLE
Add .env support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+.env
+.flaskenv
 *.pyc
 *.pyo
 env

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,11 @@ script:
 cache:
   - pip
 
+branches:
+  only:
+    - master
+    - /^.*-maintenance$/
+
 notifications:
   email: false
   irc:

--- a/CHANGES
+++ b/CHANGES
@@ -101,6 +101,9 @@ Major release, unreleased
 - The ``request.json`` property is no longer deprecated. (`#1421`_)
 - Support passing an existing ``EnvironBuilder`` or ``dict`` to
   ``test_client.open``. (`#2412`_)
+- The ``flask`` command and ``app.run`` will load environment variables using
+  from ``.env`` and ``.flaskenv`` files if python-dotenv is installed.
+  (`#2416`_)
 
 .. _#1421: https://github.com/pallets/flask/issues/1421
 .. _#1489: https://github.com/pallets/flask/pull/1489
@@ -130,6 +133,7 @@ Major release, unreleased
 .. _#2385: https://github.com/pallets/flask/issues/2385
 .. _#2412: https://github.com/pallets/flask/pull/2412
 .. _#2414: https://github.com/pallets/flask/pull/2414
+.. _#2416: https://github.com/pallets/flask/pull/2416
 
 Version 0.12.2
 --------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -814,6 +814,8 @@ Command Line Interface
 .. autoclass:: ScriptInfo
    :members:
 
+.. autofunction:: load_dotenv
+
 .. autofunction:: with_appcontext
 
 .. autofunction:: pass_script_info

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -97,9 +97,8 @@ Custom Commands
 ---------------
 
 If you want to add more commands to the shell script you can do this
-easily.  Flask uses `click`_ for the command interface which makes
-creating custom commands very easy.  For instance if you want a shell
-command to initialize the database you can do this::
+easily. For instance if you want a shell command to initialize the database you
+can do this::
 
     import click
     from flask import Flask
@@ -133,6 +132,35 @@ decorator::
     @app.cli.command(with_appcontext=False)
     def example():
         pass
+
+
+.. _dotenv:
+
+Loading Environment Variables From ``.env`` Files
+-------------------------------------------------
+
+If `python-dotenv`_ is installed, running the :command:`flask` command will set
+environment variables defined in the files :file:`.env` and :file:`.flaskenv`.
+This can be used to avoid having to set ``FLASK_APP`` manually every time you
+open a new terminal, and to set configuration using environment variables
+similar to how some deployment services work.
+
+Variables set on the command line are used over those set in :file:`.env`,
+which are used over those set in :file:`.flaskenv`. :file:`.flaskenv` should be
+used for public variables, such as ``FLASK_APP``, while :file:`.env` should not
+be committed to your repository so that it can set private variables.
+
+Directories are scanned upwards from the directory you call :command:`flask`
+from to locate the files. The current working directory will be set to the
+location of the file, with the assumption that that is the top level project
+directory.
+
+The files are only loaded by the :command:`flask` command or calling
+:meth:`~flask.Flask.run`. If you would like to load these files when running in
+production, you should call :func:`~flask.cli.load_dotenv` manually.
+
+.. _python-dotenv: https://github.com/theskumar/python-dotenv#readme
+
 
 Factory Functions
 -----------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -41,9 +41,12 @@ use them if you install them.
 * `SimpleJSON`_ is a fast JSON implementation that is compatible with
   Python's ``json`` module. It is preferred for JSON operations if it is
   installed.
+* `python-dotenv`_ enables support for :ref:`dotenv` when running ``flask``
+  commands.
 
 .. _Blinker: https://pythonhosted.org/blinker/
 .. _SimpleJSON: https://simplejson.readthedocs.io/
+.. _python-dotenv: https://github.com/theskumar/python-dotenv#readme
 
 Virtual environments
 --------------------

--- a/flask/app.py
+++ b/flask/app.py
@@ -820,7 +820,9 @@ class Flask(_PackageBoundObject):
         self.debug = debug
         self.jinja_env.auto_reload = self.templates_auto_reload
 
-    def run(self, host=None, port=None, debug=None, **options):
+    def run(
+        self, host=None, port=None, debug=None, load_dotenv=True, **options
+    ):
         """Runs the application on a local development server.
 
         Do not use ``run()`` in a production setting. It is not intended to
@@ -849,29 +851,39 @@ class Flask(_PackageBoundObject):
            won't catch any exceptions because there won't be any to
            catch.
 
+        :param host: the hostname to listen on. Set this to ``'0.0.0.0'`` to
+            have the server available externally as well. Defaults to
+            ``'127.0.0.1'`` or the host in the ``SERVER_NAME`` config variable
+            if present.
+        :param port: the port of the webserver. Defaults to ``5000`` or the
+            port defined in the ``SERVER_NAME`` config variable if present.
+        :param debug: if given, enable or disable debug mode. See
+            :attr:`debug`.
+        :param load_dotenv: Load the nearest :file:`.env` and :file:`.flaskenv`
+            files to set environment variables. Will also change the working
+            directory to the directory containing the first file found.
+        :param options: the options to be forwarded to the underlying Werkzeug
+            server. See :func:`werkzeug.serving.run_simple` for more
+            information.
+
+        .. versionchanged:: 1.0
+            If installed, python-dotenv will be used to load environment
+            variables from :file:`.env` and :file:`.flaskenv` files.
+
         .. versionchanged:: 0.10
            The default port is now picked from the ``SERVER_NAME`` variable.
 
-        :param host: the hostname to listen on. Set this to ``'0.0.0.0'`` to
-                     have the server available externally as well. Defaults to
-                     ``'127.0.0.1'`` or the host in the ``SERVER_NAME`` config
-                     variable if present.
-        :param port: the port of the webserver. Defaults to ``5000`` or the
-                     port defined in the ``SERVER_NAME`` config variable if
-                     present.
-        :param debug: if given, enable or disable debug mode.
-                      See :attr:`debug`.
-        :param options: the options to be forwarded to the underlying
-                        Werkzeug server.  See
-                        :func:`werkzeug.serving.run_simple` for more
-                        information.
         """
         # Change this into a no-op if the server is invoked from the
         # command line.  Have a look at cli.py for more information.
-        if os.environ.get('FLASK_RUN_FROM_CLI_SERVER') == '1':
+        if os.environ.get('FLASK_RUN_FROM_CLI') == 'true':
             from .debughelpers import explain_ignored_app_run
             explain_ignored_app_run()
             return
+
+        if load_dotenv:
+            from flask.cli import load_dotenv
+            load_dotenv()
 
         if debug is not None:
             self._reconfigure_for_run_debug(bool(debug))

--- a/setup.py
+++ b/setup.py
@@ -75,8 +75,10 @@ setup(
         'click>=4.0',
     ],
     extras_require={
+        'dotenv': ['python-dotenv'],
         'dev': [
             'blinker',
+            'python-dotenv',
             'greenlet',
             'pytest>=3',
             'coverage',

--- a/tests/test_apps/.env
+++ b/tests/test_apps/.env
@@ -1,0 +1,3 @@
+FOO=env
+SPAM=1
+EGGS=2

--- a/tests/test_apps/.flaskenv
+++ b/tests/test_apps/.flaskenv
@@ -1,0 +1,3 @@
+FOO=flaskenv
+BAR=bar
+EGGS=0

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     coverage
     greenlet
     blinker
+    python-dotenv
 
     lowest: Werkzeug==0.9
     lowest: Jinja2==2.4
@@ -67,4 +68,4 @@ skip_install = true
 deps = detox
 commands =
     detox -e py{36,35,34,33,27,26,py},py{36,27,py}-simplejson,py{36,33,27,26,py}-devel,py{36,33,27,26,py}-lowest
-    tox -e coverage-report
+    tox -e docs-html,coverage-report


### PR DESCRIPTION
If installed, [python-dotenv](https://github.com/theskumar/python-dotenv#readme) is used to load environment variables from `.env` and `.flaskenv` files. Manual vars override `.env`, which overrides `.flaskenv`. `.flaskenv` is intended for public vars, `.env` is intended for private vars that won't be committed to the repository.

The working directory is set to the location of the files, with the assumption that they are in the top level of the project, to facilitate local package imports (#2383).

The files are only loaded when calling the `flask` command or `app.run`, and can be disabled by passing `load_dotenv=False` to a custom `FlaskGroup` or `app.run`. If a user wants to load dotenv files in production, they can call `flask.cli.load_dotenv` manually from a `wsgi.py` file.

Closes #2375
Based off #2164 

---

Example, assuming python-dotenv is installed:

`flaskr/app.py`:

```python
from flask import Flask

def create_app():
    return Flask('flaskr')
```

`.flaskenv`:

```
FLASK_APP=flaskr.app
```

```
flask run
# no need to set FLASK_APP
# no need for intermediate file to call create_app
```