### PR TITLE
Improvements in the final sections of appfactories.rst

### DIFF
--- a/docs/patterns/appfactories.rst
+++ b/docs/patterns/appfactories.rst
@@ -89,10 +89,9 @@ For more information about the design of extensions refer to :doc:`/extensiondev
 Using Applications
 ------------------
 
-So to use such an application you then have to create the application
-first in a separate file otherwise the :command:`flask` command won't be able
-to find it.  Here an example :file:`exampleapp.py` file that creates such
-an application::
+To use such an application you have to create it in a separate file first,
+otherwise the :command:`flask` command won't be able to find it. Here's an
+example :file:`exampleapp.py` file that creates such an application::
 
     from yourapplication import create_app
     app = create_app('/path/to/config.cfg')
@@ -105,12 +104,12 @@ It can then be used with the :command:`flask` command::
 Factory Improvements
 --------------------
 
-The factory function from above is not very clever so far, you can improve
-it.  The following changes are straightforward and possible:
+The factory function above is not very clever, but you can improve it.
+The following changes are straightforward to implement:
 
-1.  make it possible to pass in configuration values for unittests so that
-    you don't have to create config files on the filesystem
-2.  call a function from a blueprint when the application is setting up so
+1.  Make it possible to pass in configuration values for unit tests so that
+    you don't have to create config files on the filesystem.
+2.  Call a function from a blueprint when the application is setting up so
     that you have a place to modify attributes of the application (like
-    hooking in before / after request handlers etc.)
-3.  Add in WSGI middlewares when the application is creating if necessary.
+    hooking in before/after request handlers etc.)
+3.  Add in WSGI middlewares when the application is being created if necessary.


### PR DESCRIPTION
This fixes a self-reported issue.

The final sections of `appfactories.rst` stood out to me while I was going through the docs.

Made some minor changes to sentences so that they flow better.
The punctuation is also more consistent now (in the final list).

With regards to:

> The following changes are straightforward and possible:

"possible" was removed because it felt like it was implied in the context (why suggest them if they're not possible?). I did not get the same feeling about the implementation part, so I added an explicit "to implement" (because that's what the straightforwardness refers to).