### PR TITLE
Add clean command to flask cli

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -697,6 +697,28 @@ def routes_command(sort, all_methods):
         click.echo(row.format(rule.endpoint, methods, rule.rule).rstrip())
 
 
+@click.command('clean', short_help='Clean python compile file.')
+@with_appcontext
+def clean_command():
+    """Clean all the .pyc and .pyo files recursively starting at 
+    the path to the root of the application.
+    """
+    from flask.globals import _app_ctx_stack
+    app = _app_ctx_stack.top.app
+    
+    root_path = app.root_path
+    if not root_path:
+        return click.echo('The path to the root of the application was not found, '
+                          'please define it through app.root_path manually.')
+
+    for dirpath, dirnames, filenames in os.walk(app.root_path):
+        for filename in filenames:
+            if filename.endswith('.pyc') or filename.endswith('.pyo'):
+                full_pathname = os.path.join(dirpath, filename)
+                click.echo('Removing %s' % full_pathname)
+                os.remove(full_pathname)
+
+
 cli = FlaskGroup(help="""\
 This shell command acts as general utility script for Flask applications.
 

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -429,6 +429,7 @@ class FlaskGroup(AppGroup):
             self.add_command(run_command)
             self.add_command(shell_command)
             self.add_command(routes_command)
+            self.add_command(clean_command)
 
         self._loaded_plugin_commands = False
 


### PR DESCRIPTION
The added command `flask clean` can be used to remove all the `.pyc` and `.pyo` file recursively starting at the path to the root of the application. Similar to Flask-Script's `clean` command.