### PR TITLE
moving match_request to RequestContext.push to enable ModelConverter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,10 @@ Unreleased
 -   The ``flask run`` command no longer fails if Python is not built
     with SSL support. Using the ``--cert`` option will show an
     appropriate error message. :issue:`3211`
+-   URL matching now occurs after the request context is pushed, rather
+    than when it's created. This allows custom URL converters to access
+    the app and request contexts, such as to query a database for an id.
+    :issue:`3088`
 
 .. _#2935: https://github.com/pallets/flask/issues/2935
 .. _#2957: https://github.com/pallets/flask/issues/2957

--- a/src/flask/ctx.py
+++ b/src/flask/ctx.py
@@ -347,8 +347,8 @@ class RequestContext(object):
         of the request.
         """
         try:
-            url_rule, self.request.view_args = self.url_adapter.match(return_rule=True)
-            self.request.url_rule = url_rule
+            result = self.url_adapter.match(return_rule=True)
+            self.request.url_rule, self.request.view_args = result
         except HTTPException as e:
             self.request.routing_exception = e
 
@@ -381,9 +381,6 @@ class RequestContext(object):
 
         _request_ctx_stack.push(self)
 
-        if self.url_adapter is not None:
-            self.match_request()
-
         # Open the session at the moment that the request context is available.
         # This allows a custom open_session method to use the request context.
         # Only open a new session if this is the first time the request was
@@ -394,6 +391,9 @@ class RequestContext(object):
 
             if self.session is None:
                 self.session = session_interface.make_null_session(self.app)
+
+        if self.url_adapter is not None:
+            self.match_request()
 
     def pop(self, exc=_sentinel):
         """Pops the request context and unbinds it by doing that.  This will

--- a/src/flask/ctx.py
+++ b/src/flask/ctx.py
@@ -314,9 +314,6 @@ class RequestContext(object):
         # functions.
         self._after_request_functions = []
 
-        if self.url_adapter is not None:
-            self.match_request()
-
     @property
     def g(self):
         return _app_ctx_stack.top.g
@@ -383,6 +380,9 @@ class RequestContext(object):
             sys.exc_clear()
 
         _request_ctx_stack.push(self)
+
+        if self.url_adapter is not None:
+            self.match_request()
 
         # Open the session at the moment that the request context is available.
         # This allows a custom open_session method to use the request context.

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1384,26 +1384,6 @@ def test_url_for_passes_special_values_to_build_error_handler(app):
         flask.url_for("/")
 
 
-def test_custom_converters(app, client):
-    from werkzeug.routing import BaseConverter
-
-    class ListConverter(BaseConverter):
-        def to_python(self, value):
-            return value.split(",")
-
-        def to_url(self, value):
-            base_to_url = super(ListConverter, self).to_url
-            return ",".join(base_to_url(x) for x in value)
-
-    app.url_map.converters["list"] = ListConverter
-
-    @app.route("/<list:args>")
-    def index(args):
-        return "|".join(args)
-
-    assert client.get("/1,2,3").data == b"1|2|3"
-
-
 def test_static_files(app, client):
     rv = client.get("/static/index.html")
     assert rv.status_code == 200

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,0 +1,38 @@
+from flask.globals import _app_ctx_stack
+
+
+def test_custom_converters(app, client):
+    from werkzeug.routing import BaseConverter
+
+    class ListConverter(BaseConverter):
+        def to_python(self, value):
+            return value.split(",")
+
+        def to_url(self, value):
+            base_to_url = super(ListConverter, self).to_url
+            return ",".join(base_to_url(x) for x in value)
+
+    app.url_map.converters["list"] = ListConverter
+
+    @app.route("/<list:args>")
+    def index(args):
+        return "|".join(args)
+
+    assert client.get("/1,2,3").data == b"1|2|3"
+
+
+def test_model_converters(app, client):
+    from werkzeug.routing import BaseConverter
+
+    class ModelConverterTester(BaseConverter):
+        def to_python(self, value):
+            assert _app_ctx_stack.top is not None
+            return value
+
+    app.url_map.converters["model"] = ModelConverterTester
+
+    @app.route("/<model:user_name>")
+    def index(user_name):
+        return user_name, 200
+
+    client.get("/admin").data

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -154,6 +154,9 @@ def test_blueprint_with_subdomain():
     ctx = app.test_request_context("/", subdomain="xxx")
     assert ctx.request.url == "http://xxx.example.com:1234/foo/"
 
+    with ctx:
+        assert ctx.request.blueprint == bp.name
+
     rv = client.get("/", subdomain="xxx")
     assert rv.data == b"http://xxx.example.com:1234/foo/"
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -153,7 +153,6 @@ def test_blueprint_with_subdomain():
 
     ctx = app.test_request_context("/", subdomain="xxx")
     assert ctx.request.url == "http://xxx.example.com:1234/foo/"
-    assert ctx.request.blueprint == bp.name
 
     rv = client.get("/", subdomain="xxx")
     assert rv.data == b"http://xxx.example.com:1234/foo/"


### PR DESCRIPTION
`match_request` will be called in `RequestContext.push` after `current_app`, `request`, and `session` are already populated.

closes #3088 