### PR TITLE
use "-m virtualenv" in installation doc

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -91,12 +91,12 @@ On Windows:
 
     py -3 -m venv venv
 
-If you needed to install virtualenv because you are on an older version of
-Python, use the following command instead:
+If you needed to install virtualenv because you are using Python 2, use
+the following command instead:
 
 .. code-block:: sh
 
-    virtualenv venv
+    python2 -m virtualenv venv
 
 On Windows:
 


### PR DESCRIPTION
On Fedora, `yum install python-virtualenv` installs virtualenv for Python 2, but it doesn't add the `virtualenv` command to the path. Use `python2 -m virutalenv` instead of the `virutalenv` command.

closes #3035 