### PR TITLE
replace @pytest.yield_fixture by @pytest.fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,7 +161,7 @@ def purge_module(request):
     return inner
 
 
-@pytest.yield_fixture(autouse=True)
+@pytest.fixture(autouse=True)
 def catch_deprecation_warnings(recwarn):
     yield
     gc.collect()


### PR DESCRIPTION
It's suggested to use pytest.fixture directly, and flask already requires 'pytest>=3'.



<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
