### PR TITLE
:art: Use `itervalues` instead of `iteritems` when `key` is not necessary

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -26,7 +26,7 @@ import click
 from werkzeug.utils import import_string
 
 from . import __version__
-from ._compat import getargspec, iteritems, reraise, text_type
+from ._compat import getargspec, itervalues, reraise, text_type
 from .globals import current_app
 from .helpers import get_debug_flag, get_env, get_load_dotenv
 
@@ -55,7 +55,7 @@ def find_best_app(script_info, module):
 
     # Otherwise find the only object that is a Flask instance.
     matches = [
-        v for k, v in iteritems(module.__dict__) if isinstance(v, Flask)
+        v for v in itervalues(module.__dict__) if isinstance(v, Flask)
     ]
 
     if len(matches) == 1:


### PR DESCRIPTION
This pull request uses the already implemented ` itervalues` from `_compat.py` module instead of the `iteritems` for iterating the **values** from a given dict (line 58).
As a consequence, the unused variable `k` is now removed since it's not necessary for iterating over the dict values.