### PR TITLE
Little improve on installation doc

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -166,7 +166,9 @@ On Linux, virtualenv is provided by your package manager:
     # Arch
     $ sudo pacman -S python-virtualenv
 
-If you are on Mac OS X or Windows, download `get-pip.py`_, then:
+If you are on Mac OS X or Windows, download `get-pip.py`_.
+
+Then, on Mac OS X:
 
 .. code-block:: sh
 


### PR DESCRIPTION
While reading installation section:

```
If you are on Mac OS X or Windows, download `get-pip.py`_, then:
    $ sudo python2 Downloads/get-pip.py
    ....
```
seems that if you are in Mac or Windows you must run ```sudo python2 ... ```

So in this PR i write for Mac run that... Then for Windows run this other command (original)
