### PR TITLE
Use https for external links wherever possible

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@ questions about using Flask or issues not related to Flask.**
 
 If you'd like to report a bug in Flask, fill out the template below. Provide
 any extra information that may be useful / related to your problem.
-Ideally, create an [MCVE](http://stackoverflow.com/help/mcve), which helps us
+Ideally, create an [MCVE](https://stackoverflow.com/help/mcve), which helps us
 understand the problem and helps check that it is not caused by something in
 your code.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -91,7 +91,7 @@ Start coding
 - Push your commits to GitHub and `create a pull request`_.
 - Celebrate 🎉
 
-.. _committing as you go: http://dont-be-afraid-to-commit.readthedocs.io/en/latest/git/commandlinegit.html#commit-your-changes
+.. _committing as you go: https://dont-be-afraid-to-commit.readthedocs.io/en/latest/git/commandlinegit.html#commit-your-changes
 .. _PEP8: https://pep8.org/
 .. _create a pull request: https://help.github.com/articles/creating-a-pull-request/
 
@@ -142,7 +142,7 @@ Build the docs in the ``docs`` directory using Sphinx::
 
 Open ``_build/html/index.html`` in your browser to view the docs.
 
-Read more about `Sphinx <http://www.sphinx-doc.org>`_.
+Read more about `Sphinx <https://www.sphinx-doc.org>`_.
 
 
 make targets

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -44,7 +44,7 @@ Incoming Request Data
    .. attribute:: url_root
 
       Provides different ways to look at the current `IRI
-      <http://tools.ietf.org/html/rfc3987>`_.  Imagine your application is
+      <https://tools.ietf.org/html/rfc3987>`_.  Imagine your application is
       listening on the following application root::
 
           http://www.example.com/myapplication

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -571,7 +571,7 @@ your configuration files.  However here a list of good recommendations:
     details about how to do that, head over to the
     :ref:`fabric-deployment` pattern.
 
-.. _fabric: http://www.fabfile.org/
+.. _fabric: https://www.fabfile.org/
 
 
 .. _instance-folders:

--- a/docs/deploying/uwsgi.rst
+++ b/docs/deploying/uwsgi.rst
@@ -69,4 +69,4 @@ to have it in the URL root its a bit simpler::
 .. _nginx: https://nginx.org/
 .. _lighttpd: https://www.lighttpd.net/
 .. _cherokee: http://cherokee-project.com/
-.. _uwsgi: http://projects.unbit.it/uwsgi/
+.. _uwsgi: https://uwsgi-docs.readthedocs.io/

--- a/docs/deploying/wsgi-standalone.rst
+++ b/docs/deploying/wsgi-standalone.rst
@@ -23,8 +23,8 @@ For example, to run a Flask application with 4 worker processes (``-w
 
     $ gunicorn -w 4 -b 127.0.0.1:4000 myproject:app
 
-.. _Gunicorn: http://gunicorn.org/
-.. _eventlet: http://eventlet.net/
+.. _Gunicorn: https://gunicorn.org/
+.. _eventlet: https://eventlet.net/
 .. _greenlet: https://greenlet.readthedocs.io/en/latest/
 
 uWSGI
@@ -39,8 +39,8 @@ Running `uWSGI HTTP Router`_::
 
 For a more optimized setup, see :doc:`configuring uWSGI and NGINX <uwsgi>`.
 
-.. _uWSGI: http://uwsgi-docs.readthedocs.io/en/latest/
-.. _uWSGI HTTP Router: http://uwsgi-docs.readthedocs.io/en/latest/HTTP.html#the-uwsgi-http-https-router
+.. _uWSGI: https://uwsgi-docs.readthedocs.io/en/latest/
+.. _uWSGI HTTP Router: https://uwsgi-docs.readthedocs.io/en/latest/HTTP.html#the-uwsgi-http-https-router
 
 Gevent
 -------

--- a/docs/htmlfaq.rst
+++ b/docs/htmlfaq.rst
@@ -186,7 +186,7 @@ Many other features have been added, as well. A good guide to new features
 in HTML5 is Mark Pilgrim's soon-to-be-published book, `Dive Into HTML5`_.
 Not all of them are supported in browsers yet, however, so use caution.
 
-.. _Dive Into HTML5: http://diveintohtml5.info/
+.. _Dive Into HTML5: http://diveintohtml5.info/table-of-contents.html
 
 What should be used?
 --------------------

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -22,7 +22,7 @@ if errorlevel 9009 (
 	echo.may add the Sphinx directory to PATH.
 	echo.
 	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
+	echo.https://www.sphinx-doc.org/
 	exit /b 1
 )
 

--- a/docs/patterns/celery.rst
+++ b/docs/patterns/celery.rst
@@ -10,7 +10,7 @@ immediately.
 Celery is a powerful task queue that can be used for simple background tasks
 as well as complex multi-stage programs and schedules. This guide will show you
 how to configure Celery using Flask, but assumes you've already read the
-`First Steps with Celery <http://docs.celeryproject.org/en/latest/getting-started/first-steps-with-celery.html>`_
+`First Steps with Celery <https://celery.readthedocs.io/en/latest/getting-started/first-steps-with-celery.html>`_
 guide in the Celery documentation.
 
 Install

--- a/docs/patterns/fabric.rst
+++ b/docs/patterns/fabric.rst
@@ -183,4 +183,4 @@ type ``fab deploy`` and see your application being deployed automatically
 to one or more remote servers.
 
 
-.. _Fabric: http://www.fabfile.org/
+.. _Fabric: https://www.fabfile.org/

--- a/docs/patterns/jquery.rst
+++ b/docs/patterns/jquery.rst
@@ -11,7 +11,7 @@ Python primitives (numbers, strings, dicts and lists) look like which is
 widely supported and very easy to parse.  It became popular a few years
 ago and quickly replaced XML as transport format in web applications.
 
-.. _jQuery: http://jquery.com/
+.. _jQuery: https://jquery.com/
 
 Loading jQuery
 --------------

--- a/docs/patterns/mongokit.rst
+++ b/docs/patterns/mongokit.rst
@@ -103,7 +103,7 @@ Querying is simple as well:
 >>> collection.User.find_one({'name': u'admin'})
 <User u'admin'>
 
-.. _MongoKit: http://bytebucket.org/namlook/mongokit/
+.. _MongoKit: https://github.com/namlook/mongokit
 
 
 PyMongo Compatibility Layer

--- a/docs/unicode.rst
+++ b/docs/unicode.rst
@@ -6,7 +6,7 @@ text.  Not only these libraries, also the majority of web related Python
 libraries that deal with text.  If you don't know Unicode so far, you
 should probably read `The Absolute Minimum Every Software Developer
 Absolutely, Positively Must Know About Unicode and Character Sets
-<http://www.joelonsoftware.com/articles/Unicode.html>`_.  This part of the
+<https://www.joelonsoftware.com/articles/Unicode.html>`_.  This part of the
 documentation just tries to cover the very basics so that you have a
 pleasant experience with Unicode related things.
 


### PR DESCRIPTION
Update docs to use https for external links wherever possible.

Please also consider supporting https on all the subdomains of pocoo.org in near future :-)