### PR TITLE
File upload code fixed

### DIFF
--- a/docs/patterns/fileuploads.rst
+++ b/docs/patterns/fileuploads.rst
@@ -64,7 +64,7 @@ the file and redirects the user to the URL for the uploaded file::
                 return redirect(request.url)
             if file and allowed_file(file.filename):
                 filename = secure_filename(file.filename)
-                file.save(os.path.join(app.config['UPLOAD_FOLDER'], filename))
+                file.save(os.path.join(app.config['UPLOAD_FOLDER'], str(filename)))
                 return redirect(url_for('uploaded_file',
                                         filename=filename))
         return '''


### PR DESCRIPTION
Converted filename into string, File upload didn't worked without doing it

The file upload code didn't worked without converting file name to string in the function file.save()
Changed the code so that the code in the documentation will work without any modification.