### PR TITLE
parse cli command's args with the application context

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -377,7 +377,9 @@ class AppGroup(click.Group):
         def decorator(f):
             if wrap_for_ctx:
                 f = with_appcontext(f)
-            return click.Group.command(self, *args, **kwargs)(f)
+                cmd = click.Group.command(self, *args, **kwargs)(f)
+                cmd.parse_args = with_appcontext(cmd.parse_args)
+            return cmd
         return decorator
 
     def group(self, *args, **kwargs):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -317,6 +317,13 @@ def test_appgroup(runner):
     def test():
         click.echo(current_app.name)
 
+    @cli.command(with_appcontext=True)
+    @click.argument(
+        "arg", callback=lambda ctx, param, value: current_app.name
+    )
+    def test_callback(arg):
+        click.echo(arg)
+
     @cli.group()
     def subgroup():
         pass
@@ -328,6 +335,10 @@ def test_appgroup(runner):
     obj = ScriptInfo(create_app=lambda info: Flask("testappgroup"))
 
     result = runner.invoke(cli, ['test'], obj=obj)
+    assert result.exit_code == 0
+    assert result.output == 'testappgroup\n'
+
+    result = runner.invoke(cli, ['test_callback', 'arg'], obj=obj)
     assert result.exit_code == 0
     assert result.output == 'testappgroup\n'
 


### PR DESCRIPTION
this allows to use application object in a callbacks, resolves #2410
