### PR TITLE
Add version warning to Flaskr tutorial

### DIFF
--- a/docs/tutorial/introduction.rst
+++ b/docs/tutorial/introduction.rst
@@ -22,6 +22,11 @@ connections in a more intelligent way, allowing you to target different
 relational databases at once and more.  You might also want to consider
 one of the popular NoSQL databases if your data is more suited for those.
 
+.. warning::
+   If you're following the tutorial from a specific version of the docs, be
+   sure to check out the same tag in the repository, otherwise the tutorial
+   may be different than the example.
+
 Here is a screenshot of the final application:
 
 .. image:: ../_static/flaskr.png


### PR DESCRIPTION
Adds a warning to the Flaskr tutorial to tell folks looking at a specific version of the docs, to be sure to check out the same tag in the repository, otherwise the tutorial may be different than the example. 

Issues with docs/code version mismatches reported in https://github.com/pallets/flask/issues/2437 and https://github.com/pallets/flask/issues/1902