### PR TITLE
Set uwsgi link to use :ref:

### DIFF
--- a/docs/deploying/wsgi-standalone.rst
+++ b/docs/deploying/wsgi-standalone.rst
@@ -37,11 +37,10 @@ Running `uWSGI HTTP Router`_::
 
     uwsgi --http 127.0.0.1:5000 --module myproject:app
 
-For a more optimized setup, see `configuring uWSGI and NGINX`_.
+For a more optimized setup, see :ref:`configuring uWSGI and NGINX <deploying-uwsgi>`.
 
 .. _uWSGI: http://uwsgi-docs.readthedocs.io/en/latest/
 .. _uWSGI HTTP Router: http://uwsgi-docs.readthedocs.io/en/latest/HTTP.html#the-uwsgi-http-https-router
-.. _configuring uWSGI and NGINX: uwsgi.html#starting-your-app-with-uwsgi
 
 Gevent
 -------


### PR DESCRIPTION
Fixes #2802

Changed the link to be a `:ref:` to the `uwsgi` document. Also mean it links to the top of the document, so includes the 'watch out' admonition for extra clarity.
