### PR TITLE
Fixes for PEP451 import loaders and pytest 5.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Unreleased
     requires upgrading to Werkzeug 0.15.5. :issue:`3249`
 -   ``send_file`` url quotes the ":" and "/" characters for more
     compatible UTF-8 filename support in some browsers. :issue:`3074`
+-   Fixes for PEP451 import loaders and pytest 5.x.  :issue:`3275`
 
 
 Version 1.0.3

--- a/docs/tutorial/tests.rst
+++ b/docs/tutorial/tests.rst
@@ -188,7 +188,7 @@ should be closed.
         with pytest.raises(sqlite3.ProgrammingError) as e:
             db.execute('SELECT 1')
 
-        assert 'closed' in str(e)
+        assert 'closed' in str(e.value)
 
 The ``init-db`` command should call the ``init_db`` function and output
 a message.

--- a/examples/tutorial/tests/test_db.py
+++ b/examples/tutorial/tests/test_db.py
@@ -12,7 +12,7 @@ def test_get_close_db(app):
     with pytest.raises(sqlite3.ProgrammingError) as e:
         db.execute('SELECT 1')
 
-    assert 'closed' in str(e)
+    assert 'closed' in str(e.value)
 
 
 def test_init_db_command(runner, monkeypatch):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1219,17 +1219,17 @@ def test_response_type_errors():
 
     with pytest.raises(TypeError) as e:
         c.get('/none')
-        assert 'returned None' in str(e)
+        assert 'returned None' in str(e.value)
 
     with pytest.raises(TypeError) as e:
         c.get('/small_tuple')
-        assert 'tuple must have the form' in str(e)
+        assert 'tuple must have the form' in str(e.value)
 
     pytest.raises(TypeError, c.get, '/large_tuple')
 
     with pytest.raises(TypeError) as e:
         c.get('/bad_type')
-        assert 'it was a bool' in str(e)
+        assert 'it was a bool' in str(e.value)
 
     pytest.raises(TypeError, c.get, '/bad_wsgi')
 
@@ -1622,7 +1622,7 @@ def test_debug_mode_complains_after_first_request(app, client):
         @app.route('/foo')
         def broken():
             return 'Meh'
-    assert 'A setup function was called' in str(e)
+    assert 'A setup function was called' in str(e.value)
 
     app.debug = False
 
@@ -1677,9 +1677,9 @@ def test_routing_redirect_debugging(app, client):
     with client:
         with pytest.raises(AssertionError) as e:
             client.post('/foo', data={})
-        assert 'http://localhost/foo/' in str(e)
+        assert 'http://localhost/foo/' in str(e.value)
         assert ('Make sure to directly send '
-                'your POST-request to this URL') in str(e)
+                'your POST-request to this URL') in str(e.value)
 
         rv = client.get('/foo', data={}, follow_redirects=True)
         assert rv.data == b'success'

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -468,8 +468,8 @@ class TestSendfile(object):
     def test_send_file_object_without_mimetype(self, app, req_ctx):
         with pytest.raises(ValueError) as excinfo:
             flask.send_file(StringIO("LOL"))
-        assert 'Unable to infer MIME-type' in str(excinfo)
-        assert 'no filename is available' in str(excinfo)
+        assert 'Unable to infer MIME-type' in str(excinfo.value)
+        assert 'no filename is available' in str(excinfo.value)
 
         flask.send_file(StringIO("LOL"), attachment_filename='filename')
 


### PR DESCRIPTION
- pytest 5.x drops python2 compatibility and therefore only implements PEP 451
- pytest 5.x made the repr of `ExcInfo` less confusing (fixed tests depending
  on the old format)

Resolves #3275
Resolves #3277