### PR TITLE
don't clear BadRequestKeyError args

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,15 @@
 .. currentmodule:: flask
 
+Version 1.0.4
+-------------
+
+Unreleased
+
+-   The key information for ``BadRequestKeyError`` is no longer cleared
+    outside debug mode, so error handlers can still access it. This
+    requires upgrading to Werkzeug 0.15.5. :issue:`3249`
+
+
 Version 1.0.3
 -------------
 

--- a/flask/__init__.py
+++ b/flask/__init__.py
@@ -10,7 +10,7 @@
     :license: BSD-3-Clause
 """
 
-__version__ = '1.0.3'
+__version__ = '1.0.4.dev'
 
 # utilities we import from Werkzeug and Jinja2 that are unused
 # in the module but are exported as public interface.

--- a/flask/app.py
+++ b/flask/app.py
@@ -1724,14 +1724,14 @@ class Flask(_PackageBoundObject):
 
         if isinstance(e, BadRequestKeyError):
             if self.debug or self.config["TRAP_BAD_REQUEST_ERRORS"]:
+                e.show_exception = True
+
                 # Werkzeug < 0.15 doesn't add the KeyError to the 400
                 # message, add it in manually.
-                description = e.get_description()
-
-                if e.args[0] not in description:
+                # TODO: clean up once Werkzeug >= 0.15.5 is required
+                if e.args[0] not in e.get_description():
                     e.description = "KeyError: '{}'".format(*e.args)
-            else:
-                # Werkzeug >= 0.15 does add it, remove it in production
+            elif not hasattr(BadRequestKeyError, "show_exception"):
                 e.args = ()
 
         if isinstance(e, HTTPException) and not self.trap_http_exception(e):


### PR DESCRIPTION
Fixes #3249. Sets `BadRequestKeyError.show_exception` to include the exception message in the description, rather than clearing `args` to hide it. The attribute was introduced by pallets/werkzeug#1595, which will be released as Werkzeug 0.15.5. Using Werkzeug >= 0.15.0, <= 0.15.4 will still have the arguments cleared, so users will need to upgrade both libraries to get the fix.