### PR TITLE
[Feature proposal] Add instance folders to the template searchpath

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -17,6 +17,7 @@ from functools import update_wrapper
 from itertools import chain
 from threading import Lock
 
+from jinja2 import FileSystemLoader
 from werkzeug.datastructures import Headers, ImmutableDict
 from werkzeug.exceptions import BadRequest, BadRequestKeyError, HTTPException, \
     InternalServerError, MethodNotAllowed, default_exceptions
@@ -634,6 +635,17 @@ class Flask(_PackageBoundObject):
         .. versionadded:: 0.3
         """
         return create_logger(self)
+
+    @locked_cached_property
+    def jinja_loader(self):
+        """The Jinja loader for the app. Allows overriding templates
+        using templates in the instance directory.
+        """
+        if self.template_folder is not None:
+            return FileSystemLoader([
+                os.path.join(self.instance_path, self.template_folder),
+                os.path.join(self.root_path, self.template_folder)
+            ])
 
     @locked_cached_property
     def jinja_env(self):


### PR DESCRIPTION
**Summary**
Adds the instance folder to the template search path for `Flask` objects.

**Pupose**

Instance folders are currently limited to specifying config. However, they have the potential to be more flexible. 

For example, consider writing a static site generator in flask. The CLI could handle initialising the application, setting up routes etc. It would make sense to specify the site directory as an instance folder, for loading configuration. This pull request would enable features like custom themes by adding them to the site directory, overriding or extending the package defaults.

**Changes**

The Jinja `FileSystemLoader` allows for multiple search paths to be specified. Each path will be tested in order, so we simply override `_PackageBoundObject.jinja_loader`, and add the instance folder to the searchpaths.

**Evaluation of Alternatives**

One alternative solution to the example specified above would be to instead change the `root_path` of the application. However, this wouldn't allow for the user to use resources installed in the package.

Another alternative solution would be to use Blueprints to solve cases where we want to create multiple similar applications. If this is the preferred solution, the I'm happy to close the request.

**Other points**

I noticed that `tests/test_templating.py::test_custom_template_loader` tested overriding `Flask.create_global_jinja_loader`. I changed the test to use the recommended method of overloading `_PackageBoundObejct.jinja_loader` instead. Let me know if you think this should be in a separate pull request.
