### PR TITLE
Add default returns for Request wrapper class properties

### DIFF
--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -145,7 +145,7 @@ class Request(RequestBase, JSONMixin):
     @property
     def max_content_length(self):
         """Read-only view of the ``MAX_CONTENT_LENGTH`` config key."""
-        return current_app.config.get('MAX_CONTENT_LENGTH') if current_app else None:
+        return current_app.config.get('MAX_CONTENT_LENGTH') if current_app else None
 
     @property
     def endpoint(self):

--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -145,8 +145,7 @@ class Request(RequestBase, JSONMixin):
     @property
     def max_content_length(self):
         """Read-only view of the ``MAX_CONTENT_LENGTH`` config key."""
-        if current_app:
-            return current_app.config['MAX_CONTENT_LENGTH']
+        return current_app.config.get('MAX_CONTENT_LENGTH') if current_app else None:
 
     @property
     def endpoint(self):

--- a/flask/wrappers.py
+++ b/flask/wrappers.py
@@ -154,14 +154,14 @@ class Request(RequestBase, JSONMixin):
         modified URL.  If an exception happened when matching, this will
         be ``None``.
         """
-        if self.url_rule is not None:
-            return self.url_rule.endpoint
+        return self.url_rule.endpoint if self.url_rule else None
 
     @property
     def blueprint(self):
         """The name of the current blueprint"""
         if self.url_rule and '.' in self.url_rule.endpoint:
             return self.url_rule.endpoint.rsplit('.', 1)[0]
+        return ''
 
     def _load_form_data(self):
         RequestBase._load_form_data(self)


### PR DESCRIPTION
The `Request` wrapper class contains properties that only return on valid logic checks. If the logic fails, a reference to the property object is returned instead of a value that is valid within the context of the property:

```python
# pytest source (abridged)
        unpatched_size = app.request_class.max_content_length
...
        assert unpatched_size == DEFAULT_UPLOAD_SIZE

# pytest output
...
>       assert unpatched_size == DEFAULT_UPLOAD_SIZE
E       assert <property object at 0x7fbb9ee964a8> == 67108864
```

This aims to tidy this up by always returning None or something relevant to the property, like an empty string.

This also avoids misleading assertion failures like "the `max_content_length` property is not X" rather than "None is not X".

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
