### PR TITLE
:art: Use set literal instead of set method in file uploading example

### DIFF
--- a/docs/patterns/fileuploads.rst
+++ b/docs/patterns/fileuploads.rst
@@ -25,7 +25,7 @@ bootstrapping code for our application::
     from werkzeug.utils import secure_filename
 
     UPLOAD_FOLDER = '/path/to/the/uploads'
-    ALLOWED_EXTENSIONS = set(['txt', 'pdf', 'png', 'jpg', 'jpeg', 'gif'])
+    ALLOWED_EXTENSIONS = {'txt', 'pdf', 'png', 'jpg', 'jpeg', 'gif'}
 
     app = Flask(__name__)
     app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER


### PR DESCRIPTION
This pull request changes the usage of `set()` method for the set literal (`{ ... }`) in the file uploading example.

Using the literal `{ }` for building non-empty sets is preferred for [it is faster](https://renzo.lucioni.xyz/pythons-set-literals/)