### PR TITLE
Set separate Session Interface for blueprint

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -909,7 +909,7 @@ class Flask(_PackageBoundObject):
         """
 
         session_interface = None
-        if request.blueprint:
+        if request and request.blueprint:
             session_interface = self.blueprints[request.blueprint].session_interface
         return session_interface or self.session_interface
 
@@ -921,7 +921,6 @@ class Flask(_PackageBoundObject):
 
         :param request: an instance of :attr:`request_class`.
         """
-
         session_interface = self.resolve_session_interface(request)
         return session_interface.open_session(self, request)
 

--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -89,6 +89,9 @@ class Blueprint(_PackageBoundObject):
     warn_on_modifications = False
     _got_registered_once = False
 
+    #: the session interface to use. If not set SessionInterface provided by application is used
+    session_interface = None
+
     def __init__(self, name, import_name, static_folder=None,
                  static_url_path=None, template_folder=None,
                  url_prefix=None, subdomain=None, url_defaults=None,
@@ -101,7 +104,6 @@ class Blueprint(_PackageBoundObject):
         self.static_folder = static_folder
         self.static_url_path = static_url_path
         self.deferred_functions = []
-        self.session_interface = None
         if url_defaults is None:
             url_defaults = {}
         self.url_values_defaults = url_defaults

--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -101,6 +101,7 @@ class Blueprint(_PackageBoundObject):
         self.static_folder = static_folder
         self.static_url_path = static_url_path
         self.deferred_functions = []
+        self.session_interface = None
         if url_defaults is None:
             url_defaults = {}
         self.url_values_defaults = url_defaults

--- a/flask/ctx.py
+++ b/flask/ctx.py
@@ -331,7 +331,7 @@ class RequestContext(object):
         # stored on `g` instead of the appcontext).
         self.session = self.app.open_session(self.request)
         if self.session is None:
-            self.session = self.app.make_null_session()
+            self.session = self.app.make_null_session(self.request)
 
     def pop(self, exc=_sentinel):
         """Pops the request context and unbinds it by doing that.  This will


### PR DESCRIPTION
**Idea:** Have separate session interface for each blueprint and app. 
It can be usefull when having one blueprint for site api and other one for pages. 

Added: 
* `session_interface` attribute to Blueprint object
* checking blueprint while creating/saving/etc. session in app
* one test to check this behavior

Usage example:
Assign SessionInterface object to Blueprint just the save way as with Flask application:
```python
blueprint = flask.Blueprint("bp", __name__)
blueprint.session_interface = MySessionInterface()
```