### PR TITLE
Fixed typo in docs

### DIFF
--- a/docs/tutorial/dbcon.rst
+++ b/docs/tutorial/dbcon.rst
@@ -25,7 +25,7 @@ will cover some more details of this later on.
 For the time being, all you have to know is that you can store information
 safely on the :data:`~flask.g` object.
 
-So when do you put it on there?  To do that you can make a helper
+So how do you put it on there?  To do that you can make a helper
 function.  The first time the function is called, it will create a database
 connection for the current context, and successive calls will return the
 already established connection::


### PR DESCRIPTION
Changed "when" to "how" as the subsequent text talks about "how to store data on the `g` object".
<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
