### PR TITLE
Fix blueprint route for ""

### DIFF
--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -10,6 +10,7 @@
     :license: BSD, see LICENSE for more details.
 """
 from functools import update_wrapper
+from werkzeug.urls import url_join
 
 from .helpers import _PackageBoundObject, _endpoint_from_view_func
 
@@ -49,8 +50,6 @@ class BlueprintSetupState(object):
         url_prefix = self.options.get('url_prefix')
         if url_prefix is None:
             url_prefix = self.blueprint.url_prefix
-        if url_prefix:
-            url_prefix = url_prefix.rstrip('/')
         #: The prefix that should be used for all URLs defined on the
         #: blueprint.
         self.url_prefix = url_prefix
@@ -67,7 +66,8 @@ class BlueprintSetupState(object):
         """
         if self.url_prefix is not None:
             if rule:
-                rule = '/'.join((self.url_prefix, rule.lstrip('/')))
+                rule = '/'.join((
+                    self.url_prefix.rstrip('/'), rule.lstrip('/')))
             else:
                 rule = self.url_prefix
         options.setdefault('subdomain', self.subdomain)

--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -66,7 +66,10 @@ class BlueprintSetupState(object):
         blueprint's name.
         """
         if self.url_prefix is not None:
-            rule = '/'.join((self.url_prefix, rule.lstrip('/')))
+            if rule:
+                rule = '/'.join((self.url_prefix, rule.lstrip('/')))
+            else:
+                rule = self.url_prefix
         options.setdefault('subdomain', self.subdomain)
         if endpoint is None:
             endpoint = _endpoint_from_view_func(view_func)

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -116,6 +116,7 @@ def test_blueprint_app_error_handling(app, client):
 
 
 @pytest.mark.parametrize(('prefix', 'rule', 'url'), (
+    ('/foo', '', '/foo'),
     ('/foo/', '/bar', '/foo/bar'),
     ('/foo/', 'bar', '/foo/bar'),
     ('/foo', '/bar', '/foo/bar'),

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -116,7 +116,12 @@ def test_blueprint_app_error_handling(app, client):
 
 
 @pytest.mark.parametrize(('prefix', 'rule', 'url'), (
+    ('', '/', '/'),
+    ('/', '', '/'),
+    ('/', '/', '/'),
     ('/foo', '', '/foo'),
+    ('/foo/', '', '/foo/'),
+    ('', '/bar', '/bar'),
     ('/foo/', '/bar', '/foo/bar'),
     ('/foo/', 'bar', '/foo/bar'),
     ('/foo', '/bar', '/foo/bar'),


### PR DESCRIPTION
1. url_prefix = '/posts'
2. rule = ''

Expected result `/posts`, instead got `/posts/`.