### PR TITLE
Use a working example to generate secret_key

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -164,7 +164,7 @@ The following configuration values are used internally by Flask:
     application. It should be a long random string of bytes, although unicode
     is accepted too. For example, copy the output of this to your config::
 
-        $ python -c 'import os; print(os.urandom(16))'
+        $ python -c 'import random; rnd = random.SystemRandom(); print("".join(chr(rnd.randint(32, 127)) for i in range(16)))'
         b'_5#y2L"F4Q8z\n\xec]/'
 
     **Do not reveal the secret key when posting questions or committing code.**

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -809,7 +809,7 @@ not using the template engine (as in this example).
     generator. Use the following command to quickly generate a value for
     :attr:`Flask.secret_key` (or :data:`SECRET_KEY`)::
 
-        $ python -c 'import os; print(os.urandom(16))'
+        $ python -c 'import random; rnd = random.SystemRandom(); print("".join(chr(rnd.randint(32, 127)) for i in range(16)))'
         b'_5#y2L"F4Q8z\n\xec]/'
 
 A note on cookie-based sessions: Flask will take the values you put into the

--- a/docs/tutorial/deploy.rst
+++ b/docs/tutorial/deploy.rst
@@ -70,7 +70,7 @@ You can use the following command to output a random secret key:
 
 .. code-block:: none
 
-    $ python -c 'import os; print(os.urandom(16))'
+    $ python -c 'import random; rnd = random.SystemRandom(); print("".join(chr(rnd.randint(32, 127)) for i in range(16)))'
 
     b'_5#y2L"F4Q8z\n\xec]/'
 


### PR DESCRIPTION
* Fixing the example given in the doc that only gives you a non-printable ascii output.
* SystemRandom is sure to use for cryptographic purpose (see random module doc)

The one-liner given in the doc provides only a non-printable output not suitable for any use. Fixing that with another one-liner.

https://docs.python.org/3/library/random.html

