### PR TITLE
Fix Travis CI argparse import error on Python 2.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
     greenlet
     blinker
     python-dotenv
+    argparse
 
     lowest: Werkzeug==0.9
     lowest: Jinja2==2.4


### PR DESCRIPTION
Tracebacks in [Travis CI](https://travis-ci.org/pallets/flask/jobs/278955320) :
```pytb
codecov runtests: commands[2] | codecov
Traceback (most recent call last):
  File "/home/travis/build/pallets/flask/.tox/codecov/bin/codecov", line 7, in <module>
    from codecov import main
  File "/home/travis/build/pallets/flask/.tox/codecov/lib/python2.6/site-packages/codecov/__init__.py", line 8, in <module>
    import argparse
ImportError: No module named argparse
ERROR: InvocationError: '/home/travis/build/pallets/flask/.tox/codecov/bin/codecov'
___________________________________ summary ____________________________________
  py: commands succeeded
ERROR:   codecov: commands failed
```

Tips in [argparse's PyPI page](https://pypi.python.org/pypi/argparse):
> As of Python >= 2.7 and >= 3.2, the argparse module is maintained within the Python standard library. For users who still need to support Python < 2.7 or < 3.2, it is also provided as a separate package, which tries to stay compatible with the module in the standard library, but also supports older Python versions.

Relevant pull request: #2475 