### PR TITLE
fix non-passing tests for logging on pytest >= 3.3.0

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -17,6 +17,10 @@ def reset_logging(monkeypatch):
     logger.handlers = []
     logger.setLevel(logging.NOTSET)
 
+    logging_plugin = pytest.config.pluginmanager.getplugin('logging-plugin')
+    pytest.config.pluginmanager.unregister(name='logging-plugin')
+    logging.root.handlers = []
+
     yield
 
     logging.root.handlers[:] = root_handlers
@@ -24,6 +28,8 @@ def reset_logging(monkeypatch):
 
     logger.handlers = []
     logger.setLevel(logging.NOTSET)
+
+    pytest.config.pluginmanager.register(logging_plugin, 'logging-plugin')
 
 
 def test_logger(app):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -29,7 +29,8 @@ def reset_logging(monkeypatch):
     logger.handlers = []
     logger.setLevel(logging.NOTSET)
 
-    pytest.config.pluginmanager.register(logging_plugin, 'logging-plugin')
+    if logging_plugin:
+        pytest.config.pluginmanager.register(logging_plugin, 'logging-plugin')
 
 
 def test_logger(app):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -9,17 +9,17 @@ from flask.logging import default_handler, has_level_handler, \
 
 
 @pytest.fixture(autouse=True)
-def reset_logging(monkeypatch):
+def reset_logging(pytestconfig):
     root_handlers = logging.root.handlers[:]
+    logging.root.handlers = []
     root_level = logging.root.level
 
     logger = logging.getLogger('flask.app')
     logger.handlers = []
     logger.setLevel(logging.NOTSET)
 
-    logging_plugin = pytest.config.pluginmanager.getplugin('logging-plugin')
-    pytest.config.pluginmanager.unregister(name='logging-plugin')
-    logging.root.handlers = []
+    logging_plugin = pytestconfig.pluginmanager.unregister(
+        name='logging-plugin')
 
     yield
 
@@ -30,7 +30,7 @@ def reset_logging(monkeypatch):
     logger.setLevel(logging.NOTSET)
 
     if logging_plugin:
-        pytest.config.pluginmanager.register(logging_plugin, 'logging-plugin')
+        pytestconfig.pluginmanager.register(logging_plugin, 'logging-plugin')
 
 
 def test_logger(app):


### PR DESCRIPTION
This fixes issue #2550, where some tests fail when using newer pytest (after version 3.2.5).

The reason for this issue is that pytest added a plugin that instantiates a handler for the logging module, while the tests were expecting no handlers.

The PR solves the issue by temporarily disabling the logging module and removing any handlers for all tests on the file

