### PR TITLE
Update docs to be more clear about from config instantiation

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -553,6 +553,44 @@ To enable such a config you just have to call into
 
     app.config.from_object('configmodule.ProductionConfig')
 
+Note that :meth:`~flask.Config.from_object` does not instantiate the class
+object. If you need to instantiate the class, such as to access a property,
+then you must do so before calling :meth:`~flask.Config.from_object`::
+
+    from configmodule import ProductionConfig
+    app.config.from_object(ProductionConfig())
+
+    # Alternatively, import via string:
+    from werkzeug.utils import import_string
+    cfg = import_string('configmodule.ProductionConfig')()
+    app.config.from_object(cfg)
+
+Instantiating the configutation object allows you to use ``@property`` in
+your configuration classes::
+
+    class Config(object):
+        """Base config, uses staging database server."""
+        DEBUG = False
+        TESTING = False
+        DB_SERVER = '192.168.1.56'
+
+        @property
+        def DATABASE_URI(self):         # Note: all caps
+            return 'mysql://user@{}/foo'.format(self.DB_SERVER)
+
+    class ProductionConfig(Config):
+        """Uses production database server."""
+        DB_SERVER = '192.168.19.32'
+
+    class DevelopmentConfig(Config):
+        DB_SERVER = 'localhost'
+        DEBUG = True
+
+    class TestingConfig(Config):
+        DB_SERVER = 'localhost'
+        DEBUG = True
+        DATABASE_URI = 'sqlite:///:memory:'
+
 There are many different ways and it's up to you how you want to manage
 your configuration files.  However here a list of good recommendations:
 

--- a/flask/config.py
+++ b/flask/config.py
@@ -156,6 +156,10 @@ class Config(dict):
             from yourapplication import default_config
             app.config.from_object(default_config)
 
+        Nothing is done to the object before loading. If the object is a
+        class and has ``@property`` attributes, it needs to be
+        instantiated before being passed to this method.
+
         You should not use this function to load the actual configuration but
         rather configuration defaults.  The actual config should be loaded
         with :meth:`from_pyfile` and ideally from a location not within the


### PR DESCRIPTION
This PR updates documentation to be more clear that `config.from_object` does not instantiate the object. It also provides examples as to how to use `@property` in a configuration class.

Addresses #2853.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
