### PR TITLE
make_test_environ_builder: use url_scheme from path if provided

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -104,6 +104,8 @@ Major release, unreleased
 - The ``flask`` command and ``app.run`` will load environment variables using
   from ``.env`` and ``.flaskenv`` files if python-dotenv is installed.
   (`#2416`_)
+- When passing a full URL to the test client, use the scheme in the URL instead
+  of the ``PREFERRED_URL_SCHEME``. (`#2436`_)
 
 .. _#1421: https://github.com/pallets/flask/issues/1421
 .. _#1489: https://github.com/pallets/flask/pull/1489
@@ -134,6 +136,7 @@ Major release, unreleased
 .. _#2412: https://github.com/pallets/flask/pull/2412
 .. _#2414: https://github.com/pallets/flask/pull/2414
 .. _#2416: https://github.com/pallets/flask/pull/2416
+.. _#2436: https://github.com/pallets/flask/pull/2436
 
 Version 0.12.2
 --------------

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -40,10 +40,10 @@ def make_test_environ_builder(
         if subdomain:
             http_host = '{0}.{1}'.format(subdomain, http_host)
 
+	url = url_parse(path)
         if url_scheme is None:
-            url_scheme = app.config['PREFERRED_URL_SCHEME']
+            url_scheme = url.scheme or app.config['PREFERRED_URL_SCHEME']
 
-        url = url_parse(path)
         base_url = '{0}://{1}/{2}'.format(
             url_scheme, url.netloc or http_host, app_root.lstrip('/')
         )

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -40,12 +40,14 @@ def make_test_environ_builder(
         if subdomain:
             http_host = '{0}.{1}'.format(subdomain, http_host)
 
-	url = url_parse(path)
         if url_scheme is None:
-            url_scheme = url.scheme or app.config['PREFERRED_URL_SCHEME']
+            url_scheme = app.config['PREFERRED_URL_SCHEME']
 
-        base_url = '{0}://{1}/{2}'.format(
-            url_scheme, url.netloc or http_host, app_root.lstrip('/')
+        url = url_parse(path)
+        base_url = '{scheme}://{netloc}/{path}'.format(
+            scheme=url.scheme or url_scheme,
+            netloc=url.netloc or http_host,
+            path=app_root.lstrip('/')
         )
         path = url.path
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -104,6 +104,14 @@ def test_specify_url_scheme(app, client):
     assert rv.data == b'https://localhost/'
 
 
+def test_path_is_url(app):
+    eb = make_test_environ_builder(app, 'https://example.com/')
+    assert eb.url_scheme == 'https'
+    assert eb.host == 'example.com'
+    assert eb.script_root == ''
+    assert eb.path == '/'
+
+
 def test_blueprint_with_subdomain(app, client):
     app.config['SERVER_NAME'] = 'example.com:1234'
     app.config['APPLICATION_ROOT'] = '/foo'


### PR DESCRIPTION
When providing https url in path ("https://example.com/")
we hope that we will get https scheme in environment

