### PR TITLE
Make script output into comments to not break syntax highlighting

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -301,10 +301,10 @@ Python shell. See :ref:`context-locals`. ::
         print(url_for('login', next='/'))
         print(url_for('profile', username='John Doe'))
 
-    /
-    /login
-    /login?next=/
-    /user/John%20Doe
+    # /
+    # /login
+    # /login?next=/
+    # /user/John%20Doe
 
 HTTP Methods
 ````````````


### PR DESCRIPTION
http://flask.pocoo.org/docs/1.0/quickstart/#url-building

In the URL Building section of the quickstart, the script output is shown right after the code.

This breaks syntax highlighting for the whole code-block. To fix this, I have made the output into comments.