### PR TITLE
fix 'static_url_path' defaulting for empty paths

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,8 @@ Unreleased
     dependency to >= 0.15. :issue:`3022`
 -   Support ``static_url_path`` that ends with a forward slash.
     :issue:`3134`
+-   Support empty ``static_folder`` without requiring setting an empty
+    ``static_url_path`` as well. :pr:`3124`
 -   :meth:`jsonify` supports :class:`dataclasses.dataclass` objects.
     :pr:`3195`
 -   Allow customizing the :attr:`Flask.url_map_class` used for routing.

--- a/flask/app.py
+++ b/flask/app.py
@@ -408,11 +408,8 @@ class Flask(_PackageBoundObject):
             self, import_name, template_folder=template_folder, root_path=root_path
         )
 
-        if static_url_path is not None:
-            self.static_url_path = static_url_path
-
-        if static_folder is not None:
-            self.static_folder = static_folder
+        self.static_url_path = static_url_path
+        self.static_folder = static_folder
 
         if instance_path is None:
             instance_path = self.auto_find_instance_path()
@@ -594,7 +591,7 @@ class Flask(_PackageBoundObject):
                 bool(static_host) == host_matching
             ), "Invalid static_host/host_matching combination"
             self.add_url_rule(
-                self.static_url_path.rstrip("/") + "/<path:filename>",
+                self.static_url_path + "/<path:filename>",
                 endpoint="static",
                 host=static_host,
                 view_func=self.send_static_file,

--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -208,7 +208,7 @@ class Blueprint(_PackageBoundObject):
 
         if self.has_static_folder:
             state.add_url_rule(
-                self.static_url_path.rstrip("/") + "/<path:filename>",
+                self.static_url_path + "/<path:filename>",
                 view_func=self.send_static_file,
                 endpoint="static",
             )

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -965,23 +965,26 @@ class _PackageBoundObject(object):
     )
     del _get_static_folder, _set_static_folder
 
-    def _get_static_url_path(self):
+    @property
+    def static_url_path(self):
+        """The URL prefix that the static route will be accessible from.
+
+        If it was not configured during init, it is derived from
+        :attr:`static_folder`.
+        """
         if self._static_url_path is not None:
             return self._static_url_path
 
         if self.static_folder is not None:
             basename = os.path.basename(self.static_folder)
-            return "/" + basename if basename else ""
+            return ("/" + basename).rstrip("/")
 
-    def _set_static_url_path(self, value):
+    @static_url_path.setter
+    def static_url_path(self, value):
+        if value is not None:
+            value = value.rstrip("/")
+
         self._static_url_path = value
-
-    static_url_path = property(
-        _get_static_url_path,
-        _set_static_url_path,
-        doc="The URL prefix that the static route will be registered for.",
-    )
-    del _get_static_url_path, _set_static_url_path
 
     @property
     def has_static_folder(self):

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -970,7 +970,8 @@ class _PackageBoundObject(object):
             return self._static_url_path
 
         if self.static_folder is not None:
-            return "/" + os.path.basename(self.static_folder)
+            basename = os.path.basename(self.static_folder)
+            return "/" + basename if basename else ""
 
     def _set_static_url_path(self, value):
         self._static_url_path = value

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1427,6 +1427,20 @@ def test_static_url_path_with_ending_slash():
         assert flask.url_for("static", filename="index.html") == "/foo/index.html"
 
 
+def test_static_url_null_path(app):
+    app = flask.Flask(__name__, static_folder='', static_url_path='')
+    rv = app.test_client().open('/static/index.html', method='GET')
+    assert rv.status_code == 200
+    rv.close()
+
+
+def test_static_url_null_path_defaulting(app):
+    app = flask.Flask(__name__, static_folder='')
+    rv = app.test_client().open('/static/index.html', method='GET')
+    assert rv.status_code == 200
+    rv.close()
+
+
 def test_static_route_with_host_matching():
     app = flask.Flask(__name__, host_matching=True, static_host="example.com")
     c = app.test_client()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1427,14 +1427,14 @@ def test_static_url_path_with_ending_slash():
         assert flask.url_for("static", filename="index.html") == "/foo/index.html"
 
 
-def test_static_url_null_path(app):
+def test_static_url_empty_path(app):
     app = flask.Flask(__name__, static_folder='', static_url_path='')
     rv = app.test_client().open('/static/index.html', method='GET')
     assert rv.status_code == 200
     rv.close()
 
 
-def test_static_url_null_path_defaulting(app):
+def test_static_url_empty_path_default(app):
     app = flask.Flask(__name__, static_folder='')
     rv = app.test_client().open('/static/index.html', method='GET')
     assert rv.status_code == 200


### PR DESCRIPTION
the documentation of the application object specifies static parameters:

static_url_path – can be used to specify a different path for the static
files on the web. **Defaults to the name of the static_folder folder.**

static_folder – the folder with static files that should be served at
static_url_path. Defaults to the 'static' folder in the root path of the
application.

so by my understanding,

`app=Flask(__name__, static_folder='')`

should allow for arbitrary (absolute) path structure for all static
files. it doesn't. but the following does:

`app=Flask(__name__, static_folder='', static_url_path='')`

given the above doc strings, that appears inconsistent

for this specific case (`static_folder=''`), stepping through the
codebase yielded:

<Rule '//<filename>' (GET, OPTIONS, HEAD) -> static> 
`re.compile('^\\|//(?P<filename>[^/].*?)$')`

which is an expression that can never be satisfied by a valid url

please consider this trivial patch. i hope the tests are appropriate
too, it was difficult to know how much of the mechanism to incorporate
for such a small change

commit message:

-prefix a path delimiter iff there's a path to delimit
-ensures a valid default static route rule is created on application
intialisation for the case 'static_folder=""' and implicit
'static_url_path'

todo
* add a changelog entry if this patch changes code