### PR TITLE
clear KeyError in production for Werkzeug 0.15

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1045,7 +1045,7 @@ def test_trapping_of_bad_request_key_errors(app, client):
     with pytest.raises(KeyError) as e:
         client.get("/key")
     assert e.errisinstance(BadRequest)
-    assert 'missing_key' in e.value.description
+    assert 'missing_key' in e.value.get_description()
     rv = client.get('/abort')
     assert rv.status_code == 400
 


### PR DESCRIPTION
Werkzeug 0.15 adds the `KeyError` message to `BadRequestKeyError`. Flask was previously adding this manually. Now it should *clear* the message when not in development mode. 1.0.x will keep compatibility with Werkzeug 0.14 and 0.15, 1.1 will bump the version requirement.