### PR TITLE
add HTTPS support for flask run command

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -118,6 +118,8 @@ Major release, unreleased
 - The dev server now uses threads by default. (`#2529`_)
 - Loading config files with ``silent=True`` will ignore ``ENOTDIR``
   errors. (`#2581`_)
+- Pass ``--cert`` and ``--key`` options to ``flask run`` to run the
+  development server over HTTPS. (`#2606`_)
 
 .. _pallets/meta#24: https://github.com/pallets/meta/issues/24
 .. _#1421: https://github.com/pallets/flask/issues/1421
@@ -154,6 +156,7 @@ Major release, unreleased
 .. _#2450: https://github.com/pallets/flask/pull/2450
 .. _#2529: https://github.com/pallets/flask/pull/2529
 .. _#2581: https://github.com/pallets/flask/pull/2581
+.. _#2606: https://github.com/pallets/flask/pull/2606
 
 
 Version 0.12.3


### PR DESCRIPTION
closes #2594 

I deliberately did not document the `adhoc` and `SSLContext` options, although they're supported. I also didn't add a `gen_cert` command, as I would have had to add a bunch of logic around `werkzeug.serving.make_ssl_devcert` to not overwrite existing files unconditionally.

Preferred use case is to manually generate a cert and key and pass them.

An interesting config is using `.flaskenv` and setting `FLASK_RUN_CERT` and `FLASK_RUN_KEY` instead of passing them in the command line.