### PR TITLE
Fix DeprecationWarning on collections import in flask.sessions

### DIFF
--- a/flask/_compat.py
+++ b/flask/_compat.py
@@ -28,6 +28,7 @@ if not PY2:
 
     from inspect import getfullargspec as getargspec
     from io import StringIO
+    import collections.abc as collections_abc
 
     def reraise(tp, value, tb=None):
         if value.__traceback__ is not tb:
@@ -47,6 +48,7 @@ else:
 
     from inspect import getargspec
     from cStringIO import StringIO
+    import collections as collections_abc
 
     exec('def reraise(tp, value, tb=None):\n raise tp, value, tb')
 

--- a/flask/sessions.py
+++ b/flask/sessions.py
@@ -11,17 +11,17 @@
 
 import hashlib
 import warnings
-from collections import MutableMapping
 from datetime import datetime
 
 from itsdangerous import BadSignature, URLSafeTimedSerializer
 from werkzeug.datastructures import CallbackDict
 
+from flask._compat import collections_abc
 from flask.helpers import is_ip, total_seconds
 from flask.json.tag import TaggedJSONSerializer
 
 
-class SessionMixin(MutableMapping):
+class SessionMixin(collections_abc.MutableMapping):
     """Expands a basic dictionary with session attributes."""
 
     @property


### PR DESCRIPTION
This fixes #3053 by moving the import to _compat . This can be directly imported since it's the only file but moving it to _compat makes it easier to use it in future for these cases and also goes in line with fixes in jinja2 and werkzeug for similar issues. Let me know if this needs to be changed. 

Thanks for Flask :)