### PR TITLE
Add link to official Discord chat server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,7 @@ Links
   * Windows: https://ci.appveyor.com/project/pallets/flask
 
 * Test coverage: https://codecov.io/gh/pallets/flask
+* Official chat: https://discord.gg/t6rrQZH
 
 .. _WSGI: https://wsgi.readthedocs.io
 .. _Werkzeug: https://www.palletsprojects.com/p/werkzeug/


### PR DESCRIPTION
All Pallets projects should have a link to the official chat server on Discord.