### PR TITLE
fix #2736 - remove explicit check for list as a return value in make_response

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -1923,7 +1923,7 @@ class Flask(_PackageBoundObject):
         status = headers = None
 
         # unpack tuple returns
-        if isinstance(rv, (tuple, list)):
+        if isinstance(rv, tuple):
             len_rv = len(rv)
 
             # a 3-tuple is unpacked directly


### PR DESCRIPTION
This PR addresses an issue introduced in #2256 which breaks a custom response class that supports returning lists from view functions.

A list is not an expected response value and is not intended to be handled by `make_response`. I'm unsure why it made it's way into this instance check, but there are no consequences to removing it, based on what I can see in the tests & related code.