### PR TITLE
:fire: Remove code supposed to be removed at v1.0

### DIFF
--- a/flask/__init__.py
+++ b/flask/__init__.py
@@ -43,7 +43,3 @@ from . import json
 # This was the only thing that Flask used to export at one point and it had
 # a more generic name.
 jsonify = json.jsonify
-
-# backwards compat, goes away in 1.0
-from .sessions import SecureCookieSession as Session
-json_available = True


### PR DESCRIPTION
This PR removes a small piece of backward compatibility code from `flask/__init__.py` that accordingly to the comment on (ex-)line 47 should "go away" in version 1.0 of Flask.

However, if for some reason it must **not** be deleted, at least the commented line must be deleted or updated with a better description.

-  :heavy_check_mark: Tests ran successfuly