### PR TITLE
Remove unused url_join of blueprints.py - 1.0 maintenance

### DIFF
--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -10,7 +10,6 @@
     :license: BSD, see LICENSE for more details.
 """
 from functools import update_wrapper
-from werkzeug.urls import url_join
 
 from .helpers import _PackageBoundObject, _endpoint_from_view_func
 


### PR DESCRIPTION
Remove unused reference in blueprints.py of URL_JOIN

From issue:
https://github.com/pallets/flask/issues/3165