### PR TITLE
use app.name as app.logger name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,12 @@ Unreleased
     -   :meth:`Flask.finalize_request` is called for all unhandled
         exceptions even if there is no ``500`` error handler.
 
+-   :attr:`Flask.logger` takes the same name as
+    :attr:`Flask.name` (the value passed as
+    ``Flask(import_name)``. This reverts 1.0's behavior of always
+    logging to ``"flask.app"``, in order to support multiple apps in the
+    same process. This may require adjusting logging configuration.
+    :issue:`2866`.
 -   :meth:`flask.RequestContext.copy` includes the current session
     object in the request context copy. This prevents ``session``
     pointing to an out-of-date object. :issue:`2935`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -382,7 +382,7 @@ The following configuration values are used internally by Flask:
 
 .. versionchanged:: 1.0
     ``LOGGER_NAME`` and ``LOGGER_HANDLER_POLICY`` were removed. See
-    :ref:`logging` for information about configuration.
+    :doc:`/logging` for information about configuration.
 
     Added :data:`ENV` to reflect the :envvar:`FLASK_ENV` environment
     variable.

--- a/docs/errorhandling.rst
+++ b/docs/errorhandling.rst
@@ -231,7 +231,7 @@ errors, use ``getattr`` to get access it for compatibility.
 Logging
 -------
 
-See :ref:`logging` for information on how to log exceptions, such as by
+See :doc:`/logging` for information on how to log exceptions, such as by
 emailing them to admins.
 
 

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -1,12 +1,12 @@
-.. _logging:
-
 Logging
 =======
 
-Flask uses standard Python :mod:`logging`. All Flask-related messages are
-logged under the ``'flask'`` logger namespace.
-:meth:`Flask.logger <flask.Flask.logger>` returns the logger named
-``'flask.app'``, and can be used to log messages for your application. ::
+Flask uses standard Python :mod:`logging`. Messages about your Flask
+application are logged with :meth:`app.logger <flask.Flask.logger>`,
+which takes the same name as :attr:`app.name <flask.Flask.name>`. This
+logger can also be used to log your own messages.
+
+.. code-block:: python
 
     @app.route('/login', methods=['POST'])
     def login():

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -653,22 +653,26 @@ class Flask(_PackageBoundObject):
 
     @locked_cached_property
     def logger(self):
-        """The ``'flask.app'`` logger, a standard Python
-        :class:`~logging.Logger`.
+        """A standard Python :class:`~logging.Logger` for the app, with
+        the same name as :attr:`name`.
 
-        In debug mode, the logger's :attr:`~logging.Logger.level` will be set
-        to :data:`~logging.DEBUG`.
+        In debug mode, the logger's :attr:`~logging.Logger.level` will
+        be set to :data:`~logging.DEBUG`.
 
-        If there are no handlers configured, a default handler will be added.
-        See :ref:`logging` for more information.
+        If there are no handlers configured, a default handler will be
+        added. See :doc:`/logging` for more information.
 
-        .. versionchanged:: 1.0
+        .. versionchanged:: 1.1.0
+            The logger takes the same name as :attr:`name` rather than
+            hard-coding ``"flask.app"``.
+
+        .. versionchanged:: 1.0.0
             Behavior was simplified. The logger is always named
-            ``flask.app``. The level is only set during configuration, it
-            doesn't check ``app.debug`` each time. Only one format is used,
-            not different ones depending on ``app.debug``. No handlers are
-            removed, and a handler is only added if no handlers are already
-            configured.
+            ``"flask.app"``. The level is only set during configuration,
+            it doesn't check ``app.debug`` each time. Only one format is
+            used, not different ones depending on ``app.debug``. No
+            handlers are removed, and a handler is only added if no
+            handlers are already configured.
 
         .. versionadded:: 0.3
         """

--- a/src/flask/logging.py
+++ b/src/flask/logging.py
@@ -57,7 +57,10 @@ default_handler.setFormatter(
 
 
 def create_logger(app):
-    """Get the ``'flask.app'`` logger and configure it if needed.
+    """Get the the Flask apps's logger and configure it if needed.
+
+    The logger name will be the same as
+    :attr:`app.import_name <flask.Flask.name>`.
 
     When :attr:`~flask.Flask.debug` is enabled, set the logger level to
     :data:`logging.DEBUG` if it is not set.
@@ -66,7 +69,7 @@ def create_logger(app):
     :class:`~logging.StreamHandler` for
     :func:`~flask.logging.wsgi_errors_stream` with a basic format.
     """
-    logger = logging.getLogger("flask.app")
+    logger = logging.getLogger(app.name)
 
     if app.debug and logger.level == logging.NOTSET:
         logger.setLevel(logging.DEBUG)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -23,7 +23,7 @@ def reset_logging(pytestconfig):
     logging.root.handlers = []
     root_level = logging.root.level
 
-    logger = logging.getLogger("flask.app")
+    logger = logging.getLogger("flask_test")
     logger.handlers = []
     logger.setLevel(logging.NOTSET)
 
@@ -42,7 +42,7 @@ def reset_logging(pytestconfig):
 
 
 def test_logger(app):
-    assert app.logger.name == "flask.app"
+    assert app.logger.name == "flask_test"
     assert app.logger.level == logging.NOTSET
     assert app.logger.handlers == [default_handler]
 

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -430,7 +430,9 @@ def test_template_loader_debugging(test_apps, monkeypatch):
 
     with app.test_client() as c:
         monkeypatch.setitem(app.config, "EXPLAIN_TEMPLATE_LOADING", True)
-        monkeypatch.setattr(logging.getLogger("flask"), "handlers", [_TestHandler()])
+        monkeypatch.setattr(
+            logging.getLogger("blueprintapp"), "handlers", [_TestHandler()]
+        )
 
         with pytest.raises(TemplateNotFound) as excinfo:
             c.get("/missing")


### PR DESCRIPTION
#2436 greatly simplified how logging is set up in Flask. Part of that removed the `LOGGER_NAME` config and hard-coded `"flask.app"`. However, #2866 points out that due to this it is no longer possible to distinguish logs when dispatching multiple apps.

This partially reverts the logger name behavior change from 1.0. There is still no config, but the logger's name is now the same as `app.name` (basically the value passed to `Flask(import_name)`).

The information that's currently logged does make sense as coming from the user's project rather than Flask itself, although we may introduce the `"flask.app"` logger again in the future for logging things truly internal to Flask and not the user's app.

This may require projects to update their logging config to reference their app's name instead of `"flask.app"`.

Closes #2866 