### PR TITLE
Fix code snippet in config.rst for env vars Fixes #3117

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -437,6 +437,7 @@ methods on the config object as well to load from individual files.  For a
 complete reference, read the :class:`~flask.Config` object's
 documentation.
 
+
 Configuring from Environment Variables
 --------------------------------------
 
@@ -448,15 +449,13 @@ Environment variables can be set on Linux or OS X with the export command in
 the shell before starting the server::
 
     $ export SECRET_KEY='5f352379324c22463451387a0aec5d2f'
-    $ export DEBUG=False
+    $ export MAIL_ENABLED=false
     $ python run-app.py
      * Running on http://127.0.0.1:5000/
-     * Restarting with reloader...
 
-On Windows systems use the `set` builtin instead::
+On Windows systems use the ``set`` builtin instead::
 
     >set SECRET_KEY='5f352379324c22463451387a0aec5d2f'
-    >set DEBUG=False
 
 While this approach is straightforward to use, it is important to remember that
 environment variables are strings -- they are not automatically deserialized
@@ -464,17 +463,15 @@ into Python types.
 
 Here is an example of a configuration file that uses environment variables::
 
-    # Example configuration
     import os
 
-    ENVIRONMENT_DEBUG = os.environ.get("DEBUG", default=False)
-    if ENVIRONMENT_DEBUG.lower() in ("f", "false"):
-        ENVIRONMENT_DEBUG = False
+    _mail_enabled = os.environ.get("MAIL_ENABLED", default="true")
+    MAIL_ENABLED = _mail_enabled.lower() in {"1", "t", "true"}
 
-    DEBUG = ENVIRONMENT_DEBUG
-    SECRET_KEY = os.environ.get("SECRET_KEY", default=None)
+    SECRET_KEY = os.environ.get("SECRET_KEY")
+
     if not SECRET_KEY:
-        raise ValueError("No secret key set for Flask application")
+        raise ValueError("No SECRET_KEY set for Flask application")
 
 
 Notice that any value besides an empty string will be interpreted as a boolean
@@ -485,6 +482,7 @@ Make sure to load the configuration very early on, so that extensions have the
 ability to access the configuration when starting up.  There are other methods
 on the config object as well to load from individual files.  For a complete
 reference, read the :class:`~flask.Config` class documentation.
+
 
 Configuration Best Practices
 ----------------------------


### PR DESCRIPTION
Changes the snippet in the config documentation to no longer assign a bool as the default value from os.environ.get()