### PR TITLE
fix tests failing with server name warnings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,10 +196,3 @@ def purge_module(request):
         request.addfinalizer(lambda: sys.modules.pop(name, None))
 
     return inner
-
-
-@pytest.fixture(autouse=True)
-def catch_deprecation_warnings(recwarn):
-    yield
-    gc.collect()
-    assert not recwarn.list, '\n'.join(str(w.message) for w in recwarn.list)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1442,62 +1442,46 @@ def test_request_locals():
     assert not flask.g
 
 
-def test_test_app_proper_environ():
+def test_server_name_subdomain():
     app = flask.Flask(__name__, subdomain_matching=True)
-    app.config.update(
-        SERVER_NAME='localhost.localdomain:5000'
-    )
     client = app.test_client()
 
-    @app.route('/')
+    @app.route("/")
     def index():
-        return 'Foo'
+        return "default"
 
-    @app.route('/', subdomain='foo')
+    @app.route("/", subdomain="foo")
     def subdomain():
-        return 'Foo SubDomain'
+        return "subdomain"
 
-    rv = client.get('/')
-    assert rv.data == b'Foo'
+    app.config["SERVER_NAME"] = "dev.local:5000"
+    rv = client.get("/")
+    assert rv.data == b"default"
 
-    rv = client.get('/', 'http://localhost.localdomain:5000')
-    assert rv.data == b'Foo'
+    rv = client.get("/", "http://dev.local:5000")
+    assert rv.data == b"default"
 
-    rv = client.get('/', 'https://localhost.localdomain:5000')
-    assert rv.data == b'Foo'
+    rv = client.get("/", "https://dev.local:5000")
+    assert rv.data == b"default"
 
-    app.config.update(SERVER_NAME='localhost.localdomain')
-    rv = client.get('/', 'https://localhost.localdomain')
-    assert rv.data == b'Foo'
+    app.config["SERVER_NAME"] = "dev.local:443"
+    rv = client.get("/", "https://dev.local")
 
-    try:
-        app.config.update(SERVER_NAME='localhost.localdomain:443')
-        rv = client.get('/', 'https://localhost.localdomain')
-        # Werkzeug 0.8
+    # Werkzeug 1.0 fixes matching https scheme with 443 port
+    if rv.status_code != 404:
+        assert rv.data == b"default"
+
+    app.config["SERVER_NAME"] = "dev.local"
+    rv = client.get("/", "https://dev.local")
+    assert rv.data == b"default"
+
+    # suppress Werkzeug 1.0 warning about name mismatch
+    with pytest.warns(None):
+        rv = client.get("/", "http://foo.localhost")
         assert rv.status_code == 404
-    except ValueError as e:
-        # Werkzeug 0.7
-        assert str(e) == (
-            "the server name provided "
-            "('localhost.localdomain:443') does not match the "
-            "server name from the WSGI environment ('localhost.localdomain')"
-        )
 
-    try:
-        app.config.update(SERVER_NAME='localhost.localdomain')
-        rv = client.get('/', 'http://foo.localhost')
-        # Werkzeug 0.8
-        assert rv.status_code == 404
-    except ValueError as e:
-        # Werkzeug 0.7
-        assert str(e) == (
-            "the server name provided "
-            "('localhost.localdomain') does not match the "
-            "server name from the WSGI environment ('foo.localhost')"
-        )
-
-    rv = client.get('/', 'http://foo.localhost.localdomain')
-    assert rv.data == b'Foo SubDomain'
+    rv = client.get("/", "http://foo.dev.local")
+    assert rv.data == b"subdomain"
 
 
 def test_exception_propagation(app, client):
@@ -1854,9 +1838,11 @@ def test_subdomain_matching_other_name(matching):
     def index():
         return '', 204
 
-    # ip address can't match name
-    rv = client.get('/', 'http://127.0.0.1:3000/')
-    assert rv.status_code == 404 if matching else 204
+    # suppress Werkzeug 0.15 warning about name mismatch
+    with pytest.warns(None):
+        # ip address can't match name
+        rv = client.get('/', 'http://127.0.0.1:3000/')
+        assert rv.status_code == 404 if matching else 204
 
     # allow all subdomains if matching is disabled
     rv = client.get('/', 'http://www.localhost.localdomain:3000/')

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -443,7 +443,7 @@ class TestSendfile(object):
             assert rv.data == f.read()
         rv.close()
 
-    def test_send_file_xsendfile(self, app, req_ctx, catch_deprecation_warnings):
+    def test_send_file_xsendfile(self, app, req_ctx):
         app.use_x_sendfile = True
         rv = flask.send_file('static/index.html')
         assert rv.direct_passthrough

--- a/tests/test_reqctx.py
+++ b/tests/test_reqctx.py
@@ -88,15 +88,10 @@ def test_proper_test_request_context(app):
         assert flask.url_for('sub', _external=True) == \
                'http://foo.localhost.localdomain:5000/'
 
-    try:
+    # suppress Werkzeug 0.15 warning about name mismatch
+    with pytest.warns(None):
         with app.test_request_context('/', environ_overrides={'HTTP_HOST': 'localhost'}):
             pass
-    except ValueError as e:
-        assert str(e) == (
-            "the server name provided "
-            "('localhost.localdomain:5000') does not match the "
-            "server name from the WSGI environment ('localhost')"
-        )
 
     app.config.update(SERVER_NAME='localhost')
     with app.test_request_context('/', environ_overrides={'SERVER_NAME': 'localhost'}):

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
     pip install -q -e examples/javascript[test]
 
     # pytest-cov doesn't seem to play nice with -p
-    coverage run -p -m pytest --tb=short {posargs:tests examples}
+    coverage run -p -m pytest --tb=short -Werror {posargs:tests examples}
 
 [testenv:nightly]
 # courtesy Python nightly test, don't fail the build in CI
@@ -41,7 +41,7 @@ ignore_outcome = true
 commands =
     pip install -q -e examples/tutorial[test]
     pip install -q -e examples/javascript[test]
-    coverage run -p -m pytest --tb=short --junitxml=test-results.xml {posargs:tests examples}
+    coverage run -p -m pytest --tb=short -Werror --junitxml=test-results.xml {posargs:tests examples}
 
 [testenv:stylecheck]
 deps = pre-commit


### PR DESCRIPTION
After pallets/werkzeug#1577, mismatched configured and real server names will show a warning in addition to raising 404. This caused tests that did this deliberately to fail.

This patch removes the pytest fixture we were using to fail on warnings, instead using the standard `-Werror` option. This speeds up the tests by ~3x.