### PR TITLE
Use string concat in jsonify

### DIFF
--- a/flask/json/__init__.py
+++ b/flask/json/__init__.py
@@ -264,7 +264,7 @@ def jsonify(*args, **kwargs):
         data = args or kwargs
 
     return current_app.response_class(
-        (dumps(data, indent=indent, separators=separators), '\n'),
+        dumps(data, indent=indent, separators=separators) + '\n',
         mimetype=current_app.config['JSONIFY_MIMETYPE']
     )
 


### PR DESCRIPTION
#1262 added a newline at the end of the response body from `jsonfiy`. It passed a tuple to the `Response`, which is more appropriate for streaming responses. Instead, use a simple `+ '\n'` and pass a string. This allows the content length header to be calculated while creating the response object (#1877).

ref pallets/werkzeug#1130