### PR TITLE
Clarify documentation about how url_for uses configuration values (#2759)

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -276,7 +276,10 @@ The following configuration values are used internally by Flask:
 .. py:data:: APPLICATION_ROOT
 
     Inform the application what path it is mounted under by the application /
-    web server.
+    web server.  This is used for generating URLs outside the context of a
+    request (inside a request, the dispatcher is responsible for setting
+    ``SCRIPT_NAME`` instead; see :ref:`Application Dispatching <app-dispatch>`
+    for examples of dispatch configuration).
 
     Will be used for the session cookie path if ``SESSION_COOKIE_PATH`` is not
     set.

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -230,6 +230,9 @@ def url_for(endpoint, **values):
 
     For more information, head over to the :ref:`Quickstart <url-building>`.
 
+    Configuration values ``APPLICATION_ROOT`` and ``SERVER_NAME`` are only used when 
+    generating URLs outside of a request context.
+
     To integrate applications, :class:`Flask` has a hook to intercept URL build
     errors through :attr:`Flask.url_build_error_handlers`.  The `url_for`
     function results in a :exc:`~werkzeug.routing.BuildError` when the current


### PR DESCRIPTION
This attempts to clarify the documentation as discussed in #2759 and #3219.