### PR TITLE
Update documentation on gunicorn deployment and app discovery

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -68,9 +68,9 @@ parts:
     The ``create_app`` factory in ``hello`` is called with the string ``'dev'``
     as the argument.
 
-If ``FLASK_APP`` is not set, the command will look for a file called
-:file:`wsgi.py` or :file:`app.py` and try to detect an application instance or
-factory.
+If ``FLASK_APP`` is not set, the command will try to import "app" or
+"wsgi" (as a ".py" file, or package) and try to detect an application
+instance or factory.
 
 Within the given import, the command looks for an application instance named
 ``app`` or ``application``, then any application instance. If no instance is

--- a/docs/deploying/wsgi-standalone.rst
+++ b/docs/deploying/wsgi-standalone.rst
@@ -23,9 +23,15 @@ For example, to run a Flask application with 4 worker processes (``-w
 
     gunicorn -w 4 -b 127.0.0.1:4000 myproject:app
 
-.. _Gunicorn: http://gunicorn.org/
-.. _eventlet: http://eventlet.net/
-.. _greenlet: https://greenlet.readthedocs.io/en/latest/
+The ``gunicorn`` command expects the names of your application module or
+package and the application instance within the module. If you use the
+application factory pattern, you can pass a call to that::
+
+    $ gunicorn "myproject:create_app()"
+
+.. _Gunicorn: https://gunicorn.org/
+.. _eventlet: https://eventlet.net/
+
 
 uWSGI
 --------


### PR DESCRIPTION
- Added that an empty `FLASK_APP` environment variable will also look for an `app` package in addition to the two files.
- Added instructions for running Gunicorn with an app factory that lacks an explicit application instance but has a function that returns one.

Regarding the Gunicorn update, perhaps the other application servers should have a similar update? It looks like uWSGI takes the same type of arguments as Gunicorn. Perhaps others more familiar with those apps can offer how to handle the same type of application I've updated the Gunicorn documentation for?