### PR TITLE
Update cli tips for .flaskenv

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -591,7 +591,7 @@ def load_dotenv(path=None):
     if dotenv is None:
         if path or os.path.isfile('.env') or os.path.isfile('.flaskenv'):
             click.secho(
-                ' * Tip: There are .env files present.'
+                ' * Tip: There are .env or .flaskenv files present.'
                 ' Do "pip install python-dotenv" to use them.',
                 fg='yellow')
         return


### PR DESCRIPTION
If people have a .flaskenv but python-dotenv not installed, the old tip may confuse them.