### PR TITLE
Add prefix for all commands in documentation

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -195,8 +195,8 @@ command, instead of ``flask run --port 8000``:
 
 .. code-block:: none
 
-    export FLASK_RUN_PORT=8000
-    flask run
+    $ export FLASK_RUN_PORT=8000
+    $ flask run
      * Running on http://127.0.0.1:8000/
 
 These can be added to the ``.flaskenv`` file just like ``FLASK_APP`` to
@@ -211,7 +211,7 @@ python-dotenv is not installed.
 
 .. code-block:: none
 
-    flask run
+    $ flask run
      * Tip: There are .env files present. Do "pip install python-dotenv" to use them.
 
 You can tell Flask not to load dotenv files even when python-dotenv is
@@ -223,8 +223,8 @@ configure as expected.
 
 .. code-block:: none
 
-    export FLASK_SKIP_DOTENV=1
-    flask run
+    $ export FLASK_SKIP_DOTENV=1
+    $ flask run
 
 
 Environment Variables From virtualenv
@@ -236,11 +236,11 @@ script. Activating the virtualenv will set the variables.
 
 Unix Bash, :file:`venv/bin/activate`::
 
-    export FLASK_APP=hello
+    $ export FLASK_APP=hello
 
 Windows CMD, :file:`venv\\Scripts\\activate.bat`::
 
-    set FLASK_APP=hello
+    > set FLASK_APP=hello
 
 It is preferred to use dotenv support over this, since :file:`.flaskenv` can be
 committed to the repository so that it works automatically wherever the project
@@ -268,7 +268,7 @@ This example adds the command ``create_user`` that takes the argument
 
 ::
 
-    flask create_user admin
+    $ flask create_user admin
 
 This example adds the same command, but as ``user create``, a command in a
 group. This is useful if you want to organize multiple related commands. ::
@@ -289,7 +289,7 @@ group. This is useful if you want to organize multiple related commands. ::
 
 ::
 
-    flask user create demo
+    $ flask user create demo
 
 See :ref:`testing-cli` for an overview of how to test your custom
 commands.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -164,7 +164,7 @@ The following configuration values are used internally by Flask:
     application. It should be a long random string of bytes, although unicode
     is accepted too. For example, copy the output of this to your config::
 
-        python -c 'import os; print(os.urandom(16))'
+        $ python -c 'import os; print(os.urandom(16))'
         b'_5#y2L"F4Q8z\n\xec]/'
 
     **Do not reveal the secret key when posting questions or committing code.**
@@ -419,7 +419,7 @@ server::
 
 On Windows systems use the `set` builtin instead::
 
-    >set YOURAPPLICATION_SETTINGS=\path\to\settings.cfg
+    > set YOURAPPLICATION_SETTINGS=\path\to\settings.cfg
 
 The configuration files themselves are actual Python files.  Only values
 in uppercase are actually stored in the config object later on.  So make
@@ -455,8 +455,8 @@ the shell before starting the server::
 
 On Windows systems use the `set` builtin instead::
 
-    >set SECRET_KEY='5f352379324c22463451387a0aec5d2f'
-    >set DEBUG=False
+    > set SECRET_KEY='5f352379324c22463451387a0aec5d2f'
+    > set DEBUG=False
 
 While this approach is straightforward to use, it is important to remember that
 environment variables are strings -- they are not automatically deserialized

--- a/docs/deploying/fastcgi.rst
+++ b/docs/deploying/fastcgi.rst
@@ -49,7 +49,7 @@ can execute it:
 
 .. sourcecode:: text
 
-    # chmod +x /var/www/yourapplication/yourapplication.fcgi
+    $ chmod +x /var/www/yourapplication/yourapplication.fcgi
 
 Configuring Apache
 ------------------

--- a/docs/deploying/mod_wsgi.rst
+++ b/docs/deploying/mod_wsgi.rst
@@ -27,21 +27,21 @@ follows:
 
 .. sourcecode:: text
 
-    # apt-get install libapache2-mod-wsgi
+    $ apt-get install libapache2-mod-wsgi
 
 If you are using a yum based distribution (Fedora, OpenSUSE, etc..) you
 can install it as follows:
 
 .. sourcecode:: text
 
-    # yum install mod_wsgi
+    $ yum install mod_wsgi
 
 On FreeBSD install `mod_wsgi` by compiling the `www/mod_wsgi` port or by
 using pkg_add:
 
 .. sourcecode:: text
 
-    # pkg install ap22-mod_wsgi2
+    $ pkg install ap22-mod_wsgi2
 
 If you are using pkgsrc you can install `mod_wsgi` by compiling the
 `www/ap2-wsgi` package.

--- a/docs/deploying/wsgi-standalone.rst
+++ b/docs/deploying/wsgi-standalone.rst
@@ -15,13 +15,13 @@ Gunicorn
 worker model ported from Ruby's Unicorn project. It supports both `eventlet`_
 and `greenlet`_. Running a Flask application on this server is quite simple::
 
-    gunicorn myproject:app
+    $ gunicorn myproject:app
 
 `Gunicorn`_ provides many command-line options -- see ``gunicorn -h``.
 For example, to run a Flask application with 4 worker processes (``-w
 4``) binding to localhost port 4000 (``-b 127.0.0.1:4000``)::
 
-    gunicorn -w 4 -b 127.0.0.1:4000 myproject:app
+    $ gunicorn -w 4 -b 127.0.0.1:4000 myproject:app
 
 .. _Gunicorn: http://gunicorn.org/
 .. _eventlet: http://eventlet.net/
@@ -35,7 +35,7 @@ which makes it more complicated to setup than gunicorn.
 
 Running `uWSGI HTTP Router`_::
 
-    uwsgi --http 127.0.0.1:5000 --module myproject:app
+    $ uwsgi --http 127.0.0.1:5000 --module myproject:app
 
 For a more optimized setup, see :doc:`configuring uWSGI and NGINX <uwsgi>`.
 
@@ -67,7 +67,7 @@ non-blocking event-driven networking library. Twisted Web comes with a
 standard WSGI container which can be controlled from the command line using
 the ``twistd`` utility::
 
-    twistd web --wsgi myproject.app
+    $ twistd web --wsgi myproject.app
 
 This example will run a Flask application called ``app`` from a module named
 ``myproject``.
@@ -77,7 +77,7 @@ as well; see ``twistd -h`` and ``twistd web -h`` for more information. For
 example, to run a Twisted Web server in the foreground, on port 8080, with an
 application from ``myproject``::
 
-    twistd -n web --port tcp:8080 --wsgi myproject.app
+    $ twistd -n web --port tcp:8080 --wsgi myproject.app
 
 .. _Twisted: https://twistedmatrix.com/
 .. _Twisted Web: https://twistedmatrix.com/trac/wiki/TwistedWeb

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -81,28 +81,28 @@ Create a project folder and a :file:`venv` folder within:
 
 .. code-block:: sh
 
-    mkdir myproject
-    cd myproject
-    python3 -m venv venv
+    $ mkdir myproject
+    $ cd myproject
+    $ python3 -m venv venv
 
 On Windows:
 
 .. code-block:: bat
 
-    py -3 -m venv venv
+    $ py -3 -m venv venv
 
 If you needed to install virtualenv because you are on an older version of
 Python, use the following command instead:
 
 .. code-block:: sh
 
-    virtualenv venv
+    $ virtualenv venv
 
 On Windows:
 
 .. code-block:: bat
 
-    \Python27\Scripts\virtualenv.exe venv
+    > \Python27\Scripts\virtualenv.exe venv
 
 .. _install-activate-env:
 
@@ -113,13 +113,13 @@ Before you work on your project, activate the corresponding environment:
 
 .. code-block:: sh
 
-    . venv/bin/activate
+    $ . venv/bin/activate
 
 On Windows:
 
 .. code-block:: bat
 
-    venv\Scripts\activate
+    > venv\Scripts\activate
 
 Your shell prompt will change to show the name of the activated environment.
 
@@ -130,7 +130,7 @@ Within the activated environment, use the following command to install Flask:
 
 .. code-block:: sh
 
-    pip install Flask
+    $ pip install Flask
 
 Flask is now installed. Check out the :doc:`/quickstart` or go to the
 :doc:`Documentation Overview </index>`.
@@ -143,7 +143,7 @@ update the code from the master branch:
 
 .. code-block:: sh
 
-    pip install -U https://github.com/pallets/flask/archive/master.tar.gz
+    $ pip install -U https://github.com/pallets/flask/archive/master.tar.gz
 
 .. _install-install-virtualenv:
 
@@ -158,27 +158,27 @@ On Linux, virtualenv is provided by your package manager:
 .. code-block:: sh
 
     # Debian, Ubuntu
-    sudo apt-get install python-virtualenv
+    $ sudo apt-get install python-virtualenv
 
     # CentOS, Fedora
-    sudo yum install python-virtualenv
+    $ sudo yum install python-virtualenv
 
     # Arch
-    sudo pacman -S python-virtualenv
+    $ sudo pacman -S python-virtualenv
 
 If you are on Mac OS X or Windows, download `get-pip.py`_, then:
 
 .. code-block:: sh
 
-    sudo python2 Downloads/get-pip.py
-    sudo python2 -m pip install virtualenv
+    $ sudo python2 Downloads/get-pip.py
+    $ sudo python2 -m pip install virtualenv
 
 On Windows, as an administrator:
 
 .. code-block:: bat
 
-    \Python27\python.exe Downloads\get-pip.py
-    \Python27\python.exe -m pip install virtualenv
+    > \Python27\python.exe Downloads\get-pip.py
+    > \Python27\python.exe -m pip install virtualenv
 
 Now you can return above and :ref:`install-create-env`.
 

--- a/docs/patterns/appfactories.rst
+++ b/docs/patterns/appfactories.rst
@@ -91,14 +91,14 @@ Using Applications
 
 To run such an application, you can use the :command:`flask` command::
 
-    export FLASK_APP=myapp
-    flask run
+    $ export FLASK_APP=myapp
+    $ flask run
     
 Flask will automatically detect the factory (``create_app`` or ``make_app``) 
 in ``myapp``. You can also pass arguments to the factory like this::
 
-    export FLASK_APP="myapp:create_app('dev')"
-    flask run
+    $ export FLASK_APP="myapp:create_app('dev')"
+    $ flask run
     
 Then the ``create_app`` factory in ``myapp`` is called with the string
 ``'dev'`` as the argument. See :doc:`/cli` for more detail.

--- a/docs/patterns/packages.rst
+++ b/docs/patterns/packages.rst
@@ -61,19 +61,19 @@ a big problem, just add a new file called :file:`setup.py` next to the inner
 In order to run the application you need to export an environment variable
 that tells Flask where to find the application instance::
 
-    export FLASK_APP=yourapplication
+    $ export FLASK_APP=yourapplication
 
 If you are outside of the project directory make sure to provide the exact
 path to your application directory. Similarly you can turn on the
 development features like this::
 
-    export FLASK_ENV=development
+    $ export FLASK_ENV=development
 
 In order to install and run the application you need to issue the following
 commands::
 
-    pip install -e .
-    flask run
+    $ pip install -e .
+    $ flask run
 
 What did we gain from this?  Now we can restructure the application a bit
 into multiple modules.  The only thing you have to remember is the

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -85,7 +85,7 @@ should see your hello world greeting.
    you can make the server publicly available simply by adding
    ``--host=0.0.0.0`` to the command line::
 
-       flask run --host=0.0.0.0
+       $ flask run --host=0.0.0.0
 
    This tells your operating system to listen on all public IPs.
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -18,7 +18,7 @@ You can then use that with your favourite testing solution.
 In this documentation we will use the `pytest`_ package as the base
 framework for our tests. You can install it with ``pip``, like so::
 
-    pip install pytest
+    $ pip install pytest
 
 .. _pytest:
    https://pytest.org

--- a/docs/tutorial/database.rst
+++ b/docs/tutorial/database.rst
@@ -204,7 +204,7 @@ Run the ``init-db`` command:
 
 .. code-block:: none
 
-    flask init-db
+    $ flask init-db
     Initialized the database.
 
 There will now be a ``flaskr.sqlite`` file in the ``instance`` folder in

--- a/docs/tutorial/deploy.rst
+++ b/docs/tutorial/deploy.rst
@@ -21,7 +21,7 @@ is installed first:
 
 .. code-block:: none
 
-    pip install wheel
+    $ pip install wheel
 
 Running ``setup.py`` with Python gives you a command line tool to issue
 build-related commands. The ``bdist_wheel`` command will build a wheel
@@ -29,7 +29,7 @@ distribution file.
 
 .. code-block:: none
 
-    python setup.py bdist_wheel
+    $ python setup.py bdist_wheel
 
 You can find the file in ``dist/flaskr-1.0.0-py3-none-any.whl``. The
 file name is the name of the project, the version, and some tags about
@@ -41,7 +41,7 @@ file with ``pip``.
 
 .. code-block:: none
 
-    pip install flaskr-1.0.0-py3-none-any.whl
+    $ pip install flaskr-1.0.0-py3-none-any.whl
 
 Pip will install your project along with its dependencies.
 
@@ -50,8 +50,8 @@ create the database in the instance folder.
 
 .. code-block:: none
 
-    export FLASK_APP=flaskr
-    flask init-db
+    $ export FLASK_APP=flaskr
+    $ flask init-db
 
 When Flask detects that it's installed (not in editable mode), it uses
 a different directory for the instance folder. You can find it at
@@ -70,7 +70,7 @@ You can use the following command to output a random secret key:
 
 .. code-block:: none
 
-    python -c 'import os; print(os.urandom(16))'
+    $ python -c 'import os; print(os.urandom(16))'
 
     b'_5#y2L"F4Q8z\n\xec]/'
 
@@ -99,7 +99,7 @@ first install it in the virtual environment:
 
 .. code-block:: none
 
-    pip install waitress
+    $ pip install waitress
 
 You need to tell Waitress about your application, but it doesn't use
 ``FLASK_APP`` like ``flask run`` does. You need to tell it to import and
@@ -107,7 +107,7 @@ call the application factory to get an application object.
 
 .. code-block:: none
 
-    waitress-serve --call 'flaskr:create_app'
+    $ waitress-serve --call 'flaskr:create_app'
 
     Serving on http://0.0.0.0:8080
 

--- a/docs/tutorial/factory.rst
+++ b/docs/tutorial/factory.rst
@@ -30,7 +30,7 @@ directory should be treated as a package.
 
 .. code-block:: none
 
-    mkdir flaskr
+    $ mkdir flaskr
 
 .. code-block:: python
     :caption: ``flaskr/__init__.py``
@@ -138,25 +138,25 @@ For Linux and Mac:
 
 .. code-block:: none
 
-    export FLASK_APP=flaskr
-    export FLASK_ENV=development
-    flask run
+    $ export FLASK_APP=flaskr
+    $ export FLASK_ENV=development
+    $ flask run
 
 For Windows cmd, use ``set`` instead of ``export``:
 
 .. code-block:: none
 
-    set FLASK_APP=flaskr
-    set FLASK_ENV=development
-    flask run
+    > set FLASK_APP=flaskr
+    > set FLASK_ENV=development
+    > flask run
 
 For Windows PowerShell, use ``$env:`` instead of ``export``:
 
 .. code-block:: none
 
-    $env:FLASK_APP = "flaskr"
-    $env:FLASK_ENV = "development"
-    flask run
+    > $env:FLASK_APP = "flaskr"
+    > $env:FLASK_ENV = "development"
+    > flask run
 
 You'll see output similar to this:
 

--- a/docs/tutorial/install.rst
+++ b/docs/tutorial/install.rst
@@ -80,7 +80,7 @@ Use ``pip`` to install your project in the virtual environment.
 
 .. code-block:: none
 
-    pip install -e .
+    $ pip install -e .
 
 This tells pip to find ``setup.py`` in the current directory and install
 it in *editable* or *development* mode. Editable mode means that as you
@@ -91,7 +91,7 @@ You can observe that the project is now installed with ``pip list``.
 
 .. code-block:: none
 
-    pip list
+    $ pip list
 
     Package        Version   Location
     -------------- --------- ----------------------------------

--- a/docs/tutorial/layout.rst
+++ b/docs/tutorial/layout.rst
@@ -5,8 +5,8 @@ Create a project directory and enter it:
 
 .. code-block:: none
 
-    mkdir flask-tutorial
-    cd flask-tutorial
+    $ mkdir flask-tutorial
+    $ cd flask-tutorial
 
 Then follow the :doc:`installation instructions </installation>` to set
 up a Python virtual environment and install Flask for your project.

--- a/docs/tutorial/tests.rst
+++ b/docs/tutorial/tests.rst
@@ -28,7 +28,7 @@ Install them both:
 
 .. code-block:: none
 
-    pip install pytest coverage
+    $ pip install pytest coverage
 
 .. _pytest: https://pytest.readthedocs.io/
 .. _coverage: https://coverage.readthedocs.io/
@@ -510,7 +510,7 @@ the test functions you've written.
 
 .. code-block:: none
 
-    pytest
+    $ pytest
 
     ========================= test session starts ==========================
     platform linux -- Python 3.6.4, pytest-3.5.0, py-1.5.3, pluggy-0.6.0
@@ -532,13 +532,13 @@ to run pytest instead of running it directly.
 
 .. code-block:: none
 
-    coverage run -m pytest
+    $ coverage run -m pytest
 
 You can either view a simple coverage report in the terminal:
 
 .. code-block:: none
 
-    coverage report
+    $ coverage report
 
     Name                 Stmts   Miss Branch BrPart  Cover
     ------------------------------------------------------
@@ -553,7 +553,7 @@ An HTML report allows you to see which lines were covered in each file:
 
 .. code-block:: none
 
-    coverage html
+    $ coverage html
 
 This generates files in the ``htmlcov`` directory. Open
 ``htmlcov/index.html`` in your browser to see the report.

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -218,12 +218,12 @@ To apply the upgrade script do the following:
     <https://raw.githubusercontent.com/pallets/flask/0.12.3/scripts/flask-07-upgrade.py>`_
 2.  Run it in the directory of your application::
 
-        python flask-07-upgrade.py > patchfile.diff
+        $ python flask-07-upgrade.py > patchfile.diff
 
 3.  Review the generated patchfile.
 4.  Apply the patch::
 
-        patch -p1 < patchfile.diff
+        $ patch -p1 < patchfile.diff
 
 5.  If you were using per-module template folders you need to move some
     templates around.  Previously if you had a folder named :file:`templates`

--- a/examples/javascript/README.rst
+++ b/examples/javascript/README.rst
@@ -23,9 +23,9 @@ Install
 
 ::
 
-    python3 -m venv venv
-    . venv/bin/activate
-    pip install -e .
+    $ python3 -m venv venv
+    $ . venv/bin/activate
+    $ pip install -e .
 
 
 Run
@@ -33,8 +33,8 @@ Run
 
 ::
 
-    export FLASK_APP=js_example
-    flask run
+    $ export FLASK_APP=js_example
+    $ flask run
 
 Open http://127.0.0.1:5000 in a browser.
 
@@ -44,6 +44,6 @@ Test
 
 ::
 
-    pip install -e '.[test]'
-    coverage run -m pytest
-    coverage report
+    $ pip install -e '.[test]'
+    $ coverage run -m pytest
+    $ coverage report

--- a/examples/tutorial/README.rst
+++ b/examples/tutorial/README.rst
@@ -14,32 +14,32 @@ you're reading.** You probably want the latest tagged version, but the
 default Git version is the master branch. ::
 
     # clone the repository
-    git clone https://github.com/pallets/flask
-    cd flask
+    $ git clone https://github.com/pallets/flask
+    $ cd flask
     # checkout the correct version
-    git tag  # shows the tagged versions
-    git checkout latest-tag-found-above
-    cd examples/tutorial
+    $ git tag  # shows the tagged versions
+    $ git checkout latest-tag-found-above
+    $ cd examples/tutorial
 
 Create a virtualenv and activate it::
 
-    python3 -m venv venv
-    . venv/bin/activate
+    $ python3 -m venv venv
+    $ . venv/bin/activate
 
 Or on Windows cmd::
 
-    py -3 -m venv venv
-    venv\Scripts\activate.bat
+    $ py -3 -m venv venv
+    $ venv\Scripts\activate.bat
 
 Install Flaskr::
 
-    pip install -e .
+    $ pip install -e .
 
 Or if you are using the master branch, install Flask from source before
 installing Flaskr::
 
-    pip install -e ../..
-    pip install -e .
+    $ pip install -e ../..
+    $ pip install -e .
 
 
 Run
@@ -47,17 +47,17 @@ Run
 
 ::
 
-    export FLASK_APP=flaskr
-    export FLASK_ENV=development
-    flask init-db
-    flask run
+    $ export FLASK_APP=flaskr
+    $ export FLASK_ENV=development
+    $ flask init-db
+    $ flask run
 
 Or on Windows cmd::
 
-    set FLASK_APP=flaskr
-    set FLASK_ENV=development
-    flask init-db
-    flask run
+    > set FLASK_APP=flaskr
+    > set FLASK_ENV=development
+    > flask init-db
+    > flask run
 
 Open http://127.0.0.1:5000 in a browser.
 
@@ -67,11 +67,11 @@ Test
 
 ::
 
-    pip install '.[test]'
-    pytest
+    $ pip install '.[test]'
+    $ pytest
 
 Run with coverage report::
 
-    coverage run -m pytest
-    coverage report
-    coverage html  # open htmlcov/index.html in a browser
+    $ coverage run -m pytest
+    $ coverage report
+    $ coverage html  # open htmlcov/index.html in a browser


### PR DESCRIPTION
This patch does the following things:

* Add "$" prefix for all command except Windows-specific commands.
* Add ">" prefix for all Windows commands.
* Change "#" to "$" in some commands.