### PR TITLE
Update gevent wsgi

### DIFF
--- a/docs/deploying/wsgi-standalone.rst
+++ b/docs/deploying/wsgi-standalone.rst
@@ -50,7 +50,7 @@ Gevent
 `greenlet`_ to provide a high-level synchronous API on top of `libev`_
 event loop::
 
-    from gevent.wsgi import WSGIServer
+    from gevent.pywsgi import WSGIServer
     from yourapplication import app
 
     http_server = WSGIServer(('', 5000), app)


### PR DESCRIPTION
gevent.wsgi is deprecated since gevent 1.1 and removed in gevent 1.3. 
gevent.pywsgi should be used instead

Describe what this patch does to fix the issue.

Link to any relevant issues or pull requests.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
