### PR TITLE
[Doc] Fix typo in code example for route defaults

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -726,7 +726,7 @@ requests, make sure the default route only handles ``GET``, as redirects
 can't preserve form data. ::
 
    @app.route('/region/', defaults={'id': 1})
-   @app.route('/region/<id>', methods=['GET', 'POST'])
+   @app.route('/region/<int:id>', methods=['GET', 'POST'])
    def region(id):
       pass
 


### PR DESCRIPTION
Adding the missing `int` URL converter for URL variable, since the related route defaults value is integer type. Without it, the default redirect behavior described above will not be triggered.