### PR TITLE
Move dotenv warning to stderr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Unreleased
 -   ``send_file`` url quotes the ":" and "/" characters for more
     compatible UTF-8 filename support in some browsers. :issue:`3074`
 -   Fixes for PEP451 import loaders and pytest 5.x.  :issue:`3275`
+-   Show message about dotenv on stderr instead of stdout.  :issue:`3285`
 
 
 Version 1.0.3

--- a/flask/cli.py
+++ b/flask/cli.py
@@ -600,7 +600,7 @@ def load_dotenv(path=None):
             click.secho(
                 ' * Tip: There are .env files present.'
                 ' Do "pip install python-dotenv" to use them.',
-                fg='yellow')
+                fg='yellow', err=True)
         return
 
     if path is not None:


### PR DESCRIPTION
It was printed to stdout, which broke custom flask subcommands whose output was consumed by scripts (which might expect json or something else that's not just text).