### PR TITLE
Support dataclass in JSONEncoder (if available)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,8 @@ Unreleased
     dependency to >= 0.15. :issue:`3022`
 -   Support ``static_url_path`` that ends with a forward slash.
     :issue:`3134`
+-   :meth:`jsonify` supports :class:`dataclasses.dataclass` objects.
+    :pr:`3195`
 
 .. _#2935: https://github.com/pallets/flask/issues/2935
 .. _#2957: https://github.com/pallets/flask/issues/2957

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -10,6 +10,7 @@
 """
 
 import re
+import sys
 import time
 import uuid
 from datetime import datetime
@@ -1288,6 +1289,14 @@ def test_jsonify_mimetype(app, req_ctx):
     rv = flask.make_response(flask.jsonify(msg), 200)
     assert rv.mimetype == "application/vnd.api+json"
 
+
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python >= 3.7")
+def test_json_dump_dataclass(app, req_ctx):
+    from dataclasses import make_dataclass
+    Data = make_dataclass("Data", [("name", str)])
+    value = flask.json.dumps(Data("Flask"), app=app)
+    value = flask.json.loads(value, app=app)
+    assert value == {"name": "Flask"}
 
 def test_jsonify_args_and_kwargs_check(app, req_ctx):
     with pytest.raises(TypeError) as e:


### PR DESCRIPTION
Support dataclass to be encoded with jsonify using `dataclasses.as_dict()`.

