### PR TITLE
removed unused reference to url_join

### DIFF
--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -10,7 +10,6 @@
     :license: BSD, see LICENSE for more details.
 """
 from functools import update_wrapper
-from werkzeug.urls import url_join
 
 from .helpers import _PackageBoundObject, _endpoint_from_view_func
 


### PR DESCRIPTION
Describe what this patch does to fix the issue.
- removes seemingly unused import of url_join

Link to any relevant issues or pull requests.
#3165 

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
