### PR TITLE
Tutorial: Stop swallowing all OSErrors when creating the instance folder

### DIFF
--- a/docs/tutorial/factory.rst
+++ b/docs/tutorial/factory.rst
@@ -35,6 +35,7 @@ directory should be treated as a package.
 .. code-block:: python
     :caption: ``flaskr/__init__.py``
 
+    import errno
     import os
 
     from flask import Flask
@@ -58,8 +59,9 @@ directory should be treated as a package.
         # ensure the instance folder exists
         try:
             os.makedirs(app.instance_path)
-        except OSError:
-            pass
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
 
         # a simple page that says hello
         @app.route('/hello')

--- a/examples/tutorial/flaskr/__init__.py
+++ b/examples/tutorial/flaskr/__init__.py
@@ -1,3 +1,4 @@
+import errno
 import os
 
 from flask import Flask
@@ -23,8 +24,9 @@ def create_app(test_config=None):
     # ensure the instance folder exists
     try:
         os.makedirs(app.instance_path)
-    except OSError:
-        pass
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
 
     @app.route('/hello')
     def hello():


### PR DESCRIPTION
Improve error reporting of the application factory built during the tutorial by not swallowing all `OSError` exceptions that could happen when trying to create the instance folder.

This PR is inspired by the following SO entry: https://stackoverflow.com/a/273227

AFAIK this is portable code (see https://stackoverflow.com/a/273872 for a discussion on errno's portability), and I tested it under Linux and Windows.