### PR TITLE
Improve the recommended way to use Celery

### DIFF
--- a/docs/patterns/celery.rst
+++ b/docs/patterns/celery.rst
@@ -49,7 +49,7 @@ This is all that is necessary to properly integrate Celery with Flask::
         class ContextTask(celery.Task):
             def __call__(self, *args, **kwargs):
                 with app.app_context():
-                    return self.run(*args, **kwargs)
+                    return super().__call__(*args, **kwargs)
 
         celery.Task = ContextTask
         return celery


### PR DESCRIPTION
Currently [docs](http://flask.pocoo.org/docs/1.0/patterns/celery/) are recommending to call `run()` method after creating a Flask context. It seems that calling `super().__call__()` instead would be a better approach, because calling run() directly skips Celery's internal threading stack management:

https://github.com/celery/celery/blob/master/celery/app/task.py#L382
```python
    def __call__(self, *args, **kwargs):
        _task_stack.push(self)
        self.push_request(args=args, kwargs=kwargs)
        try:
            return self.run(*args, **kwargs)
        finally:
            self.pop_request()
            _task_stack.pop()
```

I've applied this change in our project and can confirm that it still works without any issues.