### PR TITLE
Install CONTRIBUTING.rst with MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include Makefile CHANGES.rst LICENSE AUTHORS tox.ini
+include Makefile CHANGES.rst CONTRIBUTING.rst LICENSE AUTHORS tox.ini
 
 graft artwork
 graft tests


### PR DESCRIPTION
Without CONTRIBUTING.rst filoe, documentation is not buildable:
docs/contributing.rst:1: WARNING: Problems with "include" directive path:
InputError: [Errno 2] No such file or directory: 'CONTRIBUTING.rst'.
