### PR TITLE
2604 flask shell tab completion

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -752,7 +752,7 @@ def shell_command():
         app.env,
         app.instance_path,
     )
-    ctx = {}
+    ctx = {'__doc__': None, '__name__': '__flaskshell__'}
 
     # Support the regular Python interpreter startup script if someone
     # is using it.

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -753,6 +753,30 @@ def shell_command():
         app.instance_path,
     )
     ctx = {'__doc__': None, '__name__': '__flaskshell__'}
+    try:
+        import readline
+        import rlcompleter
+    except ImportError:
+        pass
+    else:
+        # Reading the initialization (config) file may not be enough to set a
+        # completion key, so we set one first and then read the file.
+        readline_doc = getattr(readline, '__doc__', '')
+        if readline_doc is not None and 'libedit' in readline_doc:
+            readline.parse_and_bind('bind ^I rl_complete')
+        else:
+            readline.parse_and_bind('tab: complete')
+
+        try:
+            readline.read_init_file()
+        except OSError:
+            # An OSError here could have many causes, but the most likely one
+            # is that there's no .inputrc file (or .editrc file in the case of
+            # Mac OS X + libedit) in the expected location.  In that case, we
+            # want to ignore the exception.
+            pass
+
+        readline.set_completer(rlcompleter.Completer(ctx).complete)
 
     # Support the regular Python interpreter startup script if someone
     # is using it.


### PR DESCRIPTION
This pull request makes tab completion available in the flask shell, and sets `__name__` and `__doc__` so that those do not fall back to their counterparts in the builtins module (`code.InteractiveInterpreter` sets those for its default context, so I figure flask shell should also do this.)

I've set `__name__` to `'__flaskshell__'`, I don't really know if that's what it "should" be, it does provide a way for PYTHONSTARTUP to detect what's going on though. My next suggestion would be `'__console__'` which is what `code.InteractiveInterpreter` uses by default.


I've got roughly half a clue what I'm doing here, do tell if something should be different.

Link to issue:
https://github.com/pallets/flask/issues/2604