### PR TITLE
Add link to Render deployment

### DIFF
--- a/docs/deploying/index.rst
+++ b/docs/deploying/index.rst
@@ -24,6 +24,7 @@ Hosted options
 - `Sharing your Localhost Server with Localtunnel <http://flask.pocoo.org/snippets/89/>`_
 - `Deploying on Azure (IIS) <https://azure.microsoft.com/documentation/articles/web-sites-python-configure/>`_
 - `Deploying on PythonAnywhere <https://help.pythonanywhere.com/pages/Flask/>`_
+- `Deploying Flask on Render <https://render.com/docs/deploy-flask/>`_
 
 Self-hosted options
 -------------------


### PR DESCRIPTION
Add a link to deployment instructions for [Render](https://render.com). I noticed the Heroku instructions actually link to a Django project. I created a Flask guide [here](https://render.com/docs/deploy-flask/) which is linked in this PR.