### PR TITLE
Fix docs for test_request_context

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -2140,8 +2140,8 @@ class Flask(_PackageBoundObject):
         return RequestContext(self, environ)
 
     def test_request_context(self, *args, **kwargs):
-        """Creates a WSGI environment from the given values (see
-        :class:`werkzeug.test.EnvironBuilder` for more information, this
+        """Creates a :class:`~flask.ctx.RequestContext` from the given values
+        (see :class:`werkzeug.test.EnvironBuilder` for more information, this
         function accepts the same arguments plus two additional).
 
         Additional arguments (only if ``base_url`` is not specified):


### PR DESCRIPTION
This corrects the docstring for `test_request_context` to say that it returns a `RequestContext`, rather than a WSGI environment; this is in line with the rest of the documentation, as well as the function's actual behaviour.

Fixes #2627.