### PR TITLE
Allow positional arguments to @login_required decorator in tutorial

### DIFF
--- a/examples/tutorial/flaskr/auth.py
+++ b/examples/tutorial/flaskr/auth.py
@@ -13,11 +13,11 @@ bp = Blueprint('auth', __name__, url_prefix='/auth')
 def login_required(view):
     """View decorator that redirects anonymous users to the login page."""
     @functools.wraps(view)
-    def wrapped_view(**kwargs):
+    def wrapped_view(*args, **kwargs):
         if g.user is None:
             return redirect(url_for('auth.login'))
 
-        return view(**kwargs)
+        return view(*args, **kwargs)
 
     return wrapped_view
 


### PR DESCRIPTION
Updating posts was not working due to a positional argument not playing well with the @login_required function (using Python 3.6).

I changed the function to accept positional arugments, which fixes the problem.