### PR TITLE
Adding closing list tags in code example within the Docs - 'templates.rst' file

### DIFF
--- a/docs/tutorial/templates.rst
+++ b/docs/tutorial/templates.rst
@@ -53,11 +53,11 @@ specific sections.
       <h1>Flaskr</h1>
       <ul>
         {% if g.user %}
-          <li><span>{{ g.user['username'] }}</span>
-          <li><a href="{{ url_for('auth.logout') }}">Log Out</a>
+          <li><span>{{ g.user['username'] }}</span></li>
+          <li><a href="{{ url_for('auth.logout') }}">Log Out</a></li>
         {% else %}
-          <li><a href="{{ url_for('auth.register') }}">Register</a>
-          <li><a href="{{ url_for('auth.login') }}">Log In</a>
+          <li><a href="{{ url_for('auth.register') }}">Register</a></li>
+          <li><a href="{{ url_for('auth.login') }}">Log In</a></li>
         {% endif %}
       </ul>
     </nav>


### PR DESCRIPTION
Closing list tags were missing in 'templates.rst' within the codeblock example on lines 56, 57, 59 and 60.

I noticed while working through the tutorial that the closing tags for the list elements were missing - and this is my first pull request ever! (Hopefully it is correct... and I've actually done it right!)

Describe what this patch does to fix the issue.

Link to any relevant issues or pull requests.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
