### PR TITLE
fix @click.command example by adding parens

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -308,7 +308,7 @@ decorator instead of the Flask decorator, you can use
     import click
     from flask.cli import with_appcontext
 
-    @click.command
+    @click.command()
     @with_appcontext
     def do_work():
         ...


### PR DESCRIPTION
Otherwise the example fails with the following error: 
"name = name or cmd.name AttributeError: 'function' object has no attribute 'name'". 

More details: https://stackoverflow.com/a/51923415/4619705