### PR TITLE
"#3211: Don't require ssl module"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,9 @@ Unreleased
     supported. :issue:`3214`
 -   ``flask.testing.make_test_environ_builder()`` has been deprecated in
     favour of a new class ``flask.testing.EnvironBuilder``. :pr:`3232`
+-   The ``flask run`` command no longer fails if Python is not built
+    with SSL support. Using the ``--cert`` option will show an
+    appropriate error message. :issue:`3211`
 
 .. _#2935: https://github.com/pallets/flask/issues/2935
 .. _#2957: https://github.com/pallets/flask/issues/2957

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -16,7 +16,6 @@ import inspect
 import os
 import platform
 import re
-import ssl
 import sys
 import traceback
 from functools import update_wrapper
@@ -35,6 +34,11 @@ try:
     import dotenv
 except ImportError:
     dotenv = None
+
+try:
+    import ssl
+except ImportError:
+    ssl = None
 
 
 class NoAppException(click.UsageError):
@@ -684,6 +688,13 @@ class CertParamType(click.ParamType):
         self.path_type = click.Path(exists=True, dir_okay=False, resolve_path=True)
 
     def convert(self, value, param, ctx):
+        if ssl is None:
+            raise click.BadParameter(
+                'Using "--cert" requires Python to be compiled with SSL support.',
+                ctx,
+                param,
+            )
+
         try:
             return self.path_type(value, param, ctx)
         except click.BadParameter:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -611,6 +611,12 @@ def test_run_cert_import(monkeypatch):
         run_command.make_context("run", ["--cert", "ssl_context", "--key", __file__])
 
 
+def test_run_cert_no_ssl(monkeypatch):
+    monkeypatch.setattr("flask.cli.ssl", None)
+    with pytest.raises(click.BadParameter):
+        run_command.make_context("run", ["--cert", "not_here"])
+
+
 def test_cli_blueprints(app):
     """Test blueprint commands register correctly to the application"""
     custom = Blueprint("custom", __name__, cli_group="customized")


### PR DESCRIPTION
This addresses #3211 by guarding the ssl import with an except ImportError, and then raising 
 click.BackParameter() if SSL is not present when --cert is passed to the CLI. 

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
