### PR TITLE
templates_auto_reload workaround

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -708,6 +708,11 @@ class Flask(_PackageBoundObject):
     def _set_templates_auto_reload(self, value):
         self.config['TEMPLATES_AUTO_RELOAD'] = value
 
+        # workaround to not create jinja_env if it has not been created
+        if 'jinja_env' in self.__dict__:
+            # if it was created, also modify the underlying (jinja) config
+            self.jinja_env.auto_reload = value
+
     templates_auto_reload = property(
         _get_templates_auto_reload, _set_templates_auto_reload
     )


### PR DESCRIPTION
When jinja was already set up (by having some template filters for
example), modify the jinja_env to it will take the modification into
account.
Otherwise this decorator doesn't do anything in that case

Workaround for #2755, this does not fix the config dict not being taken into account