### PR TITLE
Only trap key errors by default in debug, not all BadRequest errors

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -1663,8 +1663,14 @@ class Flask(_PackageBoundObject):
 
         trap_bad_request = self.config['TRAP_BAD_REQUEST_ERRORS']
 
-        # if unset, trap based on debug mode
-        if (trap_bad_request is None and self.debug) or trap_bad_request:
+        # if unset, trap key errors in debug mode
+        if (
+            trap_bad_request is None and self.debug
+            and isinstance(e, BadRequestKeyError)
+        ):
+            return True
+
+        if trap_bad_request:
             return isinstance(e, BadRequest)
 
         return False


### PR DESCRIPTION
closes #2735 

In order to make debugging key errors from `request.form` easier, #2348 trapped `BadRequest` errors by default in debug mode. However, this caught *all* `BadRequest` errors, not just `BadRequestKeyError`. This changes the behavior so `BadRequestKeyError` is caught in debug mode, but `abort(400)` still passes through.