### PR TITLE
Fix typo in logging.rst

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -129,7 +129,7 @@ handler. ::
     formatter = RequestFormatter(
         '[%(asctime)s] %(remote_addr)s requested %(url)s\n'
         '%(levelname)s in %(module)s: %(message)s'
-    ))
+    )
     default_handler.setFormatter(formatter)
     mail_handler.setFormatter(formatter)
 


### PR DESCRIPTION
Remove extra parenthesis from RequestFormatter constructor.
