### PR TITLE
Fix docs, how to get db connection in pattern

### DIFF
--- a/docs/patterns/sqlite3.rst
+++ b/docs/patterns/sqlite3.rst
@@ -67,7 +67,7 @@ the application context by hand::
 Easy Querying
 -------------
 
-Now in each request handling function you can access `g.db` to get the
+Now in each request handling function you can access `get_db()` to get the
 current open database connection.  To simplify working with SQLite, a
 row factory function is useful.  It is executed for every result returned
 from the database to convert the result.  For instance, in order to get


### PR DESCRIPTION
The docs are inaccurately suggestion a db connection would be available at `g.db`, after calling `get_db()` a connection will be available at `g._database` but even then I think instructing the user to use `get_db()` is the best way forward.

