### PR TITLE
Docs: update Twisted Web example

### DIFF
--- a/docs/deploying/wsgi-standalone.rst
+++ b/docs/deploying/wsgi-standalone.rst
@@ -78,7 +78,7 @@ as well; see ``twistd -h`` and ``twistd web -h`` for more information. For
 example, to run a Twisted Web server in the foreground, on port 8080, with an
 application from ``myproject``::
 
-    twistd -n web --port 8080 --wsgi myproject.app
+    twistd -n web --port tcp:8080 --wsgi myproject.app
 
 .. _Twisted: https://twistedmatrix.com/
 .. _Twisted Web: https://twistedmatrix.com/trac/wiki/TwistedWeb


### PR DESCRIPTION
In recent versions of Twisted Web, the `--port` option syntax has changed, and it is now necessary to specify the protocol along with the port.