### PR TITLE
prevent double slash /a//b when blueprint prefix ends with slash

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -143,6 +143,8 @@ unreleased
   :data:`SERVER_NAME` does not implicily enable it. It can be enabled by
   passing ``subdomain_matching=True`` to the ``Flask`` constructor.
   (`#2635`_)
+- A single trailing slash is stripped from the blueprint ``url_prefix``
+  when it is registered with the app. (`#2629`_)
 
 .. _pallets/meta#24: https://github.com/pallets/meta/issues/24
 .. _#1421: https://github.com/pallets/flask/issues/1421
@@ -186,6 +188,7 @@ unreleased
 .. _#2607: https://github.com/pallets/flask/pull/2607
 .. _#2636: https://github.com/pallets/flask/pull/2636
 .. _#2635: https://github.com/pallets/flask/pull/2635
+.. _#2629: https://github.com/pallets/flask/pull/2629
 
 
 Version 0.12.2

--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -10,6 +10,7 @@
     :license: BSD, see LICENSE for more details.
 """
 
+import re
 from functools import update_wrapper
 
 from .helpers import _PackageBoundObject, _endpoint_from_view_func
@@ -67,6 +68,7 @@ class BlueprintSetupState(object):
         """
         if self.url_prefix:
             rule = self.url_prefix + rule
+            rule = re.sub('/+', '/', rule)
         options.setdefault('subdomain', self.subdomain)
         if endpoint is None:
             endpoint = _endpoint_from_view_func(view_func)

--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -9,8 +9,6 @@
     :copyright: © 2010 by the Pallets team.
     :license: BSD, see LICENSE for more details.
 """
-
-import re
 from functools import update_wrapper
 
 from .helpers import _PackageBoundObject, _endpoint_from_view_func
@@ -54,6 +52,9 @@ class BlueprintSetupState(object):
 
         #: The prefix that should be used for all URLs defined on the
         #: blueprint.
+        if url_prefix and url_prefix[-1] == '/':
+            url_prefix = url_prefix[:-1]
+
         self.url_prefix = url_prefix
 
         #: A dictionary with URL defaults that is added to each and every
@@ -68,7 +69,6 @@ class BlueprintSetupState(object):
         """
         if self.url_prefix:
             rule = self.url_prefix + rule
-            rule = re.sub('/+', '/', rule)
         options.setdefault('subdomain', self.subdomain)
         if endpoint is None:
             endpoint = _endpoint_from_view_func(view_func)

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -114,7 +114,20 @@ def test_blueprint_app_error_handling(app, client):
     assert client.get('/nope').data == b'you shall not pass'
 
 
-def test_blueprint_url_definitions(app, client):
+def test_blueprint_prefix_slash(app, client):
+    bp = flask.Blueprint('test', __name__, url_prefix='/bar/')
+
+    @bp.route('/foo')
+    def foo():
+        return '', 204
+
+    app.register_blueprint(bp)
+    app.register_blueprint(bp, url_prefix='/spam/')
+    assert client.get('/bar/foo').status_code == 204
+    assert client.get('/spam/foo').status_code == 204
+
+
+def test_blueprint_url_defaults(app, client):
     bp = flask.Blueprint('test', __name__)
 
     @bp.route('/foo', defaults={'baz': 42})


### PR DESCRIPTION
Simple example file as below:

```
from __future__ import print_function

from flask import Flask, Blueprint, redirect

bp = Blueprint('bp', __name__)
app = Flask(__name__)

@bp.route('/b/')
def tmp():
    return "URI should be '/a/b/"


@app.route('/')
def index():
    return redirect("/a/b/")

app.register_blueprint(bp, url_prefix='/a/')

if __name__ == "__main__":
    print("app.url_map: ", app.url_map)
    app.run(port=5000, host='127.0.0.1', debug=True)
```

With the old code, there is one rule like this `<Rule '/a//b/' (HEAD, OPTIONS, GET) ->`.
With the new code, that rule would be change to `<Rule '/a/b/' (HEAD, OPTIONS, GET) ->`.