### PR TITLE
allow empty prefix and no lead slash in bp route

### DIFF
--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -65,7 +65,7 @@ class BlueprintSetupState(object):
         to the application.  The endpoint is automatically prefixed with the
         blueprint's name.
         """
-        if self.url_prefix:
+        if self.url_prefix is not None:
             rule = '/'.join((self.url_prefix, rule.lstrip('/')))
         options.setdefault('subdomain', self.subdomain)
         if endpoint is None:


### PR DESCRIPTION
closes #2742

Fix `url_prefx=''` or `url_prefix='/'` when Blueprint routes don't begin with a leading slash. Technically, routes should start with a leading slash, so don't rely on this behavior.