### PR TITLE
Session cookie secure by default

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -206,7 +206,7 @@ The following configuration values are used internally by Flask:
     marked "secure". The application must be served over HTTPS for this to make
     sense.
 
-    Default: ``False``
+    Default: ``True``
 
 .. py:data:: SESSION_COOKIE_SAMESITE
 

--- a/flask/app.py
+++ b/flask/app.py
@@ -293,7 +293,7 @@ class Flask(_PackageBoundObject):
         'SESSION_COOKIE_DOMAIN':                None,
         'SESSION_COOKIE_PATH':                  None,
         'SESSION_COOKIE_HTTPONLY':              True,
-        'SESSION_COOKIE_SECURE':                False,
+        'SESSION_COOKIE_SECURE':                True,
         'SESSION_COOKIE_SAMESITE':              None,
         'SESSION_REFRESH_EACH_REQUEST':         True,
         'MAX_CONTENT_LENGTH':                   None,


### PR DESCRIPTION
I strongly believe that more secure options should be the default. I know this is a breaking change and might spark some controversy, as it would break loads of small hobby projects that lack https running on localhost etc. 

I'm not too sure about under which version I should edit changes.rst and which version versionchanged should mention, so I will update those later if you decide to go through with this change. Sorry for the imperfect PR for now!