### PR TITLE
restore and deprecate json_available

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,15 @@
 .. currentmodule:: flask
 
+Version 1.1.1
+-------------
+
+Unreleased
+
+-   The ``flask.json_available`` flag was added back for compatibility
+    with some extensions. It will raise a deprecation warning when used,
+    and will be removed in version 2.0.0. :issue:`3288`
+
+
 Version 1.1.0
 -------------
 

--- a/src/flask/__init__.py
+++ b/src/flask/__init__.py
@@ -17,6 +17,7 @@ from werkzeug.exceptions import abort
 from werkzeug.utils import redirect
 
 from . import json
+from ._compat import json_available
 from .app import Flask
 from .app import Request
 from .app import Response
@@ -56,4 +57,4 @@ from .signals import template_rendered
 from .templating import render_template
 from .templating import render_template_string
 
-__version__ = "1.1.0"
+__version__ = "1.1.1.dev"

--- a/src/flask/_compat.py
+++ b/src/flask/_compat.py
@@ -113,3 +113,33 @@ except ImportError:
     # https://www.python.org/dev/peps/pep-0519/#backwards-compatibility
     def fspath(path):
         return path.__fspath__() if hasattr(path, "__fspath__") else path
+
+
+class _DeprecatedBool(object):
+    def __init__(self, name, version, value):
+        self.message = "'{}' is deprecated and will be removed in version {}.".format(
+            name, version
+        )
+        self.value = value
+
+    def _warn(self):
+        import warnings
+
+        warnings.warn(self.message, DeprecationWarning, stacklevel=2)
+
+    def __eq__(self, other):
+        self._warn()
+        return other == self.value
+
+    def __ne__(self, other):
+        self._warn()
+        return other != self.value
+
+    def __bool__(self):
+        self._warn()
+        return self.value
+
+    __nonzero__ = __bool__
+
+
+json_available = _DeprecatedBool("flask.json_available", "2.0.0", True)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,12 @@
+import pytest
+
+from flask import json_available
+
+
+def test_json_available():
+    with pytest.deprecated_call() as rec:
+        assert json_available
+        assert json_available == True  # noqa E712
+        assert json_available != False  # noqa E712
+
+    assert len(rec.list) == 3


### PR DESCRIPTION
`flask.json_available` was removed because it was marked deprecated in the code and doesn't do anything. `flask.json` is always available, and libaries that weren't sure about that should have used `try/except ImportError` while it was relevant. However, since a few dormant but popular extensions use it, it's added back in for now.

Anything doing `if json_available` or `if json_available == True`, such as Flask-Testing and Flask-DebugToolbar, will show a `DeprecationWarning`. `is` can't be overridden, so that won't show a warning, but I don't think things that were using this flag did that.

I've marked it for removal in 2.0.0, which will be a pretty big change anyway. Please reach out to extensions you use if you see this warning and offer to help maintain it if it's an extension you want to continue using as Flask moves forward.

closes #3288 