### PR TITLE
Updated CLI documentation to mention the issue with underscores and click 7

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -270,6 +270,25 @@ This example adds the command ``create_user`` that takes the argument
 
     $ flask create_user admin
 
+If you are using Click version 7 or higher, commands with underscores (`_`)
+will automatically be converted to dashes (`-`). The command above can be
+executed like this:
+
+::
+
+    $ flask create-user admin
+
+If you want to use underscores and Click 7, you need to explicitly specify
+the command name.
+
+::
+
+    @app.cli.command('create_user')
+    @click.argument('name')
+    def create_user(name):
+        ...
+
+
 This example adds the same command, but as ``user create``, a command in a
 group. This is useful if you want to organize multiple related commands. ::
 


### PR DESCRIPTION
When you use Flask in combination with Click 7.x, command containing underscores are no longer found, but instead exposed using dashes, so the example in the docs `create_user` only works as `create-user`.

I've extended the docs to mention this, including an example and a workaround.

The issue is mentioned here as well:
https://github.com/pallets/flask/issues/2931
https://github.com/pallets/click/issues/1123

This is the commit in Click that changes the behaviour:
https://github.com/pallets/click/commit/5d1df0e042b2f8b0dee8f6dd9ce74edce331a950
