### PR TITLE
:art: Refactor __init__.py imports

### DIFF
--- a/flask/__init__.py
+++ b/flask/__init__.py
@@ -20,19 +20,19 @@ from jinja2 import Markup, escape
 
 from .app import Flask, Request, Response
 from .config import Config
-from .helpers import url_for, flash, send_file, send_from_directory, \
-     get_flashed_messages, get_template_attribute, make_response, safe_join, \
-     stream_with_context
-from .globals import current_app, g, request, session, _request_ctx_stack, \
-     _app_ctx_stack
-from .ctx import has_request_context, has_app_context, \
-     after_this_request, copy_current_request_context
+from .helpers import (url_for, flash, send_file, send_from_directory,
+     get_flashed_messages, get_template_attribute, make_response, safe_join,
+     stream_with_context)
+from .globals import (current_app, g, request, session, _request_ctx_stack,
+     _app_ctx_stack)
+from .ctx import (has_request_context, has_app_context,
+     after_this_request, copy_current_request_context)
 from .blueprints import Blueprint
 from .templating import render_template, render_template_string
-from .signals import signals_available, template_rendered, request_started, \
-     request_finished, got_request_exception, request_tearing_down, \
-     appcontext_tearing_down, appcontext_pushed, \
-     appcontext_popped, message_flashed, before_render_template
+from .signals import (signals_available, template_rendered, request_started,
+     request_finished, got_request_exception, request_tearing_down,
+     appcontext_tearing_down, appcontext_pushed,
+     appcontext_popped, message_flashed, before_render_template)
 
 # Expose a convenient wrapper around python's builtin json module.
 from .json import jsonify

--- a/flask/__init__.py
+++ b/flask/__init__.py
@@ -29,20 +29,13 @@ from .ctx import has_request_context, has_app_context, \
      after_this_request, copy_current_request_context
 from .blueprints import Blueprint
 from .templating import render_template, render_template_string
-
-# the signals
 from .signals import signals_available, template_rendered, request_started, \
      request_finished, got_request_exception, request_tearing_down, \
      appcontext_tearing_down, appcontext_pushed, \
      appcontext_popped, message_flashed, before_render_template
 
-# We're not exposing the actual json module but a convenient wrapper around
-# it.
-from . import json
-
-# This was the only thing that Flask used to export at one point and it had
-# a more generic name.
-jsonify = json.jsonify
+# Expose a convenient wrapper around python's builtin json module.
+from .json import jsonify
 
 # backwards compat, goes away in 1.0
 from .sessions import SecureCookieSession as Session


### PR DESCRIPTION
This pull request does the following changes for simplicity and elegance:
- Remove unnecessary comment about signals section
- Import and expose `jsonify` in a single line: following the other imports pattern (see line 21 to 32):
```python
from .module import value
```
- Also, simplify the comment about exposing `json.jsonify`
- Make the imports more [PEP8](https://www.python.org/dev/peps/pep-0008/#maximum-line-length)-like using parenthesis over back-slash (`\`)

> The preferred way of wrapping long lines is by using Python's implied line continuation inside parentheses, brackets and braces. Long lines can be broken over multiple lines by wrapping expressions in parentheses. These should be used in preference to using a backslash for line continuation.

I'm not sure if changes like these - prettifying - should be preceded by an issue. If so, feel free to close this pull requests and I will file an issue asap. Thanks!