### PR TITLE
[Docs] Mention how to skip subsets of exceptions in errorpages.rst

### DIFF
--- a/docs/patterns/errorpages.rst
+++ b/docs/patterns/errorpages.rst
@@ -54,6 +54,9 @@ which is most likely a :exc:`~werkzeug.exceptions.HTTPException`. An error
 handler for "500 Internal Server Error" will be passed uncaught exceptions in
 addition to explicit 500 errors.
 
+An error handler may optionally skip handling by returning the original
+exception. This is useful for skipping a subset of captured exceptions.
+
 An error handler is registered with the :meth:`~flask.Flask.errorhandler`
 decorator or the :meth:`~flask.Flask.register_error_handler` method. A handler
 can be registered for a status code, like 404, or for an exception class.
@@ -97,3 +100,15 @@ An example template might be this:
       <p>What you were looking for is just not there.
       <p><a href="{{ url_for('index') }}">go somewhere nice</a>
     {% endblock %}
+
+Here is an example of skipping a subset of captured exceptions::
+
+    from flask import render_template
+    from werkzeug.exceptions import HTTPException
+
+    @app.errorhandler(HTTPException)
+    def generic_error(e):
+        # skip 3XX
+        if e.code < 400:
+            return e
+        return render_template('generic_error.html', code=e.code), e.code


### PR DESCRIPTION
It appears that skipping subsets of exceptions in a generic error handler has been a major point of confusion; there are at least three open issues related to this: #2778, #2841, #2984.

This PR documents the workaround without modifying current behavior (whether 3XX should be captured seems to be a point of contention in the aforementioned issues).