### PR TITLE
Comment out helpful tips in ISSUE_TEMPLATE so they're visible only when editing

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,12 +1,12 @@
-<!--**This issue tracker is a tool to address bugs in Flask itself.
+<!-- **This issue tracker is a tool to address bugs in Flask itself.
 Please use the #pocoo IRC channel on freenode or Stack Overflow for general
-questions about using Flask or issues not related to Flask.**
+questions about using Flask or issues not related to Flask.** -->
 
 <!-- If you'd like to report a bug in Flask, fill out the template below. Provide
 any extra information that may be useful / related to your problem.
 Ideally, create an [MCVE](https://stackoverflow.com/help/mcve), which helps us
 understand the problem and helps check that it is not caused by something in
-your code.
+your code. -->
 
 
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,26 +1,24 @@
-**This issue tracker is a tool to address bugs in Flask itself.
+<!--**This issue tracker is a tool to address bugs in Flask itself.
 Please use the #pocoo IRC channel on freenode or Stack Overflow for general
 questions about using Flask or issues not related to Flask.**
 
-If you'd like to report a bug in Flask, fill out the template below. Provide
+<!-- If you'd like to report a bug in Flask, fill out the template below. Provide
 any extra information that may be useful / related to your problem.
 Ideally, create an [MCVE](https://stackoverflow.com/help/mcve), which helps us
 understand the problem and helps check that it is not caused by something in
 your code.
 
----
+
 
 ### Expected Behavior
-
-Tell us what should happen.
+<!-- Tell us what should happen. -->
 
 ```python
-Paste a minimal example that causes the problem.
+# Paste a minimal example that causes the problem.
 ```
 
 ### Actual Behavior
-
-Tell us what happens instead.
+<!-- Tell us what happens instead. -->
 
 ```pytb
 Paste the full traceback if there was an exception.


### PR DESCRIPTION
The comments are now visible only to the issue creator and do not need to be manually removed before submitting the issue.