### PR TITLE
[Docs] Make super() compatible for Python2

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -124,7 +124,7 @@ handler. ::
         def format(self, record):
             record.url = request.url
             record.remote_addr = request.remote_addr
-            return super().format(record)
+            return super(RequestFormatter, self).format(record)
 
     formatter = RequestFormatter(
         '[%(asctime)s] %(remote_addr)s requested %(url)s\n'


### PR DESCRIPTION
Using `super()` with arguments for backward compatible.