### PR TITLE
Use imperative tense for CLI help text

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -725,7 +725,7 @@ def _validate_key(ctx, param, value):
     return value
 
 
-@click.command('run', short_help='Runs a development server.')
+@click.command('run', short_help='Run a development server.')
 @click.option('--host', '-h', default='127.0.0.1',
               help='The interface to bind to.')
 @click.option('--port', '-p', default=5000,
@@ -777,10 +777,10 @@ def run_command(info, host, port, reload, debugger, eager_loading,
                threaded=with_threads, ssl_context=cert)
 
 
-@click.command('shell', short_help='Runs a shell in the app context.')
+@click.command('shell', short_help='Run a shell in the app context.')
 @with_appcontext
 def shell_command():
-    """Runs an interactive Python shell in the context of a given
+    """Run an interactive Python shell in the context of a given
     Flask application.  The application will populate the default
     namespace of this shell according to it's configuration.
 
@@ -865,7 +865,7 @@ def routes_command(sort, all_methods):
 cli = FlaskGroup(help="""\
 A general utility script for Flask applications.
 
-Provides commands from Flask, extensions, and the application. Loads the
+Provide commands from Flask, extensions, and the application. Load the
 application defined in the FLASK_APP environment variable, or from a wsgi.py
 file. Setting the FLASK_ENV environment variable to 'development' will enable
 debug mode.


### PR DESCRIPTION
Fix #3005 

I also found some docstring use present tense, for example:
```py
def with_appcontext(f):
    """Wraps a callback so that it's guaranteed to be executed with the
    ...
    """
```
Is it needed to update them?