### PR TITLE
Fix #2935: Copy current session object in copy_current_request_context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,9 +20,13 @@ Unreleased
     stricter about header encodings than PEP 3333. (`#2766`_)
 -   Allow custom CLIs using ``FlaskGroup`` to set the debug flag without
     it always being overwritten based on environment variables. (`#2765`_)
+-   :func:`flask.copy_current_request_context` adds a copy of the current
+    session object to the request context copy. This prevents
+    ``flask.session`` pointing to an out-of-date object. (`#2935`)
 
 .. _#2766: https://github.com/pallets/flask/issues/2766
 .. _#2765: https://github.com/pallets/flask/pull/2765
+.. _#2935: https://github.com/pallets/flask/issues/2935
 
 
 Version 1.0.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@ Version 1.1
 
 Unreleased
 
+-   :meth:`flask.RequestContext.copy` includes the current session
+    object in the request context copy. This prevents ``flask.session`` 
+    pointing to an out-of-date object. (`#2935`)
+
+.. _#2935: https://github.com/pallets/flask/issues/2935
+
 
 Version 1.0.3
 -------------
@@ -20,13 +26,9 @@ Unreleased
     stricter about header encodings than PEP 3333. (`#2766`_)
 -   Allow custom CLIs using ``FlaskGroup`` to set the debug flag without
     it always being overwritten based on environment variables. (`#2765`_)
--   :func:`flask.copy_current_request_context` adds a copy of the current
-    session object to the request context copy. This prevents
-    ``flask.session`` pointing to an out-of-date object. (`#2935`)
 
 .. _#2766: https://github.com/pallets/flask/issues/2766
 .. _#2765: https://github.com/pallets/flask/pull/2765
-.. _#2935: https://github.com/pallets/flask/issues/2935
 
 
 Version 1.0.2

--- a/flask/ctx.py
+++ b/flask/ctx.py
@@ -122,8 +122,8 @@ def copy_current_request_context(f):
     """A helper function that decorates a function to retain the current
     request context.  This is useful when working with greenlets.  The moment
     the function is decorated a copy of the request context is created and
-    then pushed when the function is called.  A copy of the current session is
-    also included in the copied request context.
+    then pushed when the function is called.  The current session is also
+    included in the copied request context.
 
     Example::
 
@@ -324,8 +324,8 @@ class RequestContext(object):
         .. versionadded:: 0.10
 
         .. versionchanged:: 1.1
-           A copy of the current session object is added to the request context
-           copy. This prevents `flask.session` pointing to an out-of-date object.
+           The current session object is used instead of reloading the original
+           data. This prevents `flask.session` pointing to an out-of-date object.
         """
         return self.__class__(self.app,
             environ=self.request.environ,

--- a/flask/ctx.py
+++ b/flask/ctx.py
@@ -122,7 +122,8 @@ def copy_current_request_context(f):
     """A helper function that decorates a function to retain the current
     request context.  This is useful when working with greenlets.  The moment
     the function is decorated a copy of the request context is created and
-    then pushed when the function is called.
+    then pushed when the function is called.  A copy of the current session is
+    also included in the copied request context.
 
     Example::
 
@@ -133,13 +134,17 @@ def copy_current_request_context(f):
         def index():
             @copy_current_request_context
             def do_some_work():
-                # do some work here, it can access flask.request like you
-                # would otherwise in the view function.
+                # do some work here, it can access flask.request or
+                # flask.session like you would otherwise in the view function.
                 ...
             gevent.spawn(do_some_work)
             return 'Regular response'
 
     .. versionadded:: 0.10
+
+    .. versionchanged:: 1.0.3
+       A copy of the current session object is added to the request context
+       copy. This prevents `flask.session` pointing to an out-of-date object.
     """
     top = _request_ctx_stack.top
     if top is None:

--- a/flask/ctx.py
+++ b/flask/ctx.py
@@ -14,7 +14,7 @@ from functools import update_wrapper
 
 from werkzeug.exceptions import HTTPException
 
-from .globals import _request_ctx_stack, _app_ctx_stack
+from .globals import session, _request_ctx_stack, _app_ctx_stack
 from .signals import appcontext_pushed, appcontext_popped
 from ._compat import BROKEN_PYPY_CTXMGR_EXIT, reraise
 
@@ -147,6 +147,7 @@ def copy_current_request_context(f):
             'when a request context is on the stack.  For instance within '
             'view functions.')
     reqctx = top.copy()
+    reqctx.session = session.copy()
     def wrapper(*args, **kwargs):
         with reqctx:
             return f(*args, **kwargs)

--- a/tests/test_reqctx.py
+++ b/tests/test_reqctx.py
@@ -156,7 +156,9 @@ class TestGreenletContextCopying(object):
 
         @app.route('/')
         def index():
+            flask.session['fizz'] = 'buzz'
             reqctx = flask._request_ctx_stack.top.copy()
+            reqctx.session = flask.session.copy()
 
             def g():
                 assert not flask.request
@@ -166,6 +168,7 @@ class TestGreenletContextCopying(object):
                     assert flask.current_app == app
                     assert flask.request.path == '/'
                     assert flask.request.args['foo'] == 'bar'
+                    assert flask.session.get('fizz') == 'buzz'
                 assert not flask.request
                 return 42
 
@@ -183,6 +186,7 @@ class TestGreenletContextCopying(object):
 
         @app.route('/')
         def index():
+            flask.session['fizz'] = 'buzz'
             reqctx = flask._request_ctx_stack.top.copy()
 
             @flask.copy_current_request_context
@@ -191,6 +195,7 @@ class TestGreenletContextCopying(object):
                 assert flask.current_app == app
                 assert flask.request.path == '/'
                 assert flask.request.args['foo'] == 'bar'
+                assert flask.session.get('fizz') == 'buzz'
                 return 42
 
             greenlets.append(greenlet(g))

--- a/tests/test_reqctx.py
+++ b/tests/test_reqctx.py
@@ -158,7 +158,6 @@ class TestGreenletContextCopying(object):
         def index():
             flask.session['fizz'] = 'buzz'
             reqctx = flask._request_ctx_stack.top.copy()
-            reqctx.session = flask.session.copy()
 
             def g():
                 assert not flask.request


### PR DESCRIPTION
Updates `flask.copy_current_request_context` to add a copy of the current session object to the request context copy. This prevents `flask.session` pointing to an out-of-date object.

- [x] add tests that fail without the patch
- [x] ensure all tests pass with ``pytest``
- [x] add documentation to the relevant docstrings or pages
- [x] add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
- [x] add a changelog entry if this patch changes code

Please refer to #2935 for background on this