### PR TITLE
always pass InternalServerError instance to 500 handler

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ Unreleased
     due to an unhandled exception, that original exception is now
     available as ``e.original_exception`` rather than being passed
     directly to the handler. The same is true if the handler is for the
-    base ``HTTPException``.This makes error handler behavior more
+    base ``HTTPException``. This makes error handler behavior more
     consistent. :pr:`3266`
 
     -   :meth:`Flask.finalize_request` is called for all unhandled

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,17 @@ Unreleased
 
 -   Bump minimum Werkzeug version to >= 0.15.
 -   Drop support for Python 3.4.
+-   Error handlers for ``InternalServerError`` or ``500`` will always be
+    passed an instance of ``InternalServerError``. If they are invoked
+    due to an unhandled exception, that original exception is now
+    available as ``e.original_exception`` rather than being passed
+    directly to the handler. The same is true if the handler is for the
+    base ``HTTPException``.This makes error handler behavior more
+    consistent. :pr:`3266`
+
+    -   :meth:`Flask.finalize_request` is called for all unhandled
+        exceptions even if there is no ``500`` error handler.
+
 -   :meth:`flask.RequestContext.copy` includes the current session
     object in the request context copy. This prevents ``session``
     pointing to an out-of-date object. (`#2935`_)

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1811,11 +1811,36 @@ class Flask(_PackageBoundObject):
         return handler(e)
 
     def handle_exception(self, e):
-        """Default exception handling that kicks in when an exception
-        occurs that is not caught.  In debug mode the exception will
-        be re-raised immediately, otherwise it is logged and the handler
-        for a 500 internal server error is used.  If no such handler
-        exists, a default 500 internal server error message is displayed.
+        """Handle an exception that did not have an error handler
+        associated with it, or that was raised from an error handler.
+        This always causes a 500 ``InternalServerError``.
+
+        Always sends the :data:`got_request_exception` signal.
+
+        If :attr:`propagate_exceptions` is ``True``, such as in debug
+        mode, the error will be re-raised so that the debugger can
+        display it. Otherwise, the original exception is logged, and
+        an :exc:`~werkzeug.exceptions.InternalServerError` is returned.
+
+        If an error handler is registered for ``InternalServerError`` or
+        ``500``, it will be used. For consistency, the handler will
+        always receive the ``InternalServerError``. The original
+        unhandled exception is available as ``e.original_exception``.
+
+        .. note::
+            Prior to Werkzeug 1.0.0, ``InternalServerError`` will not
+            always have a ``original_exception`` attribute. Use
+            ``getattr(e, "original_exception", None)`` to simulate the
+            behavior for compatibility.
+
+        .. versionchanged:: 1.1.0
+            Always passes the ``InternalServerError`` instance to the
+            handler, setting ``original_exception`` to the unhandled
+            error.
+
+        .. versionchanged:: 1.1.0
+            ``after_request`` functions and other finalization is done
+            even for the default 500 response when there is no handler.
 
         .. versionadded:: 0.3
         """
@@ -1833,10 +1858,16 @@ class Flask(_PackageBoundObject):
                 raise e
 
         self.log_exception((exc_type, exc_value, tb))
-        handler = self._find_error_handler(InternalServerError())
-        if handler is None:
-            return InternalServerError()
-        return self.finalize_request(handler(e), from_error_handler=True)
+        server_error = InternalServerError()
+        # TODO: pass as param when Werkzeug>=1.0.0 is required
+        # TODO: also remove note about this from docstring and docs
+        server_error.original_exception = e
+        handler = self._find_error_handler(server_error)
+
+        if handler is not None:
+            server_error = handler(server_error)
+
+        return self.finalize_request(server_error, from_error_handler=True)
 
     def log_exception(self, exc_info):
         """Logs an exception.  This is called by :meth:`handle_exception`

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1829,7 +1829,7 @@ class Flask(_PackageBoundObject):
 
         .. note::
             Prior to Werkzeug 1.0.0, ``InternalServerError`` will not
-            always have a ``original_exception`` attribute. Use
+            always have an ``original_exception`` attribute. Use
             ``getattr(e, "original_exception", None)`` to simulate the
             behavior for compatibility.
 

--- a/tests/test_user_error_handler.py
+++ b/tests/test_user_error_handler.py
@@ -6,6 +6,7 @@ tests.test_user_error_handler
 :copyright: © 2010 by the Pallets team.
 :license: BSD, see LICENSE for more details.
 """
+import pytest
 from werkzeug.exceptions import Forbidden
 from werkzeug.exceptions import HTTPException
 from werkzeug.exceptions import InternalServerError
@@ -25,7 +26,13 @@ def test_error_handler_no_match(app, client):
 
     @app.errorhandler(500)
     def handle_500(e):
-        return type(e).__name__
+        assert isinstance(e, InternalServerError)
+        original = getattr(e, "original_exception", None)
+
+        if original is not None:
+            return "wrapped " + type(original).__name__
+
+        return "direct"
 
     @app.route("/custom")
     def custom_test():
@@ -35,9 +42,14 @@ def test_error_handler_no_match(app, client):
     def key_error():
         raise KeyError()
 
+    @app.route("/abort")
+    def do_abort():
+        flask.abort(500)
+
     app.testing = False
     assert client.get("/custom").data == b"custom"
-    assert client.get("/keyerror").data == b"KeyError"
+    assert client.get("/keyerror").data == b"wrapped KeyError"
+    assert client.get("/abort").data == b"direct"
 
 
 def test_error_handler_subclass(app):
@@ -194,3 +206,84 @@ def test_default_error_handler():
     assert c.get("/forbidden").data == b"forbidden"
     # Don't handle RequestRedirect raised when adding slash.
     assert c.get("/slash", follow_redirects=True).data == b"slash"
+
+
+class TestGenericHandlers(object):
+    """Test how very generic handlers are dispatched to."""
+
+    class Custom(Exception):
+        pass
+
+    @pytest.fixture()
+    def app(self, app):
+        @app.route("/custom")
+        def do_custom():
+            raise self.Custom()
+
+        @app.route("/error")
+        def do_error():
+            raise KeyError()
+
+        @app.route("/abort")
+        def do_abort():
+            flask.abort(500)
+
+        @app.route("/raise")
+        def do_raise():
+            raise InternalServerError()
+
+        app.config["PROPAGATE_EXCEPTIONS"] = False
+        return app
+
+    def report_error(self, e):
+        original = getattr(e, "original_exception", None)
+
+        if original is not None:
+            return "wrapped " + type(original).__name__
+
+        return "direct " + type(e).__name__
+
+    @pytest.mark.parametrize("to_handle", (InternalServerError, 500))
+    def test_handle_class_or_code(self, app, client, to_handle):
+        """``InternalServerError`` and ``500`` are aliases, they should
+        have the same behavior. Both should only receive
+        ``InternalServerError``, which might wrap another error.
+        """
+
+        @app.errorhandler(to_handle)
+        def handle_500(e):
+            assert isinstance(e, InternalServerError)
+            return self.report_error(e)
+
+        assert client.get("/custom").data == b"wrapped Custom"
+        assert client.get("/error").data == b"wrapped KeyError"
+        assert client.get("/abort").data == b"direct InternalServerError"
+        assert client.get("/raise").data == b"direct InternalServerError"
+
+    def test_handle_generic_http(self, app, client):
+        """``HTTPException`` should only receive ``HTTPException``
+        subclasses. It will receive ``404`` routing exceptions.
+        """
+
+        @app.errorhandler(HTTPException)
+        def handle_http(e):
+            assert isinstance(e, HTTPException)
+            return str(e.code)
+
+        assert client.get("/error").data == b"500"
+        assert client.get("/abort").data == b"500"
+        assert client.get("/not-found").data == b"404"
+
+    def test_handle_generic(self, app, client):
+        """Generic ``Exception`` will handle all exceptions directly,
+        including ``HTTPExceptions``.
+        """
+
+        @app.errorhandler(Exception)
+        def handle_exception(e):
+            return self.report_error(e)
+
+        assert client.get("/custom").data == b"direct Custom"
+        assert client.get("/error").data == b"direct KeyError"
+        assert client.get("/abort").data == b"direct InternalServerError"
+        assert client.get("/not-found").data == b"direct NotFound"


### PR DESCRIPTION
Due to multiple PRs over the last 5 years, the error handler behavior has slowly changed with the goal of being more consistent. However, after #2314 was merged in 1.0.0, these changes all cascaded together to make some inconsistent behavior finally visible.

After *extensive* discussion in #1281, #1291, and #1429, the goal was to make error handlers trigger for exceptions in MRO order, rather than registration order. It formalized the idea that HTTP exception classes and status codes were aliases. Registering a handler for `401` was the same as `Unauthorized`.

However, it (unintentionally?) preserved some old behavior where user errors would only be looked up against a `500` error handler, not a `InternalServerError` handler, even though the goal was for these to be aliases.

#2314 ensured a more consistent lookup order between blueprints and app error handlers for codes and exception classes. #2362 simplified the code even more, and made it more correct for subclass handling. A side effect of these refactors was that it fixed the preserved behavior, so 500 and `InternalServerError` handlers were equivalent.

All these changes had the goal of making error handler registration and triggering more intuitive, and making maintenance easier.

When an unhandled exception is raised, `handle_exception` is triggered so that a final, generic internal server error is returned. Previously, the behavior was to pass the unhandled exception to the 500 error handler, rather than the generic `InternalServerError`. Now that 500 and `InternalServerError` were the same thing and were both considered as handlers for generic error, users who registered a handler for `InternalServerError` or the `HTTPException` base class were surprised to get other random exceptions passed to the handler, rather than strict subclasses (#2778, #2841).

A fix was proposed in #2983 which continued to preserve the old behavior by making a handler for `500` receive any error, while a handler for `InternalServerError` only received `InternalServerError`. I think this made the code harder to reason about, both for maintainers and for app devs.

Instead, I'm going the opposite direction and ensuring that those handlers only ever receive `InternalServerError` instances. For unhandled errors, the exception has a new `original_exception` attribute that has the original unhandled error. This will be formalized in Werkzeug 1.0.0, until then `getattr` can be used to check if the attribute is set. The upside of this is that it is safe to assume that all codes and classes are aliases, and will only receive matching classes of errors, which seems to have been the intention of previous discussions, and makes the most sense to me.

The downside is that there is no way for this to be 100% backwards compatible for 500 handlers that were written assuming any exception would be passed to them, and I couldn't think of a way to have a useful deprecation warning transition. `e` will always look like `InternalServerError`, possibly making existing generic error pages less useful. However, with the availability of `e.original_exception`, it should be straightforward to get the intended behavior back. Code shouldn't *fail* in the mean time, only be less specific. I think the benefit of more consistent behavior outweighs the drawback.

closes #2778 
closes #2841 
closes #2983 

While fixing this, I noticed that `finalize_request` was only called if a 500 error handler was found. If no custom handler was registered, then an unhandled error would skip `after_request` functions, saving the session, and sending the `request_finished` signal. This is now fixed, so `finalize_request` is always called.

To clear up related confusion about very generic error handlers such as `HTTPException` and `Exception`, more docs have been added to the `errorhandling.rst` page. `handle_exception` has much clearer explanations of what it does too.