### PR TITLE
Fixed Debug default value in the docs

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -112,7 +112,7 @@ The following configuration values are used internally by Flask:
 
     **Do not enable debug mode when deploying in production.**
 
-    Default: ``True`` if :data:`ENV` is ``'production'``, or ``False``
+    Default: ``True`` if :data:`ENV` is ``'development'``, or ``False``
     otherwise.
 
 .. py:data:: TESTING


### PR DESCRIPTION
Fix Debug Default: By default Debug is only True when ENV is 'development' instead of 'production'

