### PR TITLE
Add closing tags to example's nav bar

### DIFF
--- a/examples/tutorial/flaskr/templates/base.html
+++ b/examples/tutorial/flaskr/templates/base.html
@@ -5,11 +5,11 @@
   <h1><a href="{{ url_for('index') }}">Flaskr</a></h1>
   <ul>
     {% if g.user %}
-      <li><span>{{ g.user['username'] }}</span>
-      <li><a href="{{ url_for('auth.logout') }}">Log Out</a>
+      <li><span>{{ g.user['username'] }}</span></li>
+      <li><a href="{{ url_for('auth.logout') }}">Log Out</a></li>
     {% else %}
-      <li><a href="{{ url_for('auth.register') }}">Register</a>
-      <li><a href="{{ url_for('auth.login') }}">Log In</a>
+      <li><a href="{{ url_for('auth.register') }}">Register</a></li>
+      <li><a href="{{ url_for('auth.login') }}">Log In</a></li>
     {% endif %}
   </ul>
 </nav>


### PR DESCRIPTION
In the tutorial, the base.html file does not have closing `</li>` tags. This PR adds the corresponding `</li>` tags to the nav bar.
