### PR TITLE
helpers.py: Fix docs of url_for(..., _external=True)

### DIFF
--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -276,7 +276,7 @@ def url_for(endpoint, **values):
     :param values: the variable arguments of the URL rule
     :param _external: if set to ``True``, an absolute URL is generated. Server
       address can be changed via ``SERVER_NAME`` configuration variable which
-      defaults to `localhost`.
+      falls back to the `Host` header, then to the IP and port of the request.
     :param _scheme: a string specifying the desired URL scheme. The `_external`
       parameter must be set to ``True`` or a :exc:`ValueError` is raised. The default
       behavior uses the same scheme as the current request, or


### PR DESCRIPTION
```
ryan@Ryans-Mac-mini ~ 11:59:51 % cat test.py
import flask

app = flask.Flask(__name__)


@app.route("/")
def index():
    return flask.url_for("index", _external=True)


app.run()
ryan@Ryans-Mac-mini ~ 11:59:57 % curl 127.0.0.1:5000
http://127.0.0.1:5000/
ryan@Ryans-Mac-mini ~ 12:00:05 % curl localhost:5000
http://localhost:5000/
ryan@Ryans-Mac-mini ~ 12:00:08 % nc localhost 5000
GET / HTTP/1.1
Host: testsite.com

HTTP/1.0 200 OK
Content-Type: text/html; charset=utf-8
Content-Length: 20
Server: Werkzeug/0.14.1 Python/3.7.1
Date: Tue, 12 Feb 2019 18:00:18 GMT

http://testsite.com/
ryan@Ryans-Mac-mini ~ 12:00:18 % nc localhost 5000
GET / HTTP/1.0

HTTP/1.0 200 OK
Content-Type: text/html; charset=utf-8
Content-Length: 22
Server: Werkzeug/0.14.1 Python/3.7.1
Date: Tue, 12 Feb 2019 18:00:24 GMT

http://127.0.0.1:5000/
ryan@Ryans-Mac-mini ~ 12:00:24 %
```

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
