### PR TITLE
Remove check against deprecated property is_xhr

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,12 @@ Flask Changelog
 ===============
 
 
+Version 0.12.5
+--------------
+
+-   Remove check against deprecated property ``Request.is_xhr``.
+
+
 Version 0.12.4
 --------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -114,14 +114,6 @@ Incoming Request Data
       `url_root`    ``u'http://www.example.com/myapplication/'``
       ============= ======================================================
 
-   .. attribute:: is_xhr
-
-      ``True`` if the request was triggered via a JavaScript
-      `XMLHttpRequest`. This only works with libraries that support the
-      ``X-Requested-With`` header and set it to `XMLHttpRequest`.
-      Libraries that do that are prototype, jQuery and Mochikit and
-      probably some more.
-
 .. class:: request
 
    To access incoming request data, you can use the global `request`

--- a/flask/json.py
+++ b/flask/json.py
@@ -295,7 +295,7 @@ def jsonify(*args, **kwargs):
     indent = None
     separators = (',', ':')
 
-    if current_app.config['JSONIFY_PRETTYPRINT_REGULAR'] and not request.is_xhr:
+    if current_app.config['JSONIFY_PRETTYPRINT_REGULAR']:
         indent = 2
         separators = (', ', ': ')
 


### PR DESCRIPTION
This eliminates the deprecation warning fired by werkzeug's `Request.is_xhr` property for older versions of Flask by removing the check.

https://github.com/pallets/werkzeug/blob/da57cd54c97909856e05f490418000f9ab851358/werkzeug/wrappers.py#L696-L702 

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
