### PR TITLE
Fixed typo in app.py

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -1686,7 +1686,7 @@ class Flask(_PackageBoundObject):
         exception with the same traceback.
 
         .. versionchanged:: 1.0
-            Key errors raised from request data like ``form`` show the the bad
+            Key errors raised from request data like ``form`` show the bad
             key in debug mode rather than a generic bad request message.
 
         .. versionadded:: 0.7


### PR DESCRIPTION
This patch fixes a typo in the "handle_user_exception" method in app.py.

<!--
Link to any relevant issues or pull requests.

Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
