### PR TITLE
Remove unnecessary period in documentation

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -40,7 +40,7 @@ pytest.
 
 Next, we create a `pytest fixture`_ called
 :func:`client` that configures
-the application for testing and initializes a new database.::
+the application for testing and initializes a new database::
 
     import os
     import tempfile


### PR DESCRIPTION
Except for this one, I also notice that there are [two sentences](http://flask.pocoo.org/docs/dev/testing/#testing-cli-commands) end with period instead of colon before a code snippet, should we change it?