### PR TITLE
Blueprint view function name should not contain dots

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -112,6 +112,7 @@ Major release, unreleased
   ``app.debug`` each time. Only one format is used, not different ones
   depending on ``app.debug``. No handlers are removed, and a handler is only
   added if no handlers are already configured. (`#2436`_)
+- Blueprint view function name may not contain dots. (`#2450`_)
 
 .. _#1421: https://github.com/pallets/flask/issues/1421
 .. _#1489: https://github.com/pallets/flask/pull/1489
@@ -144,6 +145,7 @@ Major release, unreleased
 .. _#2416: https://github.com/pallets/flask/pull/2416
 .. _#2430: https://github.com/pallets/flask/pull/2430
 .. _#2436: https://github.com/pallets/flask/pull/2436
+.. _#2450: https://github.com/pallets/flask/pull/2450
 
 Version 0.12.2
 --------------

--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -198,6 +198,8 @@ class Blueprint(_PackageBoundObject):
         """
         if endpoint:
             assert '.' not in endpoint, "Blueprint endpoints should not contain dots"
+        if view_func:
+            assert '.' not in view_func.__name__, "Blueprint view function name should not contain dots"
         self.record(lambda s:
             s.add_url_rule(rule, endpoint, view_func, **options))
 

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -360,6 +360,15 @@ def test_route_decorator_custom_endpoint_with_dots(app, client):
         lambda: None
     )
 
+    foo_foo_foo.__name__ = 'bar.123'
+
+    pytest.raises(
+        AssertionError,
+        lambda: bp.add_url_rule(
+            '/bar/123', view_func=foo_foo_foo
+        )
+    )
+
     app.register_blueprint(bp, url_prefix='/py')
 
     assert client.get('/py/foo').data == b'bp.foo'


### PR DESCRIPTION


I want to use `before_request` function to my `blueprint`. here is my usecase:


```
from flask import Flask, Blueprint, request, abort
from flask.views import MethodView


app = Flask(__name__)
system = Blueprint('system', __name__, url_prefix='/system')


@system.before_request
def auth():
    if not request.headers.get('token', None):
        abort(401)


class UserView(MethodView):
    def get(self):
        return 'user list'


class UserProfileView(MethodView):
    def get(self, id):
        return 'hello {}'.format(id)


system.add_url_rule('/user', view_func=UserView.as_view('user'))
system.add_url_rule('/user/<int:id>/profile', view_func=UserProfileView.as_view('user.profile'))

app.register_blueprint(system)

app.run(debug=True)

```

when I test `/system/user`, `auth` function can work, when I test `/system/user/1/profile` it doesn't work.

so I debug my code on shell:

```
In [1]: from test import app

In [2]: app
Out[2]: <Flask 'test'>

In [3]: app.blueprints
Out[3]: {'system': <flask.blueprints.Blueprint at 0x1020bc850>}

In [4]: from flask import request

In [5]: with app.test_request_context('/system/user'):
   ...:     print request.blueprint
   ...:
system

In [6]: with app.test_request_context('/system/user/1/profile'):
   ...:     print request.blueprint
   ...:
system.user
```

it's ridiculous!

so I read the [flask/wrapper.py](https://github.com/pallets/flask/blob/7c510199850957161240f081359e2246d8982be1/flask/wrappers.py#L152)

```
@property
def blueprint(self):
   """The name of the current blueprint"""
   if self.url_rule and '.' in self.url_rule.endpoint:
       return self.url_rule.endpoint.rsplit('.', 1)[0]
```

I know my view function endpoint name is not normative.

I think Blueprint endpoints should not contain dots. view function name can instead endpoint when endpoint is none, so view function name should not contain dots either.


sorry for my bad English. I'm shame it!


