### PR TITLE
fix the typo

### DIFF
--- a/docs/extensiondev.rst
+++ b/docs/extensiondev.rst
@@ -240,7 +240,7 @@ automatically.
 Additionally, the ``init_app`` method is used to support the factory pattern
 for creating apps::
 
-    db = Sqlite3()
+    db = SQLite3()
     # Then later on.
     app = create_app('the-config.cfg')
     db.init_app(app)


### PR DESCRIPTION
Fix the typo `Sqlite3` to  `SQLite3`.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
