### PR TITLE
Drop unsupported Python 2.6 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
       env: TOXENV=py,codecov
     - python: 3.4
       env: TOXENV=py,codecov
-    - python: 3.3
-      env: TOXENV=py,codecov
     - python: 2.7
       env: TOXENV=py,codecov
     - python: pypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
       env: TOXENV=py,codecov
     - python: 2.7
       env: TOXENV=py,codecov
-    - python: 2.6
-      env: TOXENV=py,codecov
     - python: pypy
       env: TOXENV=py,codecov
     - python: nightly

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -109,7 +109,7 @@ depends on which part of Flask you're working on. Travis-CI will run the full
 suite when you submit your pull request.
 
 The full test suite takes a long time to run because it tests multiple
-combinations of Python and dependencies. You need to have Python 2.6, 2.7, 3.3,
+combinations of Python and dependencies. You need to have Python 2.7, 3.3,
 3.4, 3.5 3.6, and PyPy 2.7 installed to run all of the environments. Then run::
 
     tox

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -109,8 +109,8 @@ depends on which part of Flask you're working on. Travis-CI will run the full
 suite when you submit your pull request.
 
 The full test suite takes a long time to run because it tests multiple
-combinations of Python and dependencies. You need to have Python 2.7, 3.3,
-3.4, 3.5 3.6, and PyPy 2.7 installed to run all of the environments. Then run::
+combinations of Python and dependencies. You need to have Python 2.7,
+3.4, 3.5, 3.6, and PyPy 2.7 installed to run all of the environments. Then run::
 
     tox
 

--- a/docs/deploying/fastcgi.rst
+++ b/docs/deploying/fastcgi.rst
@@ -111,7 +111,7 @@ Set yourapplication.fcgi::
     #!/usr/bin/python
     #: optional path to your local python site-packages folder
     import sys
-    sys.path.insert(0, '<your_local_path>/lib/python2.6/site-packages')
+    sys.path.insert(0, '<your_local_path>/lib/python2.7/site-packages')
 
     from flup.server.fcgi import WSGIServer
     from yourapplication import app

--- a/docs/extensiondev.rst
+++ b/docs/extensiondev.rst
@@ -383,7 +383,7 @@ extension to be approved you have to follow these guidelines:
     (``PackageName==dev``).
 9. The ``zip_safe`` flag in the setup script must be set to ``False``,
    even if the extension would be safe for zipping.
-10. An extension currently has to support Python 2.7, Python 3.3 and higher.
+10. An extension currently has to support Python 2.7, Python 3.4 and higher.
 
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,7 +7,7 @@ Python Version
 --------------
 
 We recommend using the latest version of Python 3. Flask supports Python 3.3
-and newer, Python 2.6 and newer, and PyPy.
+and newer, Python 2.7 and PyPy.
 
 Dependencies
 ------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,7 +6,7 @@ Installation
 Python Version
 --------------
 
-We recommend using the latest version of Python 3. Flask supports Python 3.3
+We recommend using the latest version of Python 3. Flask supports Python 3.4
 and newer, Python 2.7 and PyPy.
 
 Dependencies

--- a/docs/python3.rst
+++ b/docs/python3.rst
@@ -7,7 +7,7 @@ Flask, its dependencies, and most Flask extensions support Python 3.
 You should start using Python 3 for your next project,
 but there are a few things to be aware of.
 
-You need to use Python 3.3 or higher.  3.2 and older are *not* supported.
+You need to use Python 3.4 or higher.  3.3 and older are *not* supported.
 
 You should use the latest versions of all Flask-related packages.
 Flask 0.10 and Werkzeug 0.9 were the first versions to introduce Python 3 support.

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -724,9 +724,6 @@ def main(as_module=False):
     if as_module:
         this_module = 'flask'
 
-        if sys.version_info < (2, 7):
-            this_module += '.cli'
-
         name = 'python -m ' + this_module
 
         # Python rewrites "python -m flask" to the path to the file in argv.

--- a/scripts/flaskext_tester.py
+++ b/scripts/flaskext_tester.py
@@ -284,7 +284,7 @@ def main():
                         help='run against all extensions, not just approved')
     parser.add_argument('--browse', dest='browse', action='store_true',
                         help='show browser with the result summary')
-    parser.add_argument('--env', dest='env', default='py25,py26,py27',
+    parser.add_argument('--env', dest='env', default='py27',
                         help='the tox environments to run against')
     parser.add_argument('--extension=', dest='extension', default=None,
                         help='tests a single extension')

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -62,9 +62,8 @@ def test_memory_consumption():
     # Trigger caches
     fire()
 
-    # This test only works on CPython 2.7.
-    if sys.version_info >= (2, 7) and \
-            not hasattr(sys, 'pypy_translation_info'):
+    # This test only works on CPython.
+    if not hasattr(sys, 'pypy_translation_info'):
         with assert_no_leak():
             for x in range(10):
                 fire()

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{36,35,34,33,27,py}
+    py{36,35,34,27,py}
     py{36,27,py}-simplejson
-    py{36,33,27,py}-devel
-    py{36,33,27,py}-lowest
+    py{36,27,py}-devel
+    py{36,27,py}-lowest
     docs-html
     coverage-report
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{36,35,34,33,27,26,py}
+    py{36,35,34,33,27,py}
     py{36,27,py}-simplejson
-    py{36,33,27,26,py}-devel
-    py{36,33,27,26,py}-lowest
+    py{36,33,27,py}-devel
+    py{36,33,27,py}-lowest
     docs-html
     coverage-report
 
@@ -59,8 +59,6 @@ passenv = CI TRAVIS TRAVIS_*
 deps = codecov
 skip_install = true
 commands =
-    # install argparse for 2.6
-    python -c 'import sys, pip; sys.version_info < (2, 7) and pip.main(["install", "argparse", "-q"])'
     coverage combine
     coverage report
     codecov


### PR DESCRIPTION
## Reasons for dropping old ones

### 2.6

* Unsupported since [2013-10-29](https://en.wikipedia.org/wiki/CPython#Version_history)
* https://snarky.ca/stop-using-python-2-6/
* http://www.curiousefficiency.org/posts/2015/04/stop-supporting-python26.html
* http://www.python3statement.org
* Current pip 9 deprecates Python 2.6 support, pip 10 won't support it (https://github.com/pypa/pip/issues/3955)
* Not much PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796

### 3.2

* (Already dropped 👍 )

### 3.3

* Unsupported since [2017-09-29](https://en.wikipedia.org/wiki/CPython#Version_history)
* pip 10 will deprecate Python 3.3 support, pip 11 won't support it (https://github.com/pypa/pip/issues/3796)
* Very little PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796

### Also

This prevents this project's dependencies, such as MarkupSafe, from moving forward. See https://github.com/pallets/markupsafe/pull/79#issuecomment-335014965.
* [ ] Changelog

