### PR TITLE
_compat.py: Use feature detection instead of version detection

### DIFF
--- a/flask/_compat.py
+++ b/flask/_compat.py
@@ -16,12 +16,16 @@ import sys
 PY2 = sys.version_info[0] == 2
 _identity = lambda x: x
 
-
-if not PY2:
+try:  # Python 2
+    text_type = unicode
+    string_types = (str, unicode)
+    integer_types = (int, long)
+except NameError:  # Python 3
     text_type = str
     string_types = (str,)
     integer_types = (int,)
 
+if not PY2:
     iterkeys = lambda d: iter(d.keys())
     itervalues = lambda d: iter(d.values())
     iteritems = lambda d: iter(d.items())
@@ -38,10 +42,6 @@ if not PY2:
     implements_to_string = _identity
 
 else:
-    text_type = unicode
-    string_types = (str, unicode)
-    integer_types = (int, long)
-
     iterkeys = lambda d: d.iterkeys()
     itervalues = lambda d: d.itervalues()
     iteritems = lambda d: d.iteritems()


### PR DESCRIPTION
Describe what this patch does to fix the issue.

When run on Python 3, linters such as Pylint and Flake8 will correctly flag __unicode__ and __long__ as _undefined names_ because _compat.py does not currently follow the Python porting best practice [___use feature detection instead of version detection___](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).  This PR allows this codebase to pass those Pylint and Flake8 tests without adding any linter directives.

flake8 testing of https://github.com/pallets/flask on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./flask/_compat.py:41:17: F821 undefined name 'unicode'
    text_type = unicode
                ^
./flask/_compat.py:42:26: F821 undefined name 'unicode'
    string_types = (str, unicode)
                         ^
./flask/_compat.py:43:27: F821 undefined name 'long'
    integer_types = (int, long)
                          ^
3     F821 undefined name 'unicode'
3
```

Link to any relevant issues or pull requests.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
