### PR TITLE
Fix dev-server warning message readability (#3168)

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -644,8 +644,8 @@ def show_server_banner(env, debug, app_import_path, eager_loading):
 
     if env == 'production':
         click.secho(
-            '   WARNING: Do not use the development server in a production'
-            ' environment.', fg='red')
+            '   WARNING: This is a development server. '
+            'Do not use it in a production deployment.', fg='red')
         click.secho('   Use a production WSGI server instead.', dim=True)
 
     if debug is not None:


### PR DESCRIPTION
fixes #3168 

New, more explicit warning message on `app.run(debug=True)`:
![image](https://user-images.githubusercontent.com/13977519/57159683-cfef8f80-6de6-11e9-89c1-8884fab7f2e0.png)


<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->


