### PR TITLE
adds api error handling example to documentation

### DIFF
--- a/docs/patterns/errorpages.rst
+++ b/docs/patterns/errorpages.rst
@@ -97,3 +97,30 @@ An example template might be this:
       <p>What you were looking for is just not there.
       <p><a href="{{ url_for('index') }}">go somewhere nice</a>
     {% endblock %}
+
+
+Handling API Errors with Abort
+------------------------------
+
+When using Flask for web APIs, handling errors is as simple as the previous examples but with minor changes.
+
+Register the error handler::
+
+    from flask import jsonify
+
+    @app.errorhandler(404)
+    def resource_not_found(e):
+        # if passing in an Exception object directly, you may need to convert it to a string
+        return jsonify(error=str(e)), 404
+
+To use this error handler::
+
+    @app.route('/cheese', methods=['GET'])
+    def get_one_cheese():
+        # logic to find your resource
+        if (resource is None):
+            abort(404, 'Resource not found')
+        else:
+            return jsonify(resource=resource)
+
+In the above example, the error handler is invoked with the second argument passed to it. It returns the json message with the response.

--- a/docs/patterns/errorpages.rst
+++ b/docs/patterns/errorpages.rst
@@ -99,28 +99,27 @@ An example template might be this:
     {% endblock %}
 
 
-Handling API Errors with Abort
-------------------------------
+Returning API errors as JSON
+----------------------------
 
-When using Flask for web APIs, handling errors is as simple as the previous examples but with minor changes.
+When using Flask for web APIs, you can use the same techniques as above
+to return JSON responses to API errors.  :func:`~flask.abort` is called
+with a ``description`` parameter. The :meth:`~flask.errorhandler` will
+use that as the JSON error message, and set the status code to 404.
 
-Register the error handler::
+.. code-block:: python
 
-    from flask import jsonify
+    from flask import abort, jsonify
 
     @app.errorhandler(404)
     def resource_not_found(e):
-        # if passing in an Exception object directly, you may need to convert it to a string
         return jsonify(error=str(e)), 404
 
-To use this error handler::
-
-    @app.route('/cheese', methods=['GET'])
+    @app.route("/cheese")
     def get_one_cheese():
-        # logic to find your resource
-        if (resource is None):
-            abort(404, 'Resource not found')
-        else:
-            return jsonify(resource=resource)
+        resource = get_resource()
 
-In the above example, the error handler is invoked with the second argument passed to it. It returns the json message with the response.
+        if resource is None:
+            abort(404, description="Resource not found")
+
+        return jsonify(resource)


### PR DESCRIPTION
Describe what this patch does to fix the issue.

This adds documentation to the error handling page. I was having a hard time finding anything on the proper use of abort with the flask error handler. After settling on a good pattern, I added it here.

Link to any relevant issues or pull requests.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
