### PR TITLE
Fix #2943: Allow bytesio partial content

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,15 +10,19 @@ Version 1.1
 Unreleased
 
 -   :meth:`flask.RequestContext.copy` includes the current session
-    object in the request context copy. This prevents ``flask.session``
-    pointing to an out-of-date object. (`#2935`)
--   Using built-in RequestContext, unprintable Unicode characters in Host
-    header will result in a HTTP 400 response and not HTTP 500 as previously.
-    (`#2994`)
--   :func:`send_file` supports ``PathLike`` objects as describe in
-    PEP 0519, to support ``pathlib`` in Python 3. (`#3059`_)
+    object in the request context copy. This prevents ``session``
+    pointing to an out-of-date object. (`#2935`_)
+-   Using built-in RequestContext, unprintable Unicode characters in
+    Host header will result in a HTTP 400 response and not HTTP 500 as
+    previously. (`#2994`_)
+-   :func:`send_file` supports :class:`~os.PathLike` objects as
+    described in PEP 0519, to support :mod:`pathlib` in Python 3.
+    (`#3059`_)
+-   :func:`send_file` supports :class:`~io.BytesIO` partial content.
+    (`#2957`_)
 
 .. _#2935: https://github.com/pallets/flask/issues/2935
+.. _#2957: https://github.com/pallets/flask/issues/2957
 .. _#2994: https://github.com/pallets/flask/pull/2994
 .. _#3059: https://github.com/pallets/flask/pull/3059
 

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -8,7 +8,7 @@
     :copyright: © 2010 by the Pallets team.
     :license: BSD, see LICENSE for more details.
 """
-
+import io
 import os
 import socket
 import sys
@@ -512,6 +512,8 @@ def send_file(filename_or_fp, mimetype=None, as_attachment=False,
 
     .. versionchanged:: 1.1
         Filenames may be a `PathLike` object.
+    .. versionadded:: 1.1
+        Partial content supports ``BytesIO``.
 
     :param filename_or_fp: the filename of the file to send.
                            This is relative to the :attr:`~Flask.root_path`
@@ -599,6 +601,12 @@ def send_file(filename_or_fp, mimetype=None, as_attachment=False,
             file = open(filename, 'rb')
             mtime = os.path.getmtime(filename)
             fsize = os.path.getsize(filename)
+            headers['Content-Length'] = fsize
+        elif isinstance(file, io.BytesIO):
+            try:
+                fsize = file.getbuffer().nbytes
+            except AttributeError:
+                fsize = len(file.getvalue())
             headers['Content-Length'] = fsize
         data = wrap_file(request.environ, file)
 

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -511,9 +511,10 @@ def send_file(filename_or_fp, mimetype=None, as_attachment=False,
         compatibility with WSGI servers.
 
     .. versionchanged:: 1.1
-        Filenames may be a `PathLike` object.
+        Filename may be a :class:`~os.PathLike` object.
+
     .. versionadded:: 1.1
-        Partial content supports ``BytesIO``.
+        Partial content supports :class:`~io.BytesIO`.
 
     :param filename_or_fp: the filename of the file to send.
                            This is relative to the :attr:`~Flask.root_path`
@@ -606,6 +607,7 @@ def send_file(filename_or_fp, mimetype=None, as_attachment=False,
             try:
                 fsize = file.getbuffer().nbytes
             except AttributeError:
+                # Python 2 doesn't have getbuffer
                 fsize = len(file.getvalue())
             headers['Content-Length'] = fsize
         data = wrap_file(request.environ, file)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -609,10 +609,6 @@ class TestSendfile(object):
         assert rv.status_code == 200
         rv.close()
 
-    @pytest.mark.skipif(
-        not callable(getattr(Range, 'to_content_range_header', None)),
-        reason="not implemented within werkzeug"
-    )
     def test_send_file_range_request_bytesio(self, app, client):
         @app.route('/')
         def index():


### PR DESCRIPTION
In `helpers.py` when `file` is a `BytesIO`, `fsize` was not setted. It should be setted.

Issue: https://github.com/pallets/flask/issues/2943

- [x] add tests that fail without the patch
- [x] ensure all tests pass with ``pytest``
- [x] add documentation to the relevant docstrings or pages
- [x] add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
- [x] add a changelog entry if this patch changes code

