### PR TITLE
Remove the imported app module from sys.modules on SyntaxError

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -215,6 +215,11 @@ def locate_app(script_info, module_name, app_name, raise_if_not_found=True):
             )
         else:
             return
+    except SyntaxError:
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+        raise
+
 
     module = sys.modules[module_name]
 

--- a/tests/test_apps/cliapp/syntaxerror/__init__.py
+++ b/tests/test_apps/cliapp/syntaxerror/__init__.py
@@ -1,0 +1,1 @@
+spam()spam()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -243,6 +243,15 @@ def test_locate_app_suppress_raise():
         )
 
 
+def test_locate_app_init_syntax_error(test_apps):
+    info = ScriptInfo()
+    with pytest.raises(SyntaxError):
+        locate_app(info, 'cliapp.syntaxerror', None)
+
+    with pytest.raises(SyntaxError):
+        locate_app(info, 'cliapp.syntaxerror', None)
+
+
 def test_get_version(test_apps, capsys):
     """Test of get_version."""
     from flask import __version__ as flask_ver


### PR DESCRIPTION
When a SyntaxError occurrs in a package's `__init__.py` file, Python seems to leave an empty module in `sys.modules`. This will result in any request after the first to give you a `NoAppException` instead of the `SyntaxError` again.

I'm not 100% sure this doesn't have any side effects... It's an hack... So please review and tell me what you think about this. (Maybe more conditions for triggering this?)

Fixes #2423 

### Sample
In `hello/__init__.py`:
```python
from flask import Flask
app = Flask(__name__)

@app.route('/')
def hello_world():
    return 'Hello, World!'
```

```cmd
set FLASK_APP=hello
set FLASK_DEBUG=1
flask run
```

Than edit `__init__.py` and introduce a syntax error.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->

  