### PR TITLE
Casting the value received from the Web Server in the request object …

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -43,6 +43,8 @@ _sentinel = object()
 
 def _make_timedelta(value):
     if not isinstance(value, timedelta):
+        if isinstance(value, str):
+            value = int(value)
         return timedelta(seconds=value)
     return value
 


### PR DESCRIPTION
Casting the value received from the Web Server in the request object if it is a string

I'm using apache2 with libapache2-mod-wsgi-py3 When flask tries to convert the permanent_session_lifetime the following error appears.

```
[Mon Aug 07 20:22:54.177034 2017] [wsgi:error] [pid 21324:tid 139774833305344] [remote 172.17.0.1:38058] mod_wsgi (pid=21324): Exception occurred processing WSGI script '/var/www/app/web/run.wsgi'.
[Mon Aug 07 20:22:54.177830 2017] [wsgi:error] [pid 21324:tid 139774833305344] [remote 172.17.0.1:38058] Traceback (most recent call last):
[Mon Aug 07 20:22:54.177881 2017] [wsgi:error] [pid 21324:tid 139774833305344] [remote 172.17.0.1:38058]   File "/var/www/app/instance/venv/lib/python3.5/site-packages/flask/app.py", line 1998, in __call__
[Mon Aug 07 20:22:54.177889 2017] [wsgi:error] [pid 21324:tid 139774833305344] [remote 172.17.0.1:38058]     return self.wsgi_app(environ, start_response)
[Mon Aug 07 20:22:54.177902 2017] [wsgi:error] [pid 21324:tid 139774833305344] [remote 172.17.0.1:38058]   File "/var/www/app/instance/venv/lib/python3.5/site-packages/flask/app.py", line 1979, in wsgi_app
[Mon Aug 07 20:22:54.177908 2017] [wsgi:error] [pid 21324:tid 139774833305344] [remote 172.17.0.1:38058]     ctx.push()
[Mon Aug 07 20:22:54.177919 2017] [wsgi:error] [pid 21324:tid 139774833305344] [remote 172.17.0.1:38058]   File "/var/www/app/instance/venv/lib/python3.5/site-packages/flask/ctx.py", line 332, in push
[Mon Aug 07 20:22:54.177925 2017] [wsgi:error] [pid 21324:tid 139774833305344] [remote 172.17.0.1:38058]     self.session = self.app.open_session(self.request)
[Mon Aug 07 20:22:54.177935 2017] [wsgi:error] [pid 21324:tid 139774833305344] [remote 172.17.0.1:38058]   File "/var/www/app/instance/venv/lib/python3.5/site-packages/flask/app.py", line 913, in open_session
[Mon Aug 07 20:22:54.177941 2017] [wsgi:error] [pid 21324:tid 139774833305344] [remote 172.17.0.1:38058]     return self.session_interface.open_session(self, request)
[Mon Aug 07 20:22:54.177953 2017] [wsgi:error] [pid 21324:tid 139774833305344] [remote 172.17.0.1:38058]   File "/var/www/app/instance/venv/lib/python3.5/site-packages/flask/sessions.py", line 330, in open_session
[Mon Aug 07 20:22:54.177958 2017] [wsgi:error] [pid 21324:tid 139774833305344] [remote 172.17.0.1:38058]     max_age = total_seconds(app.permanent_session_lifetime)
[Mon Aug 07 20:22:54.177970 2017] [wsgi:error] [pid 21324:tid 139774833305344] [remote 172.17.0.1:38058]   File "/var/www/app/instance/venv/lib/python3.5/site-packages/flask/config.py", line 33, in __get__
[Mon Aug 07 20:22:54.177975 2017] [wsgi:error] [pid 21324:tid 139774833305344] [remote 172.17.0.1:38058]     rv = self.get_converter(rv)
[Mon Aug 07 20:22:54.177987 2017] [wsgi:error] [pid 21324:tid 139774833305344] [remote 172.17.0.1:38058]   File "/var/www/app/instance/venv/lib/python3.5/site-packages/flask/app.py", line 47, in _make_timedelta
[Mon Aug 07 20:22:54.177993 2017] [wsgi:error] [pid 21324:tid 139774833305344] [remote 172.17.0.1:38058]     return timedelta(seconds=value)
[Mon Aug 07 20:22:54.178022 2017] [wsgi:error] [pid 21324:tid 139774833305344] [remote 172.17.0.1:38058] TypeError: unsupported type for timedelta seconds component: str
```

With that pull, the permanent_session_lifetime and send_file_max_age_default will be converted correctly from string type value.