### PR TITLE
docs: Update virtualenv creation process for Fedora

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -98,6 +98,14 @@ Python, use the following command instead:
 
     virtualenv venv
 
+On Fedora (the `virtualenv` executable is reserved for
+`python3-virtualenv`, installable via `yum install virtualenv`, but we
+are using python2's virtualenv here):
+
+.. code-block:: sh
+
+    python -m venv venv
+
 On Windows:
 
 .. code-block:: bat


### PR DESCRIPTION
The other alternative is to tell to install `virtualenv` system package, then run `virtualenv -p python2.7 venv`, but this is putting exception in 2 places (1. installation and 2. venv creation).

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
