### PR TITLE
Allow customizing url map class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,8 @@ Unreleased
     :issue:`3134`
 -   :meth:`jsonify` supports :class:`dataclasses.dataclass` objects.
     :pr:`3195`
+-   Allow customizing the :attr:`Flask.url_map_class` used for routing.
+    :pr:`3069`
 
 .. _#2935: https://github.com/pallets/flask/issues/2935
 .. _#2957: https://github.com/pallets/flask/issues/2957

--- a/flask/app.py
+++ b/flask/app.py
@@ -350,6 +350,12 @@ class Flask(_PackageBoundObject):
     #: .. versionadded:: 0.7
     url_rule_class = Rule
 
+    #: The map object to use for storing the URL rules and routing
+    #: configuration parameters. Defaults to :class:`werkzeug.routing.Map`.
+    #:
+    #: .. versionadded:: 1.1.0
+    url_map_class = Map
+
     #: the test client that is used with when `test_client` is used.
     #:
     #: .. versionadded:: 0.7
@@ -567,7 +573,7 @@ class Flask(_PackageBoundObject):
         #:
         #:    app = Flask(__name__)
         #:    app.url_map.converters['list'] = ListConverter
-        self.url_map = Map()
+        self.url_map = self.url_map_class()
 
         self.url_map.host_matching = host_matching
         self.subdomain_matching = subdomain_matching


### PR DESCRIPTION
For speeding up url route matching, I defined a custom rule class and a custom url map class. But  `Flask` currently only allows modifying url rule class, it should support modify url map class too.

```python
    #: The rule object to use for URL rules created.  This is used by
    #: :meth:`add_url_rule`.  Defaults to :class:`werkzeug.routing.Rule`.
    #:
    #: .. versionadded:: 0.7
    url_rule_class = Rule
```