### PR TITLE
Do not register empty CLI groups from Blueprint

### DIFF
--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -218,6 +218,9 @@ class Blueprint(_PackageBoundObject):
 
         cli_resolved_group = options.get("cli_group", self.cli_group)
 
+        if not self.cli.commands:
+            return
+
         if cli_resolved_group is None:
             app.cli.commands.update(self.cli.commands)
         elif cli_resolved_group is _sentinel:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -652,3 +652,12 @@ def test_cli_blueprints(app):
 
     result = app_runner.invoke(args=["late_registration", "late"])
     assert "late_result" in result.output
+
+
+def test_cli_empty(app):
+    """If a Blueprint's CLI group is empty, do not register it."""
+    bp = Blueprint("blue", __name__, cli_group="blue")
+    app.register_blueprint(bp)
+
+    result = app.test_cli_runner().invoke(args=["blue", "--help"])
+    assert result.exit_code == 2, "Unexpected success:\n\n" + result.output


### PR DESCRIPTION
(Fixes #3224)

Check if the CLI group is empty during Blueprint registration, and exit early if it is.