### PR TITLE
fix little grammar detail in flaskr/db.py

### DIFF
--- a/examples/tutorial/flaskr/db.py
+++ b/examples/tutorial/flaskr/db.py
@@ -21,7 +21,7 @@ def get_db():
 
 
 def close_db(e=None):
-    """If this request connected to the database, close the
+    """If this request is connected to the database, close the
     connection.
     """
     db = g.pop('db', None)


### PR DESCRIPTION
Just add a missing 'is' in the docstring in db.py, from the flaskr example.

> If this request connected to the database

This should be: If this request **is** connected to the database.