### PR TITLE
Document 'flask run --host' and '--port'

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -101,6 +101,8 @@ replaces the :meth:`Flask.run` method in most cases. ::
     is provided for convenience, but is not designed to be particularly secure,
     stable, or efficient. See :ref:`deployment` for how to run in production.
 
+To run the development server on a specific interface or port, use the
+``--host`` or ``--port`` arguments.  Run ``flask run --help`` for details.
 
 Open a Shell
 ------------
@@ -190,14 +192,15 @@ Setting Command Options
 
 Click is configured to load default values for command options from
 environment variables. The variables use the pattern
-``FLASK_COMMAND_OPTION``. For example, to set the port for the run
-command, instead of ``flask run --port 8000``:
+``FLASK_COMMAND_OPTION``. For example, to set the port and host for the run
+command, instead of ``flask run --port 8000 --host 0.0.0.0``:
 
 .. code-block:: none
 
     $ export FLASK_RUN_PORT=8000
+    $ export FLASK_RUN_HOST=0.0.0.0
     $ flask run
-     * Running on http://127.0.0.1:8000/
+     * Running on http://0.0.0.0:8000/
 
 These can be added to the ``.flaskenv`` file just like ``FLASK_APP`` to
 control default command options.

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -31,6 +31,10 @@ disabled::
 
     $ flask run --no-reload
 
+To see descriptions of the arguments that may be passed, run::
+
+    $ flask run --help
+
 .. note::
 
     Prior to Flask 1.0 the :envvar:`FLASK_ENV` environment variable was

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -725,7 +725,9 @@ def _validate_key(ctx, param, value):
     return value
 
 
-@click.command('run', short_help='Runs a development server.')
+@click.command('run',
+               short_help='Runs a development server (flask run --help for '
+               'more info).')
 @click.option('--host', '-h', default='127.0.0.1',
               help='The interface to bind to.')
 @click.option('--port', '-p', default=5000,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -395,6 +395,37 @@ def test_print_exceptions(runner):
     assert 'Traceback' in result.output
 
 
+def test_help_mentions_run_help(runner):
+    """Print information about host and port in help output"""
+
+    def create_app(info):
+        return Flask("flaskgroup")
+
+    @click.group(cls=FlaskGroup, create_app=create_app)
+    def cli(**params):
+        pass
+
+    result = runner.invoke(cli, ['--help'])
+    assert result.exit_code == 0
+    assert 'run --help' in result.output
+
+
+def test_run_help_documents_host_and_port(runner):
+    """Print information about host and port in help output"""
+
+    def create_app(info):
+        return Flask("flaskgroup")
+
+    @click.group(cls=FlaskGroup, create_app=create_app)
+    def cli(**params):
+        pass
+
+    result = runner.invoke(cli, ['run', '--help'])
+    assert result.exit_code == 0
+    assert '--host' in result.output
+    assert '--port' in result.output
+
+
 class TestRoutes:
     @pytest.fixture
     def invoke(self, runner):


### PR DESCRIPTION
Small additions to `flask --help` and the docs to make more mention of the `--help`, `--port` and `--host` arguments to `flask run`.

Also adds a mention of the environment variable `FLASK_RUN_HOST` since that works, but was not mentioned anywhere I could find.

I don't know whether this merits a changelog entry - do let me know if that is needed.