### PR TITLE
Add `status` kwarg into jsonify()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ Version 1.1
 
 Unreleased
 
+-   :func:`jsonify` allows for a ``status`` kwarg (`#2845`_)
+
+.. _#2845: https://github.com/pallets/flask/pull/2845
+
 
 Version 1.0.3
 -------------

--- a/flask/json/__init__.py
+++ b/flask/json/__init__.py
@@ -292,7 +292,7 @@ def jsonify(*args, **kwargs):
         }
 
 
-    .. versionchanged:: 0.11
+    .. versionchanged:: 1.1
        Added support for status parameter
 
     This function's response will be pretty printed if the

--- a/flask/json/__init__.py
+++ b/flask/json/__init__.py
@@ -271,6 +271,7 @@ def jsonify(*args, **kwargs):
     3. Multiple keyword arguments: Converted to a dict before being passed to
        :func:`dumps`.
     4. Both args and kwargs: Behavior undefined and will throw an exception.
+    5. ``status`` kwarg: Set the status
 
     Example usage::
 
@@ -292,8 +293,7 @@ def jsonify(*args, **kwargs):
 
 
     .. versionchanged:: 0.11
-       Added support for serializing top-level arrays. This introduces a
-       security risk in ancient browsers. See :ref:`json-security` for details.
+       Added support for status parameter
 
     This function's response will be pretty printed if the
     ``JSONIFY_PRETTYPRINT_REGULAR`` config parameter is set to True or the
@@ -310,6 +310,10 @@ def jsonify(*args, **kwargs):
         indent = 2
         separators = (', ', ': ')
 
+    status = kwargs.get('status')
+    if status:
+        del kwargs['status']
+
     if args and kwargs:
         raise TypeError('jsonify() behavior undefined when passed both args and kwargs')
     elif len(args) == 1:  # single args are passed directly to dumps()
@@ -319,7 +323,8 @@ def jsonify(*args, **kwargs):
 
     return current_app.response_class(
         dumps(data, indent=indent, separators=separators) + '\n',
-        mimetype=current_app.config['JSONIFY_MIMETYPE']
+        mimetype=current_app.config['JSONIFY_MIMETYPE'],
+        status=status
     )
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -244,7 +244,17 @@ class TestJSON(object):
         assert rv_uuid == test_uuid
 
     def test_jsonify_status(self, app, client):
-        flask.jsonify({'code': 400}, status=400)
+        @app.route('/statusarg')
+        def return_arg_status():
+            return flask.jsonify({'code': 400}, status=400)
+
+        @app.route('/statuskwarg')
+        def return_kwarg_status():
+            return flask.jsonify(code=400, status=400)
+
+        for url in '/statuskwarg', '/statusarg':
+            rv = client.get(url)
+            assert rv.status_code == 400
 
     def test_json_attr(self, app, client):
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -243,6 +243,9 @@ class TestJSON(object):
         rv_uuid = uuid.UUID(rv_x)
         assert rv_uuid == test_uuid
 
+    def test_jsonify_status(self, app, client):
+        flask.jsonify({'code': 400}, status=400)
+
     def test_json_attr(self, app, client):
 
         @app.route('/add', methods=['POST'])


### PR DESCRIPTION
Currently, there is no way to modify the default 200 status in `jsonify`. This PR adds a kwarg for it.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
