### PR TITLE
Add tips for 413 connection reset issue

### DIFF
--- a/docs/patterns/fileuploads.rst
+++ b/docs/patterns/fileuploads.rst
@@ -153,6 +153,12 @@ The code above will limit the maximum allowed payload to 16 megabytes.
 If a larger file is transmitted, Flask will raise a
 :exc:`~werkzeug.exceptions.RequestEntityTooLarge` exception.
 
+.. admonition:: Connection Reset Issue
+
+    When using the local development server, you may get a connection
+    reset error instead of a 413 response. You will get the correct
+    status response when running the app with a production WSGI server.
+
 This feature was added in Flask 0.6 but can be achieved in older versions
 as well by subclassing the request object.  For more information on that
 consult the Werkzeug documentation on file handling.


### PR DESCRIPTION
When uploading files exceed the limit set by `MAX_CONTENT_LENGTH`, the flask development server will reset the connection instead of return a 413 response. This behavior confused a lot of people:
- https://stackoverflow.com/questions/7371660/flask-resets-the-connection-instead-of-returning-a-413-when-the-file-is-to-big
- https://stackoverflow.com/questions/19911106/flask-file-upload-limit
- https://stackoverflow.com/questions/30414696/upload-file-larger-than-max-content-length-in-flask-results-connection-reset
