### PR TITLE
Add a message `Serving Flask app (module "app.py" will be lazily loaded)` to `flask run` related to #2706

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -933,7 +933,7 @@ class Flask(_PackageBoundObject):
         options.setdefault('use_debugger', self.debug)
         options.setdefault('threaded', True)
 
-        cli.show_server_banner(self.env, self.debug, self.name)
+        cli.show_server_banner(self.env, self.debug, self.name, False)
 
         from werkzeug.serving import run_simple
 

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -614,7 +614,7 @@ def load_dotenv(path=None):
     return new_dir is not None  # at least one file was located and loaded
 
 
-def show_server_banner(env, debug, app_import_path, eager_loading=True):
+def show_server_banner(env, debug, app_import_path, eager_loading):
     """Show extra startup messages the first time the server is run,
     ignoring the reloader.
     """
@@ -623,11 +623,13 @@ def show_server_banner(env, debug, app_import_path, eager_loading=True):
 
     if app_import_path is not None:
         message = ' * Serving Flask app "{0}"'.format(app_import_path)
+
         if not eager_loading:
             message += ' (lazy loading)'
-        print(message)
 
-    print(' * Environment: {0}'.format(env))
+        click.echo(message)
+
+    click.echo(' * Environment: {0}'.format(env))
 
     if env == 'production':
         click.secho(
@@ -636,7 +638,7 @@ def show_server_banner(env, debug, app_import_path, eager_loading=True):
         click.secho('   Use a production WSGI server instead.', dim=True)
 
     if debug is not None:
-        print(' * Debug mode: {0}'.format('on' if debug else 'off'))
+        click.echo(' * Debug mode: {0}'.format('on' if debug else 'off'))
 
 
 class CertParamType(click.ParamType):

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -614,7 +614,7 @@ def load_dotenv(path=None):
     return new_dir is not None  # at least one file was located and loaded
 
 
-def show_server_banner(env, debug, app_import_path):
+def show_server_banner(env, debug, app_import_path, eager_loading=True):
     """Show extra startup messages the first time the server is run,
     ignoring the reloader.
     """
@@ -622,7 +622,10 @@ def show_server_banner(env, debug, app_import_path):
         return
 
     if app_import_path is not None:
-        print(' * Serving Flask app "{0}"'.format(app_import_path))
+        message = ' * Serving Flask app "{0}"'.format(app_import_path)
+        if not eager_loading:
+            message += ' (lazy loading)'
+        print(message)
 
     print(' * Environment: {0}'.format(env))
 
@@ -759,7 +762,7 @@ def run_command(info, host, port, reload, debugger, eager_loading,
     if eager_loading is None:
         eager_loading = not reload
 
-    show_server_banner(get_env(), debug, info.app_import_path)
+    show_server_banner(get_env(), debug, info.app_import_path, eager_loading)
     app = DispatchingApp(info.load_app, use_eager_loading=eager_loading)
 
     from werkzeug.serving import run_simple


### PR DESCRIPTION
When running `flask run` having `FLASK_DEBUG=1` the `lazy_loader` options defaults to True and it causes the `app` to be loaded only when first request comes causing errors to be raised only to werkzeug debugger (on browser)

# problem

When starting the command `flask run` you see `Serving Flask app..` message even if the `app` module cannot be located because the error will only raise later. It can cause confusion and the false impression that the `app` module was successfully found.

To be noticed and have it explicitly in logs I added:

` * Serving Flask app "app.py" (lazy loading)` to the messages

```bash
$ flask run                                                                    
 * Serving Flask app "app.py" (lazy loading)
```
Relates to #2706 