### PR TITLE
clarify where to call flask run from in tutorial

### DIFF
--- a/docs/tutorial/factory.rst
+++ b/docs/tutorial/factory.rst
@@ -127,7 +127,8 @@ Run The Application
 
 Now you can run your application using the ``flask`` command. From the
 terminal, tell Flask where to find your application, then run it in
-development mode.
+development mode. Remember, you should still be in the top-level
+``flask-tutorial`` directory, not the ``flaskr`` package.
 
 Development mode shows an interactive debugger whenever a page raises an
 exception, and restarts the server whenever you make changes to the

--- a/docs/tutorial/install.rst
+++ b/docs/tutorial/install.rst
@@ -108,6 +108,7 @@ You can observe that the project is now installed with ``pip list``.
 
 Nothing changes from how you've been running your project so far.
 ``FLASK_APP`` is still set to ``flaskr`` and ``flask run`` still runs
-the application.
+the application, but you can call it from anywhere, not just the
+``flask-tutorial`` directory.
 
 Continue to :doc:`tests`.


### PR DESCRIPTION
closes #2967 