### PR TITLE
fix issue: no theme named 'flask' found

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import inspect
 import re
 
-from pallets_sphinx_themes import DocVersion, ProjectLink, get_version
+from pallets_sphinx_themes import ProjectLink, get_version
 
 # Project --------------------------------------------------------------
 
@@ -46,11 +46,6 @@ html_context = {
         ProjectLink('Source Code', 'https://github.com/pallets/flask/'),
         ProjectLink(
             'Issue Tracker', 'https://github.com/pallets/flask/issues/'),
-    ],
-    'versions': [
-        DocVersion('dev', 'Development', 'unstable'),
-        DocVersion('1.0', 'Flask 1.0', 'stable'),
-        DocVersion('0.12', 'Flask 0.12'),
     ],
     'canonical_url': 'http://flask.pocoo.org/docs/{}/'.format(version),
     'carbon_ads_args': 'zoneid=1673&serve=C6AILKT&placement=pocooorg',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinxcontrib.log_cabinet',
+    'pallets_sphinx_themes',
 ]
 
 intersphinx_mapping = {


### PR DESCRIPTION
While build docs, some errors occurred.
```
Running Sphinx v1.7.8
loading pickled environment... not yet created

Theme error:
no theme named 'flask' found (missing theme.conf?)
```
For details, see https://github.com/pallets/pallets-sphinx-themes/issues/15

## Reason

If we use a theme of a sphinx extension which doesn't add themes into ``sphinx.html_themes`` entry points, at the same time we don't declare it as our extensions, ``sphinx`` will not find the theme.

## Solutions

There are two solutions:

1. The sphinx extension adds its themes into ``sphinx.html_themes`` entry points.

2. In the ``docs``' ``conf.py``, we declare the sphinx extension as our extensions.

I think solution **2** will be more applicable.