### PR TITLE
set FLASK_APP via env for portability across shells

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ A Simple Example
 
 .. code-block:: text
 
-    $ FLASK_APP=hello.py flask run
+    $ env FLASK_APP=hello.py flask run
      * Serving Flask app "hello"
      * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
 


### PR DESCRIPTION
this does not work on fish (https://fishshell.com):
```shell
$ FLASK_APP=hello.py flask run
```

while this works (hopefully) on any shell:
```shell
$ env FLASK_APP=hello.py flask run
```