### PR TITLE
use redirect for uwsgi

### DIFF
--- a/docs/deploying/uwsgi.rst
+++ b/docs/deploying/uwsgi.rst
@@ -50,7 +50,9 @@ Configuring nginx
 
 A basic flask nginx configuration looks like this::
 
-    location = /yourapplication { rewrite ^ /yourapplication/; }
+    location = /yourapplication {
+      return 301 $scheme://$host$uri/$is_args$args;
+    }
     location /yourapplication { try_files $uri @yourapplication; }
     location @yourapplication {
       include uwsgi_params;


### PR DESCRIPTION
If a uWSGI app handles query at the root path `/?query=xxx` then is mounted at the `https://host/app` by `uwsgi` and `nginx`, any query `https://host/app?query=xxx` would generate an HTTP error but `https://host/app/?query=xxx` will be successful.

This fix just redirects `https://host/app?query=xxx` to `https://host/app/?query=xxx`.