### PR TITLE
error on file upload document

### DIFF
--- a/docs/patterns/fileuploads.rst
+++ b/docs/patterns/fileuploads.rst
@@ -65,7 +65,7 @@ the file and redirects the user to the URL for the uploaded file::
             if file and allowed_file(file.filename):
                 filename = secure_filename(file.filename)
                 file.save(os.path.join(app.config['UPLOAD_FOLDER'], filename))
-                return redirect(url_for('upload_file',
+                return redirect(url_for('uploaded_file',
                                         filename=filename))
         return '''
         <!doctype html>


### PR DESCRIPTION
In file upload example, after file uploaded, it should redirect to uploaded_file page instead of upload_file page.