### PR TITLE
show warning for old logger config

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,8 +22,8 @@ Unreleased
     :attr:`Flask.name` (the value passed as
     ``Flask(import_name)``. This reverts 1.0's behavior of always
     logging to ``"flask.app"``, in order to support multiple apps in the
-    same process. This may require adjusting logging configuration.
-    :issue:`2866`.
+    same process. A warning will be shown if old configuration is
+    detected that needs to be moved. :issue:`2866`
 -   :meth:`flask.RequestContext.copy` includes the current session
     object in the request context copy. This prevents ``session``
     pointing to an out-of-date object. :issue:`2935`

--- a/src/flask/logging.py
+++ b/src/flask/logging.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import
 
 import logging
 import sys
+import warnings
 
 from werkzeug.local import LocalProxy
 
@@ -56,6 +57,20 @@ default_handler.setFormatter(
 )
 
 
+def _has_config(logger):
+    """Decide if a logger has direct configuration applied by checking
+    its properties against the defaults.
+
+    :param logger: The :class:`~logging.Logger` to inspect.
+    """
+    return (
+        logger.level != logging.NOTSET
+        or logger.handlers
+        or logger.filters
+        or not logger.propagate
+    )
+
+
 def create_logger(app):
     """Get the the Flask apps's logger and configure it if needed.
 
@@ -71,7 +86,21 @@ def create_logger(app):
     """
     logger = logging.getLogger(app.name)
 
-    if app.debug and logger.level == logging.NOTSET:
+    # 1.1.0 changes name of logger, warn if config is detected for old
+    # name and not new name
+    for old_name in ("flask.app", "flask"):
+        old_logger = logging.getLogger(old_name)
+
+        if _has_config(old_logger) and not _has_config(logger):
+            warnings.warn(
+                "'app.logger' is named '{name}' for this application,"
+                " but configuration was found for '{old_name}', which"
+                " no longer has an effect. The logging configuration"
+                " should be moved to '{name}'.".format(name=app.name, old_name=old_name)
+            )
+            break
+
+    if app.debug and not logger.level:
         logger.setLevel(logging.DEBUG)
 
     if not has_level_handler(logger):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -104,3 +104,12 @@ def test_log_view_exception(app, client):
     err = stream.getvalue()
     assert "Exception on / [GET]" in err
     assert "Exception: test" in err
+
+
+def test_warn_old_config(app, request):
+    old_logger = logging.getLogger("flask.app")
+    old_logger.setLevel(logging.DEBUG)
+    request.addfinalizer(lambda: old_logger.setLevel(logging.NOTSET))
+
+    with pytest.warns(UserWarning):
+        assert app.logger.getEffectiveLevel() == logging.WARNING


### PR DESCRIPTION
Adds a warning for #3282 when config for the `"flask.app"` or `"flask"` loggers is found and the logger for `app.name` *isn't* configured.

> UserWarning: 'app.logger' is named 'example' for this application, but configuration was found for 'flask.app', which no longer has an effect. The logging configuration should be moved to 'example'.

closes #3284 