### PR TITLE
update Jinja2 requirement to >=2.10.1 (re CVE-2019-10906)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     install_requires=[
         'Werkzeug>=0.14',
-        'Jinja2>=2.10',
+        'Jinja2>=2.10.1',
         'itsdangerous>=0.24',
         'click>=5.1',
     ],


### PR DESCRIPTION
Ensure that Jinja2 version isn't vulnerable to the str.format_map vulnerability

Link to any relevant issues or pull requests.
https://nvd.nist.gov/vuln/detail/CVE-2019-10906


