### PR TITLE
Fix sentry raven install docs

### DIFF
--- a/docs/errorhandling.rst
+++ b/docs/errorhandling.rst
@@ -42,9 +42,9 @@ aggregates duplicate errors, captures the full stack trace and local
 variables for debugging, and sends you mails based on new errors or
 frequency thresholds.
 
-To use Sentry you need to install the `raven` client::
+To use Sentry you need to install the `raven` client with extra `flask` dependencies::
 
-    $ pip install raven
+    $ pip install raven[flask]
 
 And then add this to your Flask app::
 


### PR DESCRIPTION
The documentation for installing Sentry's raven client was incorrect. It should state that the client must be installed with the extra flask dependencies as mentioned in getsentry/raven-python#1075
