### PR TITLE
Add comment about using factory function in __init__.py

### DIFF
--- a/docs/deploying/mod_wsgi.rst
+++ b/docs/deploying/mod_wsgi.rst
@@ -61,6 +61,11 @@ For most applications the following file should be sufficient::
 
     from yourapplication import app as application
 
+If a factory function is used in a :file:`__init__.py` file, then the function should be imported::
+
+    from yourapplication import create_app
+    application = create_app()
+
 If you don't have a factory function for application creation but a singleton
 instance you can directly import that one as `application`.
 


### PR DESCRIPTION
If the tutorial is followed, a factory function is created in `__init__.py`. As far as I understand this requires the factory function to be imported and then used to create the application in a `yourapplication.wsgi` file. This pull request adds a comment about this.