### PR TITLE
Fix #2937: Ensure the consistency in load_dotenv's return type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,9 @@ Unreleased
     :pr:`3069`
 -   The development server port can be set to 0, which tells the OS to
     pick an available port. :issue:`2926`
+-   The return value from :meth:`cli.load_dotenv` is more consistent
+    with the documentation. It will return ``False`` if python-dotenv is
+    not installed, or if the given path isn't a file. :issue:`2937`
 
 .. _#2935: https://github.com/pallets/flask/issues/2935
 .. _#2957: https://github.com/pallets/flask/issues/2957

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -598,6 +598,10 @@ def load_dotenv(path=None):
     :param path: Load the file at this location instead of searching.
     :return: ``True`` if a file was loaded.
 
+    .. versionchanged:: 1.1.0
+        Returns ``False`` when python-dotenv is not installed, or when
+        the given path isn't a file.
+
     .. versionadded:: 1.0
     """
     if dotenv is None:
@@ -607,10 +611,16 @@ def load_dotenv(path=None):
                 ' Do "pip install python-dotenv" to use them.',
                 fg="yellow",
             )
-        return
 
+        return False
+
+    # if the given path specifies the actual file then return True,
+    # else False
     if path is not None:
-        return dotenv.load_dotenv(path)
+        if os.path.isfile(path):
+            return dotenv.load_dotenv(path)
+
+        return False
 
     new_dir = None
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -513,7 +513,7 @@ def test_load_dotenv(monkeypatch):
 
     monkeypatch.setenv("EGGS", "3")
     monkeypatch.chdir(os.path.join(test_path, "cliapp", "inner1"))
-    load_dotenv()
+    assert load_dotenv()
     assert os.getcwd() == test_path
     # .flaskenv doesn't overwrite .env
     assert os.environ["FOO"] == "env"
@@ -523,6 +523,9 @@ def test_load_dotenv(monkeypatch):
     assert os.environ["SPAM"] == "1"
     # set manually, files don't overwrite
     assert os.environ["EGGS"] == "3"
+
+    # Non existent file should not load
+    assert not load_dotenv('non-existent-file')
 
 
 @need_dotenv


### PR DESCRIPTION
In the ``flask.cli`` module, the ``load_dotenv`` function is not consistent in its return type. It should either return True or False depending on whether it has loaded the file or not, respectively.

fixes https://github.com/pallets/flask/issues/2937

Commit checklist:

- [x] add tests that fail without the patch

- [x] ensure all tests pass with ``pytest``

- [x] add documentation to the relevant docstrings or pages

- [x] add ``versionadded`` or ``versionchanged`` directives to relevant docstrings

- [x] add a changelog entry if this patch changes code
