### PR TITLE
Fixed LaTeX errors on documentation PDF generation

### DIFF
--- a/docs/flaskstyle.sty
+++ b/docs/flaskstyle.sty
@@ -1,11 +1,17 @@
 \definecolor{TitleColor}{rgb}{0,0,0}
 \definecolor{InnerLinkColor}{rgb}{0,0,0}
 
+% Replace Unicode character 'PARTY POPPER' (U+1F389) with a non-breaking space.
+% pdfLaTeX doesn't support Unicode.
+\DeclareUnicodeCharacter{1F389}{\nobreakspace}
+
 \renewcommand{\maketitle}{%
   \begin{titlepage}%
     \let\footnotesize\small
     \let\footnoterule\relax
-    \ifsphinxpdfoutput
+    % Apply following fix only on PDF output, i.e. pdfoutput macro is not 
+    % undefined
+    \ifx\pdfoutput\undefined\else
       \begingroup
       % This \def is required to deal with multi-line authors; it
       % changes \\ to ', ' (comma-space), making it pass muster for


### PR DESCRIPTION
This PR fixes problems with the generation of the PDF documentation from LaTeX files. 

First issue was a problematic emoji character in the documentation, which the LaTeX distribution used in the build process didn't understand. The least invasive fix was to replace it with a space. Alternative fixes would be removal of the character causing errors or adapting the build process.

Second issue was the missing `\ifsphinxpdfoutput` macro. In this case it was only used to check if the output is PDF, which is now handled with an appropriate if statement.

Relevant issues:
https://github.com/pallets/flask/issues/2514
https://github.com/pallets/flask-docs/issues/3