### PR TITLE
Fix typos found while completing the Flask tutorial

### DIFF
--- a/docs/tutorial/blog.rst
+++ b/docs/tutorial/blog.rst
@@ -314,7 +314,7 @@ Delete
 
 The delete view doesn't have its own template, the delete button is part
 of ``update.html`` and posts to the ``/<id>/delete`` URL. Since there
-is no template, it will only handle the ``POST`` method then redirect
+is no template, it will only handle the ``POST`` method and then redirect
 to the ``index`` view.
 
 .. code-block:: python

--- a/docs/tutorial/database.rst
+++ b/docs/tutorial/database.rst
@@ -149,7 +149,7 @@ Register with the Application
 -----------------------------
 
 The ``close_db`` and ``init_db_command`` functions need to be registered
-with the application instance, otherwise they won't be used by the
+with the application instance; otherwise, they won't be used by the
 application. However, since you're using a factory function, that
 instance isn't available when writing the functions. Instead, write a
 function that takes an application and does the registration.


### PR DESCRIPTION
Fix minor typos in `blog.rst` and `database.rst`.