### PR TITLE
doc: Improve description for valid view func return value

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -683,10 +683,10 @@ converting return values into response objects is as follows:
     returned from the view.
 2.  If it's a string, a response object is created with that data and the
     default parameters.
-3.  If a tuple is returned the items in the tuple can provide extra
-    information.  Such tuples have to be in the form ``(response, status,
-    headers)`` or ``(response, headers)`` where at least one item has
-    to be in the tuple.  The ``status`` value will override the status code
+3.  If a tuple is returned the items in the tuple can provide extra information.
+    Such tuples have to be in the form ``(response, status, headers)``,
+    ``(response, headers)`` or ``(response, status)`` where at least one item
+    has to be in the tuple. The ``status`` value will override the status code
     and ``headers`` can be a list or dictionary of additional header values.
 4.  If none of that works, Flask will assume the return value is a
     valid WSGI application and convert that into a response object.


### PR DESCRIPTION
* improve wording.
* remove unnecessary spaces.

Alternate fix of #3112 