### PR TITLE
Fix #2926 `Default port overrides requesting a system assigned port`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,8 @@ Unreleased
     :pr:`3195`
 -   Allow customizing the :attr:`Flask.url_map_class` used for routing.
     :pr:`3069`
+-   The development server port can be set to 0, which tells the OS to
+    pick an available port. :issue:`2926`
 
 .. _#2935: https://github.com/pallets/flask/issues/2935
 .. _#2957: https://github.com/pallets/flask/issues/2957

--- a/flask/app.py
+++ b/flask/app.py
@@ -972,7 +972,8 @@ class Flask(_PackageBoundObject):
             sn_host, _, sn_port = server_name.partition(":")
 
         host = host or sn_host or _host
-        port = int(port or sn_port or _port)
+        # pick the first value that's not None (0 is allowed)
+        port = int(next((p for p in (port, sn_port) if p is not None), _port))
 
         options.setdefault("use_reloader", self.debug)
         options.setdefault("use_debugger", self.debug)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1916,21 +1916,24 @@ def test_run_server_port(monkeypatch, app):
 
 
 @pytest.mark.parametrize(
-    "host,port,expect_host,expect_port",
+    "host,port,server_name,expect_host,expect_port",
     (
-        (None, None, "pocoo.org", 8080),
-        ("localhost", None, "localhost", 8080),
-        (None, 80, "pocoo.org", 80),
-        ("localhost", 80, "localhost", 80),
+        (None, None, "pocoo.org:8080", "pocoo.org", 8080),
+        ("localhost", None, "pocoo.org:8080", "localhost", 8080),
+        (None, 80, "pocoo.org:8080", "pocoo.org", 80),
+        ("localhost", 80, "pocoo.org:8080", "localhost", 80),
+        ("localhost", 0, "localhost:8080", "localhost", 0),
+        (None, None, "localhost:8080", "localhost", 8080),
+        (None, None, "localhost:0", "localhost", 0),
     ),
 )
-def test_run_from_config(monkeypatch, host, port, expect_host, expect_port, app):
+def test_run_from_config(monkeypatch, host, port, server_name, expect_host, expect_port, app):
     def run_simple_mock(hostname, port, *args, **kwargs):
         assert hostname == expect_host
         assert port == expect_port
 
     monkeypatch.setattr(werkzeug.serving, "run_simple", run_simple_mock)
-    app.config["SERVER_NAME"] = "pocoo.org:8080"
+    app.config["SERVER_NAME"] = server_name
     app.run(host, port)
 
 


### PR DESCRIPTION
Fix #2926 

In `app.py`, compare possible port values with `None` explicitly, instead of relying on bool casting. Thanks to this, `0` is treated as legitimate port value, and not overwritten by the default value.
