### PR TITLE
Fixes issue #2824 flask --version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,9 +14,12 @@ Unreleased
     stricter about header encodings than PEP 3333. (`#2766`_)
 -   Allow custom CLIs using ``FlaskGroup`` to set the debug flag without
     it always being overwritten based on environment variables. (`#2765`_)
+-   ``flask --version`` outputs Werkzeug's version and simplifies the
+    Python version. (`#2825`_)
 
 .. _#2766: https://github.com/pallets/flask/issues/2766
 .. _#2765: https://github.com/pallets/flask/pull/2765
+.. _#2825: https://github.com/pallets/flask/pull/2825
 
 
 Version 1.0.2

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 import ast
 import inspect
 import os
+import platform
 import re
 import ssl
 import sys
@@ -21,7 +22,6 @@ import traceback
 from functools import update_wrapper
 from operator import attrgetter
 from threading import Lock, Thread
-import werkzeug
 
 import click
 from werkzeug.utils import import_string
@@ -260,11 +260,16 @@ def locate_app(script_info, module_name, app_name, raise_if_not_found=True):
 def get_version(ctx, param, value):
     if not value or ctx.resilient_parsing:
         return
-    message = 'Python %(python_version)s\nFlask %(version)s\nWerkzeug %(werkzeug_version)s'
+    import werkzeug
+    message = (
+        'Python %(python)s\n'
+        'Flask %(flask)s\n'
+        'Werkzeug %(werkzeug)s'
+    )
     click.echo(message % {
-        'version': __version__,
-        'python_version': sys.version,
-        'werkzeug_version': werkzeug.__version__,
+        'python': platform.python_version(),
+        'flask': __version__,
+        'werkzeug': werkzeug.__version__,
     }, color=ctx.color)
     ctx.exit()
 

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -21,6 +21,7 @@ import traceback
 from functools import update_wrapper
 from operator import attrgetter
 from threading import Lock, Thread
+import werkzeug
 
 import click
 from werkzeug.utils import import_string
@@ -259,10 +260,11 @@ def locate_app(script_info, module_name, app_name, raise_if_not_found=True):
 def get_version(ctx, param, value):
     if not value or ctx.resilient_parsing:
         return
-    message = 'Flask %(version)s\nPython %(python_version)s'
+    message = 'Python %(python_version)s\nFlask %(version)s\nWerkzeug %(werkzeug_version)s'
     click.echo(message % {
         'version': __version__,
         'python_version': sys.version,
+        'werkzeug_version': werkzeug.__version__,
     }, color=ctx.color)
     ctx.exit()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -241,9 +241,9 @@ def test_locate_app_suppress_raise():
 
 
 def test_get_version(test_apps, capsys):
-    """Test of get_version."""
-    from flask import __version__ as flask_ver
-    from sys import version as py_ver
+    from flask import __version__ as flask_version
+    from werkzeug import __version__ as werkzeug_version
+    from platform import python_version
 
     class MockCtx(object):
         resilient_parsing = False
@@ -254,8 +254,9 @@ def test_get_version(test_apps, capsys):
     ctx = MockCtx()
     get_version(ctx, None, "test")
     out, err = capsys.readouterr()
-    assert flask_ver in out
-    assert py_ver in out
+    assert "Python " + python_version() in out
+    assert "Flask " + flask_version in out
+    assert "Werkzeug " + werkzeug_version in out
 
 
 def test_scriptinfo(test_apps, monkeypatch):


### PR DESCRIPTION
Fixes issue [2824](https://github.com/pallets/flask/issues/2824)

Now when you run ```flask --version``` command it shows you the Werkzeug version as well. I changed the order as well to be Python, Flask and Werkzeug as it is shown in the issue template.

Let me know if it has to be done in some other way.