### PR TITLE
cleanup werkzeug import

### DIFF
--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -22,21 +22,12 @@ import unicodedata
 from werkzeug.routing import BuildError
 from functools import update_wrapper
 
-try:
-    from werkzeug.urls import url_quote
-except ImportError:
-    from urlparse import quote as url_quote
-
+from werkzeug.urls import url_quote
 from werkzeug.datastructures import Headers, Range
 from werkzeug.exceptions import BadRequest, NotFound, \
     RequestedRangeNotSatisfiable
 
-# this was moved in 0.7
-try:
-    from werkzeug.wsgi import wrap_file
-except ImportError:
-    from werkzeug.utils import wrap_file
-
+from werkzeug.wsgi import wrap_file
 from jinja2 import FileSystemLoader
 
 from .signals import message_flashed

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -15,11 +15,7 @@ from contextlib import contextmanager
 from werkzeug.test import Client, EnvironBuilder
 from flask import _request_ctx_stack
 from flask.json import dumps as json_dumps
-
-try:
-    from werkzeug.urls import url_parse
-except ImportError:
-    from urlparse import urlsplit as url_parse
+from werkzeug.urls import url_parse
 
 
 def make_test_environ_builder(


### PR DESCRIPTION
Flask now requires werkzeug >= 0.9. There is no need to try import these werkzeug modules.