### PR TITLE
Guard against missing request context in logging docs.

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -117,13 +117,18 @@ your own fields that can be used in messages. You can change the formatter for
 Flask's default handler, the mail handler defined above, or any other
 handler. ::
 
-    from flask import request
+    from flask import has_request_context, request
     from flask.logging import default_handler
 
     class RequestFormatter(logging.Formatter):
         def format(self, record):
-            record.url = request.url
-            record.remote_addr = request.remote_addr
+            if has_request_context():
+                record.url = request.url
+                record.remote_addr = request.remote_addr
+            else:
+                record.url = None
+                record.remote_addr = None
+
             return super().format(record)
 
     formatter = RequestFormatter(


### PR DESCRIPTION
Wrapped request context use with `has_request_context` in logging docs.

Fixes https://github.com/pallets/flask/issues/2838