### PR TITLE
Require opt-in for subdomain matching

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -139,8 +139,10 @@ unreleased
   attribute on the session cookie. (`#2607`_)
 - Added :meth:`~flask.Flask.test_cli_runner` to create a Click runner
   that can invoke Flask CLI commands for testing. (`#2636`_)
-- Subdomain matching is disabled by default now.  It can be turned on by
-  passing ``subdomain_matching=True`` to the Flask constructor.
+- Subdomain matching is disabled by default and setting
+  :data:`SERVER_NAME` does not implicily enable it. It can be enabled by
+  passing ``subdomain_matching=True`` to the ``Flask`` constructor.
+  (`#2635`_)
 
 .. _pallets/meta#24: https://github.com/pallets/meta/issues/24
 .. _#1421: https://github.com/pallets/flask/issues/1421
@@ -183,6 +185,7 @@ unreleased
 .. _#2606: https://github.com/pallets/flask/pull/2606
 .. _#2607: https://github.com/pallets/flask/pull/2607
 .. _#2636: https://github.com/pallets/flask/pull/2636
+.. _#2635: https://github.com/pallets/flask/pull/2635
 
 
 Version 0.12.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -139,6 +139,8 @@ unreleased
   attribute on the session cookie. (`#2607`_)
 - Added :meth:`~flask.Flask.test_cli_runner` to create a Click runner
   that can invoke Flask CLI commands for testing. (`#2636`_)
+- Subdomain matching is disabled by default now.  It can be turned on by
+  passing ``subdomain_matching=True`` to the Flask constructor.
 
 .. _pallets/meta#24: https://github.com/pallets/meta/issues/24
 .. _#1421: https://github.com/pallets/flask/issues/1421

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -181,8 +181,8 @@ The following configuration values are used internally by Flask:
 .. py:data:: SESSION_COOKIE_DOMAIN
 
     The domain match rule that the session cookie will be valid for. If not
-    set, the cookie will be valid for all subdomains of ``SERVER_NAME``. If
-    ``False``, the cookie's domain will not be set.
+    set, the cookie will be valid for all subdomains of :data:`SERVER_NAME`.
+    If ``False``, the cookie's domain will not be set.
 
     Default: ``None``
 
@@ -257,13 +257,14 @@ The following configuration values are used internally by Flask:
 
 .. py:data:: SERVER_NAME
 
-    Inform the application what host and port it is bound to. Required for
-    subdomain route matching support.
+    Inform the application what host and port it is bound to. Required
+    for subdomain route matching support.
 
     If set, will be used for the session cookie domain if
-    ``SESSION_COOKIE_DOMAIN`` is not set. Modern web browsers will not allow
-    setting cookies for domains without a dot. To use a domain locally,
-    add any names that should route to the app to your ``hosts`` file. ::
+    :data:`SESSION_COOKIE_DOMAIN` is not set. Modern web browsers will
+    not allow setting cookies for domains without a dot. To use a domain
+    locally, add any names that should route to the app to your
+    ``hosts`` file. ::
 
         127.0.0.1 localhost.dev
 

--- a/flask/app.py
+++ b/flask/app.py
@@ -126,6 +126,11 @@ class Flask(_PackageBoundObject):
     .. versionadded:: 0.13
        The `host_matching` and `static_host` parameters were added.
 
+    .. versionadded:: 1.0
+       The `subdomain_matching` parameter was added.  Subdomain matching
+       needs to be enabled manually now.  Setting `SERVER_NAME` does not
+       implicitly enable it.
+
     :param import_name: the name of the application package
     :param static_url_path: can be used to specify a different path for the
                             static files on the web.  Defaults to the name
@@ -347,6 +352,7 @@ class Flask(_PackageBoundObject):
         static_folder='static',
         static_host=None,
         host_matching=False,
+        subdomain_matching=False,
         template_folder='templates',
         instance_path=None,
         instance_relative_config=False,
@@ -530,6 +536,7 @@ class Flask(_PackageBoundObject):
         self.url_map = Map()
 
         self.url_map.host_matching = host_matching
+        self.subdomain_matching = subdomain_matching
 
         # tracks internally if the application already handled at least one
         # request.
@@ -1988,8 +1995,15 @@ class Flask(_PackageBoundObject):
            URL adapter is created for the application context.
         """
         if request is not None:
-            return self.url_map.bind_to_environ(request.environ,
+            rv = self.url_map.bind_to_environ(request.environ,
                 server_name=self.config['SERVER_NAME'])
+            # If subdomain matching is not enabled (which is the default
+            # we put back the default subdomain in all cases.  This really
+            # should be the default in Werkzeug but it currently does not
+            # have that feature.
+            if not self.subdomain_matching:
+                rv.subdomain = self.url_map.default_subdomain
+            return rv
         # We need at the very least the server name to be set for this
         # to work.
         if self.config['SERVER_NAME'] is not None:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1429,10 +1429,12 @@ def test_request_locals():
     assert not flask.g
 
 
-def test_test_app_proper_environ(app, client):
+def test_test_app_proper_environ():
+    app = flask.Flask(__name__, subdomain_matching=True)
     app.config.update(
         SERVER_NAME='localhost.localdomain:5000'
     )
+    client = app.test_client()
 
     @app.route('/')
     def index():
@@ -1783,8 +1785,10 @@ def test_g_iteration_protocol(app_ctx):
     assert sorted(flask.g) == ['bar', 'foo']
 
 
-def test_subdomain_basic_support(app, client):
+def test_subdomain_basic_support():
+    app = flask.Flask(__name__, subdomain_matching=True)
     app.config['SERVER_NAME'] = 'localhost.localdomain'
+    client = app.test_client()
 
     @app.route('/')
     def normal_index():
@@ -1801,7 +1805,9 @@ def test_subdomain_basic_support(app, client):
     assert rv.data == b'test index'
 
 
-def test_subdomain_matching(app, client):
+def test_subdomain_matching():
+    app = flask.Flask(__name__, subdomain_matching=True)
+    client = app.test_client()
     app.config['SERVER_NAME'] = 'localhost.localdomain'
 
     @app.route('/', subdomain='<user>')
@@ -1812,8 +1818,10 @@ def test_subdomain_matching(app, client):
     assert rv.data == b'index for mitsuhiko'
 
 
-def test_subdomain_matching_with_ports(app, client):
+def test_subdomain_matching_with_ports():
+    app = flask.Flask(__name__, subdomain_matching=True)
     app.config['SERVER_NAME'] = 'localhost.localdomain:3000'
+    client = app.test_client()
 
     @app.route('/', subdomain='<user>')
     def index(user):
@@ -1821,6 +1829,23 @@ def test_subdomain_matching_with_ports(app, client):
 
     rv = client.get('/', 'http://mitsuhiko.localhost.localdomain:3000/')
     assert rv.data == b'index for mitsuhiko'
+
+
+def test_subdomain_matching_behavior():
+    for matching in False, True:
+        app = flask.Flask(__name__, subdomain_matching=matching)
+        app.config['SERVER_NAME'] = 'localhost.localdomain:3000'
+        client = app.test_client()
+
+        @app.route('/')
+        def index():
+            return 'matched without subdomain'
+
+        rv = client.get('/', 'http://127.0.0.1:3000/')
+        if matching:
+            assert rv.status_code == 404
+        else:
+            assert rv.data == b'matched without subdomain'
 
 
 def test_multi_route_rules(app, client):

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -114,9 +114,11 @@ def test_path_is_url(app):
     assert eb.path == '/'
 
 
-def test_blueprint_with_subdomain(app, client):
+def test_blueprint_with_subdomain():
+    app = flask.Flask(__name__, subdomain_matching=True)
     app.config['SERVER_NAME'] = 'example.com:1234'
     app.config['APPLICATION_ROOT'] = '/foo'
+    client = app.test_client()
 
     bp = flask.Blueprint('company', __name__, subdomain='xxx')
 
@@ -304,8 +306,10 @@ def test_json_request_and_response(app, client):
         assert rv.get_json() == json_data
 
 
-def test_subdomain(app, client):
+def test_subdomain():
+    app = flask.Flask(__name__, subdomain_matching=True)
     app.config['SERVER_NAME'] = 'example.com'
+    client = app.test_client()
 
     @app.route('/', subdomain='<company_id>')
     def view(company_id):


### PR DESCRIPTION
This fixes #998.  An argument can be made that this should actually land in
Werkzeug instead.  Question is if we want a new release for this or not.
Can be worked around in Flask for now.