### PR TITLE
Fix testing documentation to demonstrate using test client with teardown

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -54,12 +54,11 @@ the application for testing and initializes a new database.::
     def client():
         db_fd, flaskr.app.config['DATABASE'] = tempfile.mkstemp()
         flaskr.app.config['TESTING'] = True
-        client = flaskr.app.test_client()
-
-        with flaskr.app.app_context():
-            flaskr.init_db()
-
-        yield client
+        
+        with flaskr.app.test_client() as client:
+            with flaskr.app.app_context():
+                flaskr.init_db()
+            yield client
 
         os.close(db_fd)
         os.unlink(flaskr.app.config['DATABASE'])


### PR DESCRIPTION
Change the example in "Testing Flask Applications" to demonstrate using test client with teardown. (by using with statement)

#2949

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
