### PR TITLE
add option to use None config for later evaluation

### DIFF
--- a/flask/config.py
+++ b/flask/config.py
@@ -81,9 +81,9 @@ class Config(dict):
     :param defaults: an optional dictionary of default values
     """
 
-    def __init__(self, root_path, defaults=None):
+    def __init__(self, root_path=None, defaults=None):
         dict.__init__(self, defaults or {})
-        self.root_path = root_path
+        self.root_path = root_path or ""
 
     def from_envvar(self, variable_name, silent=False):
         """Loads a configuration from an environment variable pointing to

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -206,3 +206,37 @@ def test_from_pyfile_weird_encoding(tmpdir, encoding):
     if PY2:
         value = value.decode(encoding)
     assert value == u'föö'
+
+def test_none_root_path():
+    app = flask.Flask(__name__)
+    app.config = app.config_class()
+
+    app = flask.Flask(__name__)
+    app.config.from_mapping({
+        'SECRET_KEY': 'config',
+        'TEST_KEY': 'foo'
+    })
+    common_object_test(app)
+
+    app = flask.Flask(__name__)
+    app.config = app.config_class()
+    app.config.from_mapping([
+        ('SECRET_KEY', 'config'),
+        ('TEST_KEY', 'foo')
+    ])
+    common_object_test(app)
+
+    app = flask.Flask(__name__)
+    app.config = app.config_class()
+    app.config.from_mapping(
+        SECRET_KEY='config',
+        TEST_KEY='foo'
+    )
+    common_object_test(app)
+
+    app = flask.Flask(__name__)
+    with pytest.raises(TypeError):
+        app.config.from_mapping(
+            {}, {}
+        )
+


### PR DESCRIPTION
Allows to create "empty" configuration object in order to initialize it in later during runtime. #2495