### PR TITLE
document blueprint static folder without prefix

### DIFF
--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -151,22 +151,30 @@ To quickly open sources from this folder you can use the
 Static Files
 ````````````
 
-A blueprint can expose a folder with static files by providing a path to a
-folder on the filesystem via the `static_folder` keyword argument.  It can
-either be an absolute path or one relative to the folder of the
-blueprint::
+A blueprint can expose a folder with static files by providing the path
+to the folder on the filesystem with the ``static_folder`` argument.
+It is either an absolute path or relative to the blueprint's location::
 
     admin = Blueprint('admin', __name__, static_folder='static')
 
 By default the rightmost part of the path is where it is exposed on the
-web.  Because the folder is called :file:`static` here it will be available at
-the location of the blueprint + ``/static``.  Say the blueprint is
-registered for ``/admin`` the static folder will be at ``/admin/static``.
+web. This can be changed with the ``static_url`` argument. Because the
+folder is called ``static`` here it will be available at the
+``url_prefix`` of the blueprint + ``/static``. If the blueprint
+has the prefix ``/admin``, the static URL will be ``/admin/static``.
 
-The endpoint is named `blueprint_name.static` so you can generate URLs to
-it like you would do to the static folder of the application::
+The endpoint is named ``blueprint_name.static``. You can generate URLs
+to it with :func:`url_for` like you would with the static folder of the
+application::
 
     url_for('admin.static', filename='style.css')
+
+However, if the blueprint does not have a ``url_prefix``, it is not
+possible to access the blueprint's static folder. This is because the
+URL would be ``/static`` in this case, and the application's ``/static``
+route takes precedence. Unlike template folders, blueprint static
+folders are not searched if the file does not exist in the application
+static folder.
 
 Templates
 `````````


### PR DESCRIPTION
closes #348 

Documents that blueprint static URL is only accessible if the blueprint has a prefix, otherwise the application static URL takes precedence.