### PR TITLE
Minor session serializer fixes.

### DIFF
--- a/flask/json/tag.py
+++ b/flask/json/tag.py
@@ -243,7 +243,7 @@ class TaggedJSONSerializer(object):
         for cls in self.default_tags:
             self.register(cls)
 
-    def register(self, tag_class, force=False, index=-1):
+    def register(self, tag_class, force=False, index=None):
         """Register a new tag with this serializer.
 
         :param tag_class: tag class to register. Will be instantiated with this
@@ -251,8 +251,8 @@ class TaggedJSONSerializer(object):
         :param force: overwrite an existing tag. If false (default), a
             :exc:`KeyError` is raised.
         :param index: index to insert the new tag in the tag order. Useful when
-            the new tag is a special case of an existing tag. If -1 (default),
-            the tag is appended to the end of the order.
+            the new tag is a special case of an existing tag. If ``None``
+            (default), the tag is appended to the end of the order.
 
         :raise KeyError: if the tag key is already registered and ``force`` is
             not true.
@@ -266,7 +266,7 @@ class TaggedJSONSerializer(object):
 
             self.tags[key] = tag
 
-        if index == -1:
+        if index is None:
             self.order.append(tag)
         else:
             self.order.insert(index, tag)

--- a/flask/json/tag.py
+++ b/flask/json/tag.py
@@ -36,7 +36,7 @@ processes dicts first, so insert the new tag at the front of the order since
         def to_python(self, value):
             return OrderedDict(value)
 
-    app.session_interface.serializer.register(TagOrderedDict, 0)
+    app.session_interface.serializer.register(TagOrderedDict, index=0)
 
 :copyright: © 2010 by the Pallets team.
 :license: BSD, see LICENSE for more details.

--- a/tests/test_json_tag.py
+++ b/tests/test_json_tag.py
@@ -72,3 +72,19 @@ def test_tag_interface():
     pytest.raises(NotImplementedError, t.check, None)
     pytest.raises(NotImplementedError, t.to_json, None)
     pytest.raises(NotImplementedError, t.to_python, None)
+
+
+def test_tag_order():
+    class Tag1(JSONTag):
+        key = ' 1'
+
+    class Tag2(JSONTag):
+        key = ' 2'
+
+    s = TaggedJSONSerializer()
+
+    s.register(Tag1, index=-1)
+    assert isinstance(s.order[-2], Tag1)
+
+    s.register(Tag2, index=None)
+    assert isinstance(s.order[-1], Tag2)


### PR DESCRIPTION
A couple of minor fixes for the extensible session serializer added by #2352.

There were two issues observed:

1. The example usage of ``register()`` passes and ``index`` to the ``force`` argument.
2. It is not possible to insert a tag as the penultimate item in the order list.

Regarding the latter, `a.append(x)` is not the same as `a.insert(-1, x)` - it is `a.insert(len(a), x)`.

It would be good to get these out before the release of 1.0.0 so that the index default is correct.

- [x] add tests that fail without the patch
- [x] ensure all tests pass with ``pytest``
- [x] add documentation to the relevant docstrings or pages
- [ ] ~~add ``versionadded`` or ``versionchanged`` directives to relevant docstrings~~
- [ ] ~~add a changelog entry if this patch changes code~~ *Not required as the feature is unreleased?*
