### PR TITLE
use builtin total_seconds of timedelta object

### DIFF
--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -996,7 +996,7 @@ def total_seconds(td):
     :returns: number of seconds
     :rtype: int
     """
-    return td.days * 60 * 60 * 24 + td.seconds
+    return int(td.total_seconds())
 
 
 def is_ip(value):


### PR DESCRIPTION
It is more efficient to use the builtin `timedelta.total_seconds()`, and cleaner.