### PR TITLE
Uwsgi link

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -289,6 +289,53 @@ group. This is useful if you want to organize multiple related commands. ::
 
     flask user create demo
 
+
+If your application uses blueprints, you can optionally register cli
+commands directly onto them.
+When your blueprint is registered onto your application the associated
+commands will be available to the ``flask`` command.
+By default those commands will be nested in a group matching the
+name of the blueprint. ::
+
+    from flask import Blueprint
+    bp = Blueprint('students', __name__)
+
+    @bp.cli.command('create')
+    @click.argument('name')
+    def create(name):
+        ...
+
+    app.register_blueprint(bp)
+
+::
+
+    flask students create alice
+
+You can alter the cli group name by specifying the ``cli_group`` keyword
+argument when creating the :class:`Blueprint` object or later during
+:meth:`app.register_blueprint(bp, cli_group='...') <Flask.register_blueprint>`
+process, the following are equivilant::
+
+    bp = Blueprint('students', __name__, cli_group='other')
+    ...
+    app.register_blueprint(bp, cli_group='other')
+
+::
+
+    flask other create alice
+
+Specifying ``cli_group=None`` will remove the nesting and merge the commands
+directly to the application's level::
+
+    bp = Blueprint('students', __name__, cli_group=None)
+    ...
+    app.register_blueprint(bp, cli_group=None)
+
+::
+
+    flask create alice
+
+
 See :ref:`testing-cli` for an overview of how to test your custom
 commands.
 

--- a/docs/deploying/wsgi-standalone.rst
+++ b/docs/deploying/wsgi-standalone.rst
@@ -37,11 +37,10 @@ Running `uWSGI HTTP Router`_::
 
     uwsgi --http 127.0.0.1:5000 --module myproject:app
 
-For a more optimized setup, see `configuring uWSGI and NGINX`_.
+For a more optimized setup, see :ref:`configuring uWSGI and NGINX <deploying-uwsgi>`.
 
 .. _uWSGI: http://uwsgi-docs.readthedocs.io/en/latest/
 .. _uWSGI HTTP Router: http://uwsgi-docs.readthedocs.io/en/latest/HTTP.html#the-uwsgi-http-https-router
-.. _configuring uWSGI and NGINX: uwsgi.html#starting-your-app-with-uwsgi
 
 Gevent
 -------

--- a/flask/app.py
+++ b/flask/app.py
@@ -562,13 +562,14 @@ class Flask(_PackageBoundObject):
                 view_func=self.send_static_file
             )
 
-        #: The click command line context for this application.  Commands
+        #: Set the name of the cli context for this application.  Commands
         #: registered here show up in the :command:`flask` command once the
         #: application has been discovered.  The default commands are
         #: provided by Flask itself and can be overridden.
         #:
-        #: This is an instance of a :class:`click.Group` object.
-        self.cli = cli.AppGroup(self.name)
+        #: Set the name of the :class:``cli.AppGroup`` instance to allow
+        #: commands to be registered on the application.
+        self.cli.name = self.name
 
     @locked_cached_property
     def name(self):

--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -118,7 +118,7 @@ class Blueprint(_PackageBoundObject):
     def __init__(self, name, import_name, static_folder=None,
                  static_url_path=None, template_folder=None,
                  url_prefix=None, subdomain=None, url_defaults=None,
-                 root_path=None):
+                 root_path=None, cli_group=-1):
         _PackageBoundObject.__init__(self, import_name, template_folder,
                                      root_path=root_path)
         self.name = name
@@ -130,6 +130,7 @@ class Blueprint(_PackageBoundObject):
         if url_defaults is None:
             url_defaults = {}
         self.url_values_defaults = url_defaults
+        self.cli_group = cli_group
 
     def record(self, func):
         """Registers a function that is called when the blueprint is
@@ -185,6 +186,16 @@ class Blueprint(_PackageBoundObject):
 
         for deferred in self.deferred_functions:
             deferred(state)
+
+        cli_resolved_group = options.get('cli_group', self.cli_group)
+        if cli_resolved_group is None:
+            app.cli.commands.update(self.cli.commands)
+        elif cli_resolved_group == -1:
+            self.cli.name = self.name
+            app.cli.add_command(self.cli)
+        else:
+            self.cli.name = cli_resolved_group
+            app.cli.add_command(self.cli)
 
     def route(self, rule, **options):
         """Like :meth:`Flask.route` but for a blueprint.  The endpoint for the

--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -14,6 +14,9 @@ from werkzeug.urls import url_join
 
 from .helpers import _PackageBoundObject, _endpoint_from_view_func
 
+# a singleton sentinel value for parameter defaults
+_sentinel = object()
+
 
 class BlueprintSetupState(object):
     """Temporary holder object for registering a blueprint with the
@@ -118,7 +121,7 @@ class Blueprint(_PackageBoundObject):
     def __init__(self, name, import_name, static_folder=None,
                  static_url_path=None, template_folder=None,
                  url_prefix=None, subdomain=None, url_defaults=None,
-                 root_path=None, cli_group=-1):
+                 root_path=None, cli_group=_sentinel):
         _PackageBoundObject.__init__(self, import_name, template_folder,
                                      root_path=root_path)
         self.name = name
@@ -190,7 +193,7 @@ class Blueprint(_PackageBoundObject):
         cli_resolved_group = options.get('cli_group', self.cli_group)
         if cli_resolved_group is None:
             app.cli.commands.update(self.cli.commands)
-        elif cli_resolved_group == -1:
+        elif cli_resolved_group is _sentinel:
             self.cli.name = self.name
             app.cli.add_command(self.cli)
         else:

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -15,6 +15,7 @@ import sys
 import pkgutil
 import posixpath
 import mimetypes
+from . import cli
 from time import time
 from zlib import adler32
 from threading import RLock
@@ -886,6 +887,14 @@ class _PackageBoundObject(object):
         self.root_path = root_path
         self._static_folder = None
         self._static_url_path = None
+
+        #: The click command line context for registration of cli commands
+        #: on the application and associated blueprints, accessible via the
+        #: :command:`flask` command once the application has been discovered
+        #: and blueprints optionally registered.
+        #:
+        #: This is an instance of a :class:`click.Group` object.
+        self.cli = cli.AppGroup()
 
     def _get_static_folder(self):
         if self._static_folder is not None:

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -15,7 +15,7 @@ import sys
 import pkgutil
 import posixpath
 import mimetypes
-from . import cli
+import flask.cli
 from time import time
 from zlib import adler32
 from threading import RLock
@@ -894,7 +894,7 @@ class _PackageBoundObject(object):
         #: and blueprints optionally registered.
         #:
         #: This is an instance of a :class:`click.Group` object.
-        self.cli = cli.AppGroup()
+        self.cli = flask.cli.AppGroup()
 
     def _get_static_folder(self):
         if self._static_folder is not None:


### PR DESCRIPTION
Fixes #2802 

Just changed the link to be a `:ref:` to the `uwsgi` document.  Also mean it links to the top of the document, so includes the 'watch out' admonition for extra clarity.