### PR TITLE
add badges to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,38 @@
 Flask
 =====
 
+
+.. start-badges
+
+.. list-table::
+    :stub-columns: 1
+
+    * - build
+      - | |travis| |appveyor| |coverage|
+    * - package
+      - | |version| |supported-versions|
+
+
+.. |version| image:: https://img.shields.io/pypi/v/flask.svg
+   :target: https://pypi.python.org/pypi/flask
+   :alt: Package on PyPi
+
+.. |coverage| image:: https://codecov.io/gh/pallets/flask/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/pallets/flask
+
+.. |travis| image:: https://img.shields.io/travis/pallets/flask.svg?logo=travis
+    :target: https://travis-ci.org/pallets/flask
+    :alt: Travis (.org)
+
+.. |appveyor| image:: https://img.shields.io/appveyor/ci/pallets/flask.svg?logo=appveyor
+    :alt: AppVeyor
+    :target: https://ci.appveyor.com/project/pallets/flask
+
+.. |supported-versions| image:: https://img.shields.io/pypi/pyversions/flask.svg
+    :alt: Supported versions
+    :target: https://pypi.python.org/pypi/flask
+
+
 Flask is a lightweight `WSGI`_ web application framework. It is designed
 to make getting started quick and easy, with the ability to scale up to
 complex applications. It began as a simple wrapper around `Werkzeug`_


### PR DESCRIPTION
Add the following badges for easier access: travis, appveyor, coverage,
supported pypi versions, pypi version. All badges include links to the
proper urls. Badges also add better visibility into our code coverage
as well as give better visibility into the build status.

If the contributors, we can also simplify the docs by removing some
of the links at the bottom that are now included in the badges.