### PR TITLE
docs: installation: Fix "now you can continue" link

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -142,6 +142,8 @@ update the code from the master branch:
 
     pip install -U https://github.com/pallets/flask/archive/master.tar.gz
 
+Once you've installed Flask you can continue to :ref:`quickstart`.
+
 .. _install-install-virtualenv:
 
 Install virtualenv

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -132,6 +132,9 @@ Within the activated environment, use the following command to install Flask:
 
     pip install Flask
 
+Flask is now installed. Check out the :doc:`/quickstart` or go to the
+:doc:`Documentation Overview </index>`.
+
 Living on the edge
 ~~~~~~~~~~~~~~~~~~
 
@@ -141,8 +144,6 @@ update the code from the master branch:
 .. code-block:: sh
 
     pip install -U https://github.com/pallets/flask/archive/master.tar.gz
-
-Once you've installed Flask you can continue to :ref:`quickstart`.
 
 .. _install-install-virtualenv:
 
@@ -179,7 +180,7 @@ On Windows, as an administrator:
     \Python27\python.exe Downloads\get-pip.py
     \Python27\python.exe -m pip install virtualenv
 
-Now you can continue to :ref:`install-create-env`.
+Now you can return above and :ref:`install-create-env`.
 
 .. _virtualenv: https://virtualenv.pypa.io/
 .. _get-pip.py: https://bootstrap.pypa.io/get-pip.py


### PR DESCRIPTION
At the end of the installation docs we currently
point the reader back into the middle of the
installation doc itself, which is probably not very
helpful to the reader since they just finished
reading that.

Instead, point to the next section in the docs
(Quickstart).