### PR TITLE
 Add version '3.7' and a comma in "Running the test" of contributing guide.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -134,7 +134,7 @@ suite when you submit your pull request.
 
 The full test suite takes a long time to run because it tests multiple
 combinations of Python and dependencies. You need to have Python 2.7, 3.4,
-3.5 3.6, and PyPy 2.7 installed to run all of the environments. Then run::
+3.5, 3.6, 3.7 and PyPy 2.7 installed to run all of the environments. Then run::
 
     tox
 


### PR DESCRIPTION
Now python 3.7 has been added into [tox.ini](https://github.com/pallets/flask/blob/master/tox.ini), but the contributing guide has not been updated yet.
 And i added a missing comma.
<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
