### PR TITLE
Add additional information in the url_rule docs

### DIFF
--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -119,6 +119,10 @@ class Request(RequestBase, JSONMixin):
     #: The internal URL rule that matched the request.  This can be
     #: useful to inspect which methods are allowed for the URL from
     #: a before/after handler (``request.url_rule.methods``) etc.
+    #: Though if the request's method was invalid for the URL rule,
+    #: the valid list is available in ``routing_exception.valid_methods``
+    #: instead (an attribute of the Werkzeug exception :exc:`~werkzeug.exceptions.MethodNotAllowed`)
+    #: because the request was never internally bound. 
     #:
     #: .. versionadded:: 0.6
     url_rule = None


### PR DESCRIPTION
Small doc change because it is not documented anywhere else and may be confusing. 

If a user is making use of the `@errorhandler(405)` decorator, and they wish to include an Allow header (as per HTTP spec), they may be confused to find that url_rule is None (when they were attempting to get the allowed methods). While an experienced Flask user knows why this won't work, it may be unclear to a new user who is attempting to conform to HTTP. 

This doc change aims to clarify that: because the request was never successfully matched, it was never bound to a URL rule.  In order to access the valid methods, they must examine `routing_exception` instead.

Doc change only, no uncommented code is affected. 
