### PR TITLE
[Fixed 2823] Checking if .env is file before prompting to install dotenv

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -584,7 +584,7 @@ def load_dotenv(path=None):
     .. versionadded:: 1.0
     """
     if dotenv is None:
-        if path or os.path.exists('.env') or os.path.exists('.flaskenv'):
+        if path or os.path.isfile('.env') or os.path.isfile('.flaskenv'):
             click.secho(
                 ' * Tip: There are .env files present.'
                 ' Do "pip install python-dotenv" to use them.',


### PR DESCRIPTION
This PR fixes the issue of wrongly prompting to install dotenv if .env is a file

Link to any relevant issues or pull requests.
https://github.com/pallets/flask/issues/2823

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
