### PR TITLE
allow nightly to fail on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
       env: TOXENV=py,codecov
     - python: nightly
       env: TOXENV=py
+  allow_failures:
+    - python: nightly
+      env: TOXENV=py
 
 install:
   - pip install tox


### PR DESCRIPTION
For some reason nightly just fails with "invocation error" on Travis. May be related to pytest-dev/pytest#3011.