### PR TITLE
Fix DeprecationWarning: invlid escape sequence in make-release.py

### DIFF
--- a/scripts/make-release.py
+++ b/scripts/make-release.py
@@ -14,7 +14,7 @@ def parse_changelog():
     with open('CHANGES.rst') as f:
         lineiter = iter(f)
         for line in lineiter:
-            match = re.search('^Version\s+(.*)', line.strip())
+            match = re.search(r'^Version\s+(.*)', line.strip())
 
             if match is None:
                 continue


### PR DESCRIPTION
Hello,

In addition to #3056, this is a little patch to fix the last remaining `DeprecationWarning: invalid escape sequence` in `make-release.py`.

Signed-off-by: Mickaël Schoentgen <contact@tiger-222.fr>