### PR TITLE
FakeSignal should stub connect_via method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,8 @@ Unreleased
 -   The return value from :meth:`cli.load_dotenv` is more consistent
     with the documentation. It will return ``False`` if python-dotenv is
     not installed, or if the given path isn't a file. :issue:`2937`
+-   Signaling support has a stub for the ``connect_via`` method when
+    the Blinker library is not installed. :pr:`3208`
 
 .. _#2935: https://github.com/pallets/flask/issues/2935
 .. _#2957: https://github.com/pallets/flask/issues/2957

--- a/flask/signals.py
+++ b/flask/signals.py
@@ -32,19 +32,18 @@ except ImportError:
             self.name = name
             self.__doc__ = doc
 
+        def send(self, *args, **kwargs):
+            pass
+
         def _fail(self, *args, **kwargs):
             raise RuntimeError(
-                "signalling support is unavailable "
-                "because the blinker library is "
-                "not installed."
+                "Signalling support is unavailable because the blinker"
+                " library is not installed."
             )
 
-        send = lambda *a, **kw: None
-        connect = (
-            disconnect
-        ) = (
-            has_receivers_for
-        ) = receivers_for = temporarily_connected_to = connected_to = _fail
+        connect = connect_via = connected_to = temporarily_connected_to = _fail
+        disconnect = _fail
+        has_receivers_for = receivers_for = _fail
         del _fail
 
 


### PR DESCRIPTION
Blinker has a [`connect_via()`](https://pythonhosted.org/blinker/#blinker.base.Signal.connect_via) method. `_FakeSignal` should stub this method, as well as the others.