### PR TITLE
Add `JSON_STRICT` config option

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -315,6 +315,14 @@ The following configuration values are used internally by Flask:
 
     Default: ``True``
 
+.. py:data:: JSON_STRICT
+
+    Raise an error when encountering values that cannot be serialized in a
+    strictly JSON compliant manner (such as ``NaN`` and ``Infinity``),
+    rather than encoding them as such.
+
+    Default: ``False``
+
 .. py:data:: JSONIFY_PRETTYPRINT_REGULAR
 
     ``jsonify`` responses will be output with newlines, spaces, and indentation

--- a/flask/app.py
+++ b/flask/app.py
@@ -304,6 +304,7 @@ class Flask(_PackageBoundObject):
         'PREFERRED_URL_SCHEME':                 'http',
         'JSON_AS_ASCII':                        True,
         'JSON_SORT_KEYS':                       True,
+        'JSON_STRICT':                          False,
         'JSONIFY_PRETTYPRINT_REGULAR':          False,
         'JSONIFY_MIMETYPE':                     'application/json',
         'TEMPLATES_AUTO_RELOAD':                None,

--- a/flask/json/__init__.py
+++ b/flask/json/__init__.py
@@ -102,6 +102,9 @@ def _dump_arg_defaults(kwargs):
         if not current_app.config['JSON_AS_ASCII']:
             kwargs.setdefault('ensure_ascii', False)
 
+        if current_app.config['JSON_STRICT']:
+            kwargs.setdefault('allow_nan', False)
+
         kwargs.setdefault('sort_keys', current_app.config['JSON_SORT_KEYS'])
     else:
         kwargs.setdefault('sort_keys', True)
@@ -173,6 +176,10 @@ def dumps(obj, **kwargs):
     default which coerce into unicode strings automatically.  That behavior by
     default is controlled by the ``JSON_AS_ASCII`` configuration variable
     and can be overridden by the simplejson ``ensure_ascii`` parameter.
+
+    If the ``JSON_STRICT`` config parameter is set to True, this function will
+    raise a :exc:`ValueError` if it encounters values that cannot be represented in
+    a JSON specification compliant manner.
     """
     _dump_arg_defaults(kwargs)
     encoding = kwargs.pop('encoding', None)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1298,6 +1298,14 @@ def test_jsonify_prettyprint(app, req_ctx):
     assert rv.data == pretty_response
 
 
+@pytest.mark.parametrize('test_value', [float('nan'), float('Infinity')])
+def test_json_strict(app, req_ctx, test_value):
+    app.config.update({'JSON_STRICT': True})
+
+    with pytest.raises(ValueError) as e:
+        flask.jsonify(test_value)
+    assert 'not JSON compliant' in str(e.value)
+
 def test_jsonify_mimetype(app, req_ctx):
     app.config.update({"JSONIFY_MIMETYPE": 'application/vnd.api+json'})
     msg = {

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -155,7 +155,7 @@ class TestJSON(object):
         rv = flask.json.load(out)
         assert rv == test_data
 
-    @pytest.mark.parametrize('test_value', [0, -1, 1, 23, 3.14, 's', "longer string", True, False, None])
+    @pytest.mark.parametrize('test_value', [0, -1, 1, 23, 3.14, float('Infinity'), 's', "longer string", True, False, None])
     def test_jsonify_basic_types(self, test_value, app, client):
         """Test jsonify with basic types."""
 


### PR DESCRIPTION
## Summary
Provide a new config option to control how JSON is serialized. This would prevent situations where Flask returns a response that is not actually JSON specification compliant.

This proposal is an opt-in mechanism. For backwards compatibility, it is disabled by default.

## Purpose
The default Python JSON serializer is not strictly [RFC-compliant](https://docs.python.org/3/library/json.html#standard-compliance-and-interoperability). In particular, it [outputs](https://docs.python.org/3/library/json.html#infinite-and-nan-number-values)
 `Infinity` and `NaN` values.

This means that by default, JSON APIs written in Flask may produce output that cannot be parsed by the browser, especially when dealing with numerical data.

Enabling the newly provided `JSON_STRICT` option would treat this scenario as an application error server-side and raise an exception. It would be up to the application developer to identify their preferred handling of such values.

## Changes and scope
This adds a new `JSON_STRICT` config option, adding to the [existing config flags](http://flask.pocoo.org/docs/1.0/config/#JSON_AS_ASCII) that also control serialization. 

The default value is chosen to leave existing applications unaffected. If `JSON_STRICT` is `True`, the application will raise an error in situations where it previously would have produced invalid JSON. 

## Previous discussion
This pitfall has been noted previously elsewhere. Others have expressed an interest in a simple, explicit configurable error option, but I am not aware of any previous pull requests that implemented the idea.

- https://coderwall.com/p/amb0va/python-s-json-module-does-not-always-produce-valid-json
- https://github.com/miguelgrinberg/Flask-SocketIO/issues/208

Particularly due to backwards compatibility concerns, the Python standard library has rejected previous suggestions to change the default `json` module behavior:
https://bugs.python.org/issue26105

## Evaluation of alternatives
Libraries such as `simplejson` [provide](https://simplejson.readthedocs.io/en/latest/#simplejson.dumps) an [ECMA-262 compliant](https://www.ecma-international.org/ecma-262/8.0/index.html#sec-serializejsonproperty) `ignore_nan` option, in which out-of-range values are serialized as `null`.

However, this option is not supported by the Python standard library, and in practice the best choice of replacement value may be somewhat application specific.
