### PR TITLE
Enable threads by default for the dev server

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -113,6 +113,7 @@ Major release, unreleased
   depending on ``app.debug``. No handlers are removed, and a handler is only
   added if no handlers are already configured. (`#2436`_)
 - Blueprint view function name may not contain dots. (`#2450`_)
+- The dev server now uses threads by default.
 
 .. _#1421: https://github.com/pallets/flask/issues/1421
 .. _#1489: https://github.com/pallets/flask/pull/1489

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -592,7 +592,7 @@ def load_dotenv(path=None):
 @click.option('--eager-loading/--lazy-loader', default=None,
               help='Enable or disable eager loading.  By default eager '
               'loading is enabled if the reloader is disabled.')
-@click.option('--with-threads/--without-threads', default=False,
+@click.option('--with-threads/--without-threads', default=True,
               help='Enable or disable multithreading.')
 @pass_script_info
 def run_command(info, host, port, reload, debugger, eager_loading,


### PR DESCRIPTION
It's way too easy currently to deadlock the server with background resource
fetching.  We really should have threads enabled by default now in my mind.