### PR TITLE
don't use Flask(__name__) in conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ class Flask(_Flask):
 
 @pytest.fixture
 def app():
-    app = Flask(__name__)
+    app = Flask('flask_test', root_path=os.path.dirname(__file__))
     return app
 
 

--- a/tests/test_appctx.py
+++ b/tests/test_appctx.py
@@ -215,5 +215,5 @@ def test_clean_pop(app):
     except ZeroDivisionError:
         pass
 
-    assert called == ['conftest', 'TEARDOWN']
+    assert called == ['flask_test', 'TEARDOWN']
     assert not flask.current_app


### PR DESCRIPTION
Pytest puts all test directories on `sys.path`. Flask determines the `root_path` by import, so the path of the app in `tests/conftest.py` will think the root is `examples/tutorial/tests/` if the example also has a `conftest.py`.