### PR TITLE
send_file quotes ":/" in UTF-8 filename

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 -   The key information for ``BadRequestKeyError`` is no longer cleared
     outside debug mode, so error handlers can still access it. This
     requires upgrading to Werkzeug 0.15.5. :issue:`3249`
+-   ``send_file`` url quotes the ":" and "/" characters for more
+    compatible UTF-8 filename support in some browsers. :issue:`3074`
 
 
 Version 1.0.3

--- a/flask/helpers.py
+++ b/flask/helpers.py
@@ -576,7 +576,7 @@ def send_file(filename_or_fp, mimetype=None, as_attachment=False,
             filenames = {
                 'filename': unicodedata.normalize(
                     'NFKD', attachment_filename).encode('ascii', 'ignore'),
-                'filename*': "UTF-8''%s" % url_quote(attachment_filename),
+                'filename*': "UTF-8''%s" % url_quote(attachment_filename, safe=b""),
             }
         else:
             filenames = {'filename': attachment_filename}

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -646,6 +646,8 @@ class TestSendfile(object):
         (u'Vögel.txt', 'Vogel.txt', 'V%C3%B6gel.txt'),
         # Native string not marked as Unicode on Python 2
         ('tést.txt', 'test.txt', 't%C3%A9st.txt'),
+        # ":/" are not safe in filename* value
+        (u"те:/ст", '":/"', "%D1%82%D0%B5%3A%2F%D1%81%D1%82"),
     ))
     def test_attachment_filename_encoding(self, filename, ascii, utf8):
         rv = flask.send_file('static/index.html', as_attachment=True, attachment_filename=filename)


### PR DESCRIPTION
fixes #3074 

Through https://tools.ietf.org/html/rfc8187#section-3.2.1, ":" and "/" are not part of `attr-char` and should be quoted.