### PR TITLE
don't push app context for test client json

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,10 +23,13 @@ Unreleased
     handle ``RoutingExcpetion``, which is used internally during
     routing. This fixes the unexpected behavior that had been introduced
     in 1.0. (`#2986`_)
+-   Passing the ``json`` argument to ``app.test_client`` does not
+    push/pop an extra app context. (`#2900`_)
 
 .. _#2766: https://github.com/pallets/flask/issues/2766
 .. _#2765: https://github.com/pallets/flask/pull/2765
 .. _#2825: https://github.com/pallets/flask/pull/2825
+.. _#2900: https://github.com/pallets/flask/issues/2900
 .. _#2933: https://github.com/pallets/flask/issues/2933
 .. _#2986: https://github.com/pallets/flask/pull/2986
 

--- a/flask/testing.py
+++ b/flask/testing.py
@@ -73,14 +73,10 @@ def make_test_environ_builder(
             sep = b'?' if isinstance(url.query, bytes) else '?'
             path += sep + url.query
 
+    # TODO use EnvironBuilder.json_dumps once we require Werkzeug 0.15
     if 'json' in kwargs:
-        assert 'data' not in kwargs, (
-            "Client cannot provide both 'json' and 'data'."
-        )
-
-        # push a context so flask.json can use app's json attributes
-        with app.app_context():
-            kwargs['data'] = json_dumps(kwargs.pop('json'))
+        assert 'data' not in kwargs, "Client cannot provide both 'json' and 'data'."
+        kwargs['data'] = json_dumps(kwargs.pop('json'), app=app)
 
         if 'content_type' not in kwargs:
             kwargs['content_type'] = 'application/json'


### PR DESCRIPTION
Allow passing `app` to `json.dumps` (and `json.loads` for symmetry, though it's not required for this), and use it instead of `current_app` when available. `make_test_environ_builder` can pass the app it was passed, rather than pushing an app context in order to configure the JSON encoder.

closes #2900 