### PR TITLE
Remove ending slash from static_url_path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,8 @@ Unreleased
 -   The ``flask`` command entry point is simplified to take advantage
     of Werkzeug 0.15's better reloader support. This bumps the Werkzeug
     dependency to >= 0.15. :issue:`3022`
+-   Support ``static_url_path`` that ends with a forward slash.
+    :issue:`3134`
 
 .. _#2935: https://github.com/pallets/flask/issues/2935
 .. _#2957: https://github.com/pallets/flask/issues/2957

--- a/flask/app.py
+++ b/flask/app.py
@@ -587,7 +587,7 @@ class Flask(_PackageBoundObject):
                 bool(static_host) == host_matching
             ), "Invalid static_host/host_matching combination"
             self.add_url_rule(
-                self.static_url_path + "/<path:filename>",
+                self.static_url_path.rstrip("/") + "/<path:filename>",
                 endpoint="static",
                 host=static_host,
                 view_func=self.send_static_file,

--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -198,7 +198,7 @@ class Blueprint(_PackageBoundObject):
 
         if self.has_static_folder:
             state.add_url_rule(
-                self.static_url_path + "/<path:filename>",
+                self.static_url_path.rstrip("/") + "/<path:filename>",
                 view_func=self.send_static_file,
                 endpoint="static",
             )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1399,6 +1399,17 @@ def test_static_url_path():
         assert flask.url_for("static", filename="index.html") == "/foo/index.html"
 
 
+def test_static_url_path_with_ending_slash():
+    app = flask.Flask(__name__, static_url_path="/foo/")
+    app.testing = True
+    rv = app.test_client().get("/foo/index.html")
+    assert rv.status_code == 200
+    rv.close()
+
+    with app.test_request_context():
+        assert flask.url_for("static", filename="index.html") == "/foo/index.html"
+
+
 def test_static_route_with_host_matching():
     app = flask.Flask(__name__, host_matching=True, static_host="example.com")
     c = app.test_client()


### PR DESCRIPTION
Describe what this patch does to fix the issue.

Fixes #3134 where flask fails if `static_url_path` ends with a slash, e.g. `/foo/`

Because the `/<path:filename>` param already starts with a slash, it is imperative the the `static_url_path` prefix does NOT end with a forward slash.