### PR TITLE
Simplify flask.cli.main

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ Unreleased
     moved into Werkzeug. Use Werkzeug's version with Flask-specific
     support. This bumps the Werkzeug dependency to >= 0.15.
     :issue:`3125`
+-   The ``flask`` command entry point is simplified to take advantage
+    of Werkzeug 0.15's better reloader support. This bumps the Werkzeug
+    dependency to >= 0.15. :issue:`3022`
 
 .. _#2935: https://github.com/pallets/flask/issues/2935
 .. _#2957: https://github.com/pallets/flask/issues/2957

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -907,23 +907,7 @@ debug mode.
 
 
 def main(as_module=False):
-    args = sys.argv[1:]
-
-    if as_module:
-        this_module = "flask"
-
-        if sys.version_info < (2, 7):
-            this_module += ".cli"
-
-        name = "python -m " + this_module
-
-        # Python rewrites "python -m flask" to the path to the file in argv.
-        # Restore the original command so that the reloader works.
-        sys.argv = ["-m", this_module] + args
-    else:
-        name = None
-
-    cli.main(args=args, prog_name=name)
+    cli.main(prog_name="python -m flask" if as_module else None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Werkzeug>=0.15's reloader now properly detects `python -m module`.

Fixes #3022

The PR https://github.com/pallets/flask/pull/3181 is the one updating Werkzeug to >=0.15, so it should be merged first.