### PR TITLE
Added :param to the Blueprint concstructor docstring

### DIFF
--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -87,6 +87,24 @@ class Blueprint(_PackageBoundObject):
     information.
 
     .. versionadded:: 0.7
+
+    :param name: the name of the Blueprint
+    :param import_name: the name of the Blueprint package, __name__ most of the time.
+            The module folder will be the blueprint resource folder by default.
+    :param static_folder: you can serve your Blueprint static files by setting `static_folder`
+            to the folder with static files to serve at `static_url`.
+            The path can be absolute or relative to the Blueprint resource folder
+    :param static_url: the url to serve static files from. Defaults to ``static_folder``.
+            If your app's static_url is the same, your Blueprint's files won't be accessible.
+    :param template_folder: your blueprint can expose template from this folder by adding this path
+            to the search path of templates. The path can be absolute or relative to
+            the Blueprint resource folder.
+    :param url_prefix: url to prefix all the Blueprint routes.
+    :param subdomain: If set up, Blueprint routes will match on this subdomain.
+    :param url_defaults: Blueprint routes will use these default values for
+            view arguments.
+    :param root_path: you can specify a different root_path than the module folder.
+            to become your Blueprint resource folder.
     """
 
     warn_on_modifications = False

--- a/flask/blueprints.py
+++ b/flask/blueprints.py
@@ -80,31 +80,51 @@ class BlueprintSetupState(object):
 
 
 class Blueprint(_PackageBoundObject):
-    """Represents a blueprint.  A blueprint is an object that records
-    functions that will be called with the
-    :class:`~flask.blueprints.BlueprintSetupState` later to register functions
-    or other things on the main application.  See :ref:`blueprints` for more
-    information.
+    """Represents a blueprint, a collection of routes and other
+    app-related functions that can be registered on a real application
+    later.
+
+    A blueprint is an object that allows defining application functions
+    without requiring an application object ahead of time. It uses the
+    same decorators as :class:`~flask.Flask`, but defers the need for an
+    application by recording them for later registration.
+
+    Decorating a function with a blueprint creates a deferred function
+    that is called with :class:`~flask.blueprints.BlueprintSetupState`
+    when the blueprint is registered on an application.
+
+    See :ref:`blueprints` for more information.
 
     .. versionadded:: 0.7
 
-    :param name: the name of the Blueprint
-    :param import_name: the name of the Blueprint package, __name__ most of the time.
-            The module folder will be the blueprint resource folder by default.
-    :param static_folder: you can serve your Blueprint static files by setting `static_folder`
-            to the folder with static files to serve at `static_url`.
-            The path can be absolute or relative to the Blueprint resource folder
-    :param static_url: the url to serve static files from. Defaults to ``static_folder``.
-            If your app's static_url is the same, your Blueprint's files won't be accessible.
-    :param template_folder: your blueprint can expose template from this folder by adding this path
-            to the search path of templates. The path can be absolute or relative to
-            the Blueprint resource folder.
-    :param url_prefix: url to prefix all the Blueprint routes.
-    :param subdomain: If set up, Blueprint routes will match on this subdomain.
-    :param url_defaults: Blueprint routes will use these default values for
-            view arguments.
-    :param root_path: you can specify a different root_path than the module folder.
-            to become your Blueprint resource folder.
+    :param name: The name of the blueprint. Will be prepended to each
+        endpoint name.
+    :param import_name: The name of the blueprint package, usually
+        ``__name__``. This helps locate the ``root_path`` for the
+        blueprint.
+    :param static_folder: A folder with static files that should be
+        served by the blueprint's static route. The path is relative to
+        the blueprint's root path. Blueprint static files are disabled
+        by default.
+    :param static_url_path: The url to serve static files from.
+        Defaults to ``static_folder``. If the blueprint does not have
+        a ``url_prefix``, the app's static route will take precedence,
+        and the blueprint's static files won't be accessible.
+    :param template_folder: A folder with templates that should be added
+        to the app's template search path. The path is relative to the
+        blueprint's root path. Blueprint templates are disabled by
+        default. Blueprint templates have a lower precedence than those
+        in the app's templates folder.
+    :param url_prefix: A path to prepend to all of the blueprint's URLs,
+        to make them distinct from the rest of the app's routes.
+    :param subdomain: A subdomain that blueprint routes will match on by
+        default.
+    :param url_defaults: A dict of default values that blueprint routes
+        will receive by default.
+    :param root_path: By default, the blueprint will automatically this
+        based on ``import_name``. In certain situations this automatic
+        detection can fail, so the path can be specified manually
+        instead.
     """
 
     warn_on_modifications = False


### PR DESCRIPTION
Describe what this patch does to fix the issue.
Added the :params list to the Blueprint documentation
Link to any relevant issues or pull requests.
#3216
<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself  #can save time.
-->
