### PR TITLE
[docs] Fix broken Sphinx cross-references; use :doc: tags where necessary

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,15 @@ A Simple Example
      * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
 
 
+Contributing
+------------
+
+For guidance on setting up a development environment and how to make a
+contribution to Flask, see the `contributing guidelines`_.
+
+.. _contributing guidelines: https://github.com/pallets/flask/blob/master/CONTRIBUTING.rst
+
+
 Donate
 ------
 

--- a/docs/deploying/fastcgi.rst
+++ b/docs/deploying/fastcgi.rst
@@ -4,10 +4,10 @@ FastCGI
 =======
 
 FastCGI is a deployment option on servers like `nginx`_, `lighttpd`_, and
-`cherokee`_; see :ref:`deploying-uwsgi` and :ref:`deploying-wsgi-standalone`
-for other options.  To use your WSGI application with any of them you will need
-a FastCGI server first.  The most popular one is `flup`_ which we will use for
-this guide.  Make sure to have it installed to follow along.
+`cherokee`_; see :doc:`uwsgi` and :doc:`wsgi-standalone` for other options. To
+use your WSGI application with any of them you will need a FastCGI server first.
+The most popular one is `flup`_ which we will use for this guide. Make sure to
+have it installed to follow along.
 
 .. admonition:: Watch Out
 

--- a/docs/deploying/uwsgi.rst
+++ b/docs/deploying/uwsgi.rst
@@ -4,13 +4,13 @@ uWSGI
 =====
 
 uWSGI is a deployment option on servers like `nginx`_, `lighttpd`_, and
-`cherokee`_; see :ref:`deploying-fastcgi` and :ref:`deploying-wsgi-standalone`
-for other options.  To use your WSGI application with uWSGI protocol you will
-need a uWSGI server first. uWSGI is both a protocol and an application server;
-the application server can serve uWSGI, FastCGI, and HTTP protocols.
+`cherokee`_; see :doc:`fastcgi` and :doc:`wsgi-standalone` for other options.
+To use your WSGI application with uWSGI protocol you will need a uWSGI server
+first. uWSGI is both a protocol and an application server; the application
+server can serve uWSGI, FastCGI, and HTTP protocols.
 
 The most popular uWSGI server is `uwsgi`_, which we will use for this
-guide.  Make sure to have it installed to follow along.
+guide. Make sure to have it installed to follow along.
 
 .. admonition:: Watch Out
 
@@ -32,13 +32,13 @@ Given a flask application in myapp.py, use the following command:
     $ uwsgi -s /tmp/yourapplication.sock --manage-script-name --mount /yourapplication=myapp:app
 
 The ``--manage-script-name`` will move the handling of ``SCRIPT_NAME`` to uwsgi,
-since its smarter about that. It is used together with the ``--mount`` directive
-which will make requests to ``/yourapplication`` be directed to ``myapp:app``.
-If your application is accessible at root level, you can use a single ``/``
-instead of ``/yourapplication``. ``myapp`` refers to the name of the file of
-your flask application (without extension) or the module which provides ``app``.
-``app`` is the callable inside of your application (usually the line reads
-``app = Flask(__name__)``.
+since it is smarter about that. It is used together with the ``--mount``
+directive which will make requests to ``/yourapplication`` be directed to
+``myapp:app``. If your application is accessible at root level, you can use a
+single ``/`` instead of ``/yourapplication``. ``myapp`` refers to the name of
+the file of your flask application (without extension) or the module which
+provides ``app``. ``app`` is the callable inside of your application (usually
+the line reads ``app = Flask(__name__)``.
 
 If you want to deploy your flask application inside of a virtual environment,
 you need to also add ``--virtualenv /path/to/virtual/environment``. You might

--- a/docs/deploying/wsgi-standalone.rst
+++ b/docs/deploying/wsgi-standalone.rst
@@ -37,7 +37,7 @@ Running `uWSGI HTTP Router`_::
 
     uwsgi --http 127.0.0.1:5000 --module myproject:app
 
-For a more optimized setup, see :ref:`configuring uWSGI and NGINX <deploying-uwsgi>`.
+For a more optimized setup, see :doc:`configuring uWSGI and NGINX <uwsgi>`.
 
 .. _uWSGI: http://uwsgi-docs.readthedocs.io/en/latest/
 .. _uWSGI HTTP Router: http://uwsgi-docs.readthedocs.io/en/latest/HTTP.html#the-uwsgi-http-https-router


### PR DESCRIPTION
This PR…

* Fixes broken cross-references to other documentation
* Fixes all warnings from Sphinx when building the docs
* Makes an explicit call-out to contributing guidelines in README

I hit the broken cross-references when reading the docs, when opening the link to the uWSGI docs from the Standalone WSGI Containers page would give me a 404 error. It seems like there was some rearranging at some point and this was probably overlooked, so this should fix the broken links and make a better experience for others browsing the docs. :slightly_smiling_face: 

Additionally, in an oversight, I missed the contributing guidelines in the root directory of the repository but I did scan the README. When I came back to this, I found the contributing guidelines, but I would have noticed them quicker and submitted this PR a day earlier if I had seen them mentioned in the README. So I thought an explicit call-out to the existing contributing guidelines (which were well-written and very helpful to me) in the README might be useful for others too.

I successfully ran the tests on the docs and I was able to build them locally on my workstation.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
