### PR TITLE
More explicit explanation: session testing

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -354,14 +354,15 @@ This however does not make it possible to also modify the session or to
 access the session before a request was fired.  Starting with Flask 0.8 we
 provide a so called “session transaction” which simulates the appropriate
 calls to open a session in the context of the test client and to modify
-it.  At the end of the transaction the session is stored.  This works
-independently of the session backend used::
+it. At the end of the transaction the session is stored and ready to be
+used by the test client. This works independently of the session backend used::
 
     with app.test_client() as c:
         with c.session_transaction() as sess:
             sess['a_key'] = 'a value'
 
-        # once this is reached the session was stored
+        # once this is reached the session was stored and ready to be used by the client
+        c.get(...)
 
 Note that in this case you have to use the ``sess`` object instead of the
 :data:`flask.session` proxy.  The object however itself will provide the


### PR DESCRIPTION
Use a more explicit explanation on how to write code to test own code
when sessions are needed.
The previous code was not fully explicit that the client is supposed
to be called after the session transaction and not during.
That caused https://stackoverflow.com/questions/55500672/flask-testing-endpoint-with-session-data-the-call-has-no-session and what it duplicates.

This patch makes the documentation on this part more explicit and more idiot-proof.

**Note:** Due to 
```
Exception occurred:
  File "conf.py", line 3, in <module>
    from pallets_sphinx_themes import get_version
ImportError: No module named 'pallets_sphinx_themes'
```
I can't test the documentation locally