### PR TITLE
Add `python_requires` metadata for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     platforms='any',
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     install_requires=[
         'Werkzeug>=0.14',
         'Jinja2>=2.10',

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     platforms='any',
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
     install_requires=[
         'Werkzeug>=0.14',
         'Jinja2>=2.10',


### PR DESCRIPTION
Prevents pip from seeing the dist on unsupported Python versions.