### PR TITLE
[0.12.x] Remove outdated text on flask.ext redirect package

### DIFF
--- a/docs/extensiondev.rst
+++ b/docs/extensiondev.rst
@@ -29,12 +29,6 @@ be something like "Flask-SimpleXML".  Make sure to include the name
 This is how users can then register dependencies to your extension in
 their :file:`setup.py` files.
 
-Flask sets up a redirect package called :data:`flask.ext` where users
-should import the extensions from.  If you for instance have a package
-called ``flask_something`` users would import it as
-``flask.ext.something``.  This is done to transition from the old
-namespace packages.  See :ref:`ext-import-transition` for more details.
-
 But what do extensions look like themselves?  An extension has to ensure
 that it works with multiple Flask application instances at once.  This is
 a requirement because many people will use patterns like the


### PR DESCRIPTION
...from 0.12.x documentation. i.e. here: http://flask.pocoo.org/docs/0.12/extensiondev/#ext-import-transition

I noticed that the live documentation for 0.12.x has this paragraph on the current stable version saying that the flask.ext. namespace should be used. This is deprecated since 0.11.x right? The development version has that paragraph removed, so I just did the same for this branch.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
