### PR TITLE
 Force endpoint name to string in Python 2

### DIFF
--- a/flask/views.py
+++ b/flask/views.py
@@ -10,7 +10,7 @@
 """
 
 from .globals import request
-from ._compat import with_metaclass
+from ._compat import with_metaclass, PY2, text_type
 
 
 http_method_funcs = frozenset(['get', 'post', 'head', 'options',
@@ -83,6 +83,9 @@ class View(object):
         The arguments passed to :meth:`as_view` are forwarded to the
         constructor of the class.
         """
+        if PY2 and isinstance(name, text_type):
+            name = str(name)
+
         def view(*args, **kwargs):
             self = view.view_class(*class_args, **class_kwargs)
             return self.dispatch_request(*args, **kwargs)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -237,3 +237,11 @@ def test_remove_method_from_parent(app, client):
     assert client.get('/').data == b'GET'
     assert client.post('/').status_code == 405
     assert sorted(View.methods) == ['GET']
+
+
+def test_unicode_endpoint_for_py2(app, client):
+    class Index(flask.views.MethodView):
+        def get(self):
+            return 'GET'
+
+    app.add_url_rule('/', view_func=Index.as_view(u'index'))


### PR DESCRIPTION
Using unicode endpoint name in Python 2 will raise `TypeError: __name__ must be set to a string object`.

Example application:
```py
from __future__ import unicode_literals

from flask import Flask
from flask.views import MethodView

app = Flask(__name__)

class Index(MethodView):
    def get(self):
        return 'GET'

app.add_url_rule('/', view_func=Index.as_view('index'))
```
Full error traceback:
```pytb
Traceback (most recent call last):
  File "...\app.py", line 93, in <module>
    app.add_url_rule('/', view_func=Index.as_view('index'))
  File "python27\lib\site-packages\flask\views.py", line 105, in as_view
    view.__name__ = name
TypeError: __name__ must be set to a string object
```

This PR will force endpoint name to string in Python 2.

Close #3033 