### PR TITLE
Handle errors during create_url_adapter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,8 +12,12 @@ Unreleased
 -   :meth:`flask.RequestContext.copy` includes the current session
     object in the request context copy. This prevents ``flask.session`` 
     pointing to an out-of-date object. (`#2935`)
+-   Using built-in RequestContext, unprintable Unicode characters in Host
+    header will result in a HTTP 400 response and not HTTP 500 as previously.
+    (`#2994`)
 
 .. _#2935: https://github.com/pallets/flask/issues/2935
+.. _#2994: https://github.com/pallets/flask/pull/2994
 
 
 Version 1.0.3

--- a/flask/ctx.py
+++ b/flask/ctx.py
@@ -282,7 +282,11 @@ class RequestContext(object):
         if request is None:
             request = app.request_class(environ)
         self.request = request
-        self.url_adapter = app.create_url_adapter(self.request)
+        self.url_adapter = None
+        try:
+            self.url_adapter = app.create_url_adapter(self.request)
+        except HTTPException as e:
+            self.request.routing_exception = e
         self.flashes = None
         self.session = session
 
@@ -305,7 +309,8 @@ class RequestContext(object):
         # functions.
         self._after_request_functions = []
 
-        self.match_request()
+        if self.url_adapter is not None:
+            self.match_request()
 
     def _get_g(self):
         return _app_ctx_stack.top.g

--- a/tests/test_reqctx.py
+++ b/tests/test_reqctx.py
@@ -229,3 +229,26 @@ def test_session_error_pops_context():
     assert response.status_code == 500
     assert not flask.request
     assert not flask.current_app
+
+
+def test_bad_environ_raises_bad_request():
+    app = flask.Flask(__name__)
+
+    @app.route('/')
+    def index():
+        # shouldn't get here anyway
+        assert False
+
+    response = app.test_client().get('/', headers={'host': 'ąśź.com'})
+    assert response.status_code == 400
+
+
+def test_normal_environ_completes():
+    app = flask.Flask(__name__)
+
+    @app.route('/')
+    def index():
+        return 'Hello World!'
+
+    response = app.test_client().get('/', headers={'host': 'xn--on-0ia.com'})
+    assert response.status_code == 200


### PR DESCRIPTION
If create_url_adapter raises (which it can if werkzeug cannot bind environment, for example on ~non-ASCII~ non-printable Host header), we should handle it as other routing exceptions rather than raising through. This allows us to return a HTTP 400, rather than a 500 from unhandled exception.

This came up in https://github.com/pallets/werkzeug/issues/640

Do we need to add it to any documentation or changelogs?