### PR TITLE
Add option to not overwrite debug flag in cli

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,8 +12,11 @@ Unreleased
 -   :func:`send_file` encodes filenames as ASCII instead of Latin-1
     (ISO-8859-1). This fixes compatibility with Gunicorn, which is
     stricter about header encodings than PEP 3333. (`#2766`_)
+-   Allow custom CLIs using ``FlaskGroup`` to set the debug flag without
+    it always being overwritten based on environment variables. (`#2765`_)
 
 .. _#2766: https://github.com/pallets/flask/issues/2766
+.. _#2765: https://github.com/pallets/flask/pull/2765
 
 
 Version 1.0.2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -356,6 +356,28 @@ def test_flaskgroup(runner):
     assert result.output == 'flaskgroup\n'
 
 
+@pytest.mark.parametrize('set_debug_flag', (True, False))
+def test_flaskgroup_debug(runner, set_debug_flag):
+    """Test FlaskGroup debug flag behavior."""
+
+    def create_app(info):
+        app = Flask("flaskgroup")
+        app.debug = True
+        return app
+
+    @click.group(cls=FlaskGroup, create_app=create_app, set_debug_flag=set_debug_flag)
+    def cli(**params):
+        pass
+
+    @cli.command()
+    def test():
+        click.echo(str(current_app.debug))
+
+    result = runner.invoke(cli, ['test'])
+    assert result.exit_code == 0
+    assert result.output == '%s\n' % str(not set_debug_flag)
+
+
 def test_print_exceptions(runner):
     """Print the stacktrace if the CLI."""
 


### PR DESCRIPTION
This is intended for custom CLIs that may load a config file which already sets the debug flag and does not make use of the `FLASK_*` env vars at all.

Filed against 1,0-maintenance since this is functionality that was present before and was lost between 0.12 and 1.0.