### PR TITLE
docs: add Hasura as hosted deployment option

### DIFF
--- a/docs/deploying/index.rst
+++ b/docs/deploying/index.rst
@@ -17,6 +17,7 @@ Hosted options
 --------------
 
 - `Deploying Flask on Heroku <https://devcenter.heroku.com/articles/getting-started-with-python>`_
+- `Deploying Flask on Hasura <https://hasura.io/hub/project/hasura/hello-python-flask>`_
 - `Deploying Flask on OpenShift <https://developers.openshift.com/en/python-flask.html>`_
 - `Deploying Flask on Webfaction <http://flask.pocoo.org/snippets/65/>`_
 - `Deploying Flask on Google App Engine <https://cloud.google.com/appengine/docs/standard/python/getting-started/python-standard-env>`_


### PR DESCRIPTION
Hasura is Kubernetes based microservices platform with Postgres based BaaS features, including authentication, data, files and notification APIs. 

https://hasura.io/hub/project/hasura/hello-python-flask is a boilerplate which can be deployed easily to a free Hasura cluster using a simple git-push. It also integrates with Hasura data and auth APIs to provide authentication and database out-of-the-box.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->

  