### PR TITLE
rework context docs

### DIFF
--- a/flask/ctx.py
+++ b/flask/ctx.py
@@ -24,18 +24,60 @@ _sentinel = object()
 
 
 class _AppCtxGlobals(object):
-    """A plain object."""
+    """A plain object. Used as a namespace for storing data during an
+    application context.
+
+    Creating an app context automatically creates this object, which is
+    made available as the :data:`g` proxy.
+
+    .. describe:: 'key' in g
+
+        Check whether an attribute is present.
+
+        .. versionadded:: 0.10
+
+    .. describe:: iter(g)
+
+        Return an iterator over the attribute names.
+
+        .. versionadded:: 0.10
+    """
 
     def get(self, name, default=None):
+        """Get an attribute by name, or a default value. Like
+        :meth:`dict.get`.
+
+        :param name: Name of attribute to get.
+        :param default: Value to return if the attribute is not present.
+
+        .. versionadded:: 0.10
+        """
         return self.__dict__.get(name, default)
 
     def pop(self, name, default=_sentinel):
+        """Get and remove an attribute by name. Like :meth:`dict.pop`.
+
+        :param name: Name of attribute to pop.
+        :param default: Value to return if the attribute is not present,
+            instead of raise a ``KeyError``.
+
+        .. versionadded:: 0.11
+        """
         if default is _sentinel:
             return self.__dict__.pop(name)
         else:
             return self.__dict__.pop(name, default)
 
     def setdefault(self, name, default=None):
+        """Get the value of an attribute if it is present, otherwise
+        set and return a default value. Like :meth:`dict.setdefault`.
+
+        :param name: Name of attribute to get.
+        :param: default: Value to set and return if the attribute is not
+            present.
+
+        .. versionadded:: 0.11
+        """
         return self.__dict__.setdefault(name, default)
 
     def __contains__(self, item):

--- a/flask/globals.py
+++ b/flask/globals.py
@@ -25,8 +25,8 @@ _app_ctx_err_msg = '''\
 Working outside of application context.
 
 This typically means that you attempted to use functionality that needed
-to interface with the current application object in a way.  To solve
-this set up an application context with app.app_context().  See the
+to interface with the current application object in some way. To solve
+this, set up an application context with app.app_context().  See the
 documentation for more information.\
 '''
 

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -25,7 +25,26 @@ def make_test_environ_builder(
     app, path='/', base_url=None, subdomain=None, url_scheme=None,
     *args, **kwargs
 ):
-    """Creates a new test builder with some application defaults thrown in."""
+    """Create a :class:`~werkzeug.test.EnvironBuilder`, taking some
+    defaults from the application.
+
+    :param app: The Flask application to configure the environment from.
+    :param path: URL path being requested.
+    :param base_url: Base URL where the app is being served, which
+        ``path`` is relative to. If not given, built from
+        :data:`PREFERRED_URL_SCHEME`, ``subdomain``,
+        :data:`SERVER_NAME`, and :data:`APPLICATION_ROOT`.
+    :param subdomain: Subdomain name to append to :data:`SERVER_NAME`.
+    :param url_scheme: Scheme to use instead of
+        :data:`PREFERRED_URL_SCHEME`.
+    :param json: If given, this is serialized as JSON and passed as
+        ``data``. Also defaults ``content_type`` to
+        ``application/json``.
+    :param args: other positional arguments passed to
+        :class:`~werkzeug.test.EnvironBuilder`.
+    :param kwargs: other keyword arguments passed to
+        :class:`~werkzeug.test.EnvironBuilder`.
+    """
 
     assert (
         not (base_url or subdomain or url_scheme)


### PR DESCRIPTION
closes #1151 

Mostly keeps the same sections and concepts. References to old version behavior is removed since it's no longer relevant. Added more explanation about what to do about "no app / request context" errors, since it comes up constantly on Stack Overflow. Added more cross references and cleaned up many API docs as well to make them more consistent. Added documentation for `_AppCtxGlobals` rather than recreating it in the `g` docs. Added documentation about the `test_request_context` arguments.

This is an inherently advanced topic, so I don't think there's any way to make it completely clear to all readers. Hopefully it's at least easier to follow to get an idea of how the process works.