### PR TITLE
add test_cli_runner for testing app.cli commands

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -137,6 +137,8 @@ unreleased
   development server over HTTPS. (`#2606`_)
 - Added :data:`SESSION_COOKIE_SAMESITE` to control the ``SameSite``
   attribute on the session cookie. (`#2607`_)
+- Added :meth:`~flask.Flask.test_cli_runner` to create a Click runner
+  that can invoke Flask CLI commands for testing. (`#2636`_)
 
 .. _pallets/meta#24: https://github.com/pallets/meta/issues/24
 .. _#1421: https://github.com/pallets/flask/issues/1421
@@ -178,6 +180,7 @@ unreleased
 .. _#2581: https://github.com/pallets/flask/pull/2581
 .. _#2606: https://github.com/pallets/flask/pull/2606
 .. _#2607: https://github.com/pallets/flask/pull/2607
+.. _#2636: https://github.com/pallets/flask/pull/2636
 
 
 Version 0.12.2

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -188,6 +188,15 @@ Test Client
    :members:
 
 
+Test CLI Runner
+---------------
+
+.. currentmodule:: flask.testing
+
+.. autoclass:: FlaskCliRunner
+    :members:
+
+
 Application Globals
 -------------------
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -413,15 +413,17 @@ with ``get_json``.
 Testing CLI Commands
 --------------------
 
-Click comes with `utilities for testing`_ your CLI commands.
+Click comes with `utilities for testing`_ your CLI commands. A
+:class:`~click.testing.CliRunner` runs commands in isolation and
+captures the output in a :class:`~click.testing.Result` object.
 
-Use :meth:`CliRunner.invoke <click.testing.CliRunner.invoke>` to call
-commands in the same way they would be called from the command line. The
-:class:`~click.testing.CliRunner` runs the command in isolation and
-captures the output in a :class:`~click.testing.Result` object. ::
+Flask provides :meth:`~flask.Flask.test_cli_runner` to create a
+:class:`~flask.testing.FlaskCliRunner` that passes the Flask app to the
+CLI automatically. Use its :meth:`~flask.testing.FlaskCliRunner.invoke`
+method to call commands in the same way they would be called from the
+command line. ::
 
     import click
-    from click.testing import CliRunner
 
     @app.cli.command('hello')
     @click.option('--name', default='World')
@@ -429,14 +431,22 @@ captures the output in a :class:`~click.testing.Result` object. ::
         click.echo(f'Hello, {name}!')
 
     def test_hello():
-        runner = CliRunner()
+        runner = app.test_cli_runner()
+
+        # invoke the command directly
         result = runner.invoke(hello_command, ['--name', 'Flask'])
         assert 'Hello, Flask' in result.output
 
+        # or by name
+        result = runner.invoke(args=['hello'])
+        assert 'World' in result.output
+
+In the example above, invoking the command by name is useful because it
+verifies that the command was correctly registered with the app.
+
 If you want to test how your command parses parameters, without running
-the command, use the command's :meth:`~click.BaseCommand.make_context`
-method. This is useful for testing complex validation rules and custom
-types. ::
+the command, use its :meth:`~click.BaseCommand.make_context` method.
+This is useful for testing complex validation rules and custom types. ::
 
     def upper(ctx, param, value):
         if value is not None:

--- a/flask/app.py
+++ b/flask/app.py
@@ -311,6 +311,14 @@ class Flask(_PackageBoundObject):
     #: .. versionadded:: 0.7
     test_client_class = None
 
+    #: The :class:`~click.testing.CliRunner` subclass, by default
+    #: :class:`~flask.testing.FlaskCliRunner` that is used by
+    #: :meth:`test_cli_runner`. Its ``__init__`` method should take a
+    #: Flask app object as the first argument.
+    #:
+    #: .. versionadded:: 1.0
+    test_cli_runner_class = None
+
     #: the session interface to use.  By default an instance of
     #: :class:`~flask.sessions.SecureCookieSessionInterface` is used here.
     #:
@@ -982,6 +990,23 @@ class Flask(_PackageBoundObject):
         if cls is None:
             from flask.testing import FlaskClient as cls
         return cls(self, self.response_class, use_cookies=use_cookies, **kwargs)
+
+    def test_cli_runner(self, **kwargs):
+        """Create a CLI runner for testing CLI commands.
+        See :ref:`testing-cli`.
+
+        Returns an instance of :attr:`test_cli_runner_class`, by default
+        :class:`~flask.testing.FlaskCliRunner`. The Flask app object is
+        passed as the first argument.
+
+        .. versionadded:: 1.0
+        """
+        cls = self.test_cli_runner_class
+
+        if cls is None:
+            from flask.testing import FlaskCliRunner as cls
+
+        return cls(self, **kwargs)
 
     def open_session(self, request):
         """Creates or opens a new session.  Default implementation stores all


### PR DESCRIPTION
Using a regular `CliRunner` requires passing a `ScriptInfo` instance that knows how to load the app being tested, otherwise `app.cli` commands will fail. This adds `app.test_cli_runner`, which creates an instance of `app.test_cli_runner_class`, which defaults to `FlaskCliRunner`.

This runner's `invoke` method adds `obj=ScriptInfo(create_app=lambda: app)` so that invoking commands works as expected. It also sets the command to `app.cli` by default, so `invoke(args=['my-command', ...])` can invoke commands by name to test that they were actually registered.