### PR TITLE
Added parameter to click.echo call

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -626,7 +626,7 @@ def show_server_banner(env, debug, app_import_path, eager_loading):
         if not eager_loading:
             message += ' (lazy loading)'
 
-        click.echo(message)
+        click.echo(message, sys.stdout)
 
     click.echo(' * Environment: {0}'.format(env))
 


### PR DESCRIPTION
Added sys.stdout as a second parameter to click.echo. This helps with the 'UnsupportedOperation: not writable' error in Jupyter.

I think that Jupyter hijacks and locks the STDOUT/STDERR (at least the one click is trying to use) and if you don't provide a stream to click.echo(), it will attempt writing to the STDOUT/STDERR, hence the error.


<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
