### PR TITLE
Fix issue #2933: Make sure the attachment filename is text type.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,13 +13,17 @@ Unreleased
     (ISO-8859-1). This fixes compatibility with Gunicorn, which is
     stricter about header encodings than PEP 3333. (`#2766`_)
 -   Allow custom CLIs using ``FlaskGroup`` to set the debug flag without
-    it always being overwritten based on environment variables. (`#2765`_)
+    it always being overwritten based on environment variables.
+    (`#2765`_)
 -   ``flask --version`` outputs Werkzeug's version and simplifies the
     Python version. (`#2825`_)
+-   :func:`send_file` handles an ``attachment_filename`` that is a
+    native Python 2 string (bytes) with UTF-8 coded bytes. (`#2933`_)
 
 .. _#2766: https://github.com/pallets/flask/issues/2766
 .. _#2765: https://github.com/pallets/flask/pull/2765
 .. _#2825: https://github.com/pallets/flask/pull/2825
+.. _#2933: https://github.com/pallets/flask/issues/2933
 
 
 Version 1.0.2

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -567,6 +567,9 @@ def send_file(filename_or_fp, mimetype=None, as_attachment=False,
             raise TypeError('filename unavailable, required for '
                             'sending as attachment')
 
+        if not isinstance(attachment_filename, text_type):
+            attachment_filename = attachment_filename.decode('utf-8')
+
         try:
             attachment_filename = attachment_filename.encode('ascii')
         except UnicodeEncodeError:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -644,6 +644,8 @@ class TestSendfile(object):
         (u'Ñandú／pingüino.txt', '"Nandu/pinguino.txt"',
         '%C3%91and%C3%BA%EF%BC%8Fping%C3%BCino.txt'),
         (u'Vögel.txt', 'Vogel.txt', 'V%C3%B6gel.txt'),
+        # Native string not marked as Unicode on Python 2
+        ('tést.txt', 'test.txt', 't%C3%A9st.txt'),
     ))
     def test_attachment_filename_encoding(self, filename, ascii, utf8):
         rv = flask.send_file('static/index.html', as_attachment=True, attachment_filename=filename)


### PR DESCRIPTION
1. If attachment filename is bytes type and contains non-ascii coded bytes,
then the following ASCII encoding process will raise a ``UnicodeDecodeError`` exception.

2. Since the following exception handling uses ``unicodedata`` for normalization, this also implies that the attachment filename is a ``unicode`` when encoding .
https://github.com/pallets/flask/blob/363205bdc3abcfeed08c7e85e397fb7a7dc9ef07/flask/helpers.py#L570-L577

3. Since ``UnicodeDecodeError`` exception was raised, we can see that an ASCII decoding process was also performed implicitly when encoding bytes string. So this solution won't introduce unnecessary overhead.

fixes #2933 