### PR TITLE
cli: optionally silence flask startup messages when using werkzeug

### DIFF
--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -661,6 +661,12 @@ def show_server_banner(env, debug, app_import_path, eager_loading):
     if os.environ.get("WERKZEUG_RUN_MAIN") == "true":
         return
 
+    # If all you want to do is avoid the startup messages, define
+    # "FLASK_SILENCE_STARTUP" = "true"". WERKZEUG_RUN_MAIN above is
+    # recognized in werkzeug code and has other effects.
+    if os.environ.get("FLASK_SILENCE_STARTUP") == "true":
+        return
+
     if app_import_path is not None:
         message = ' * Serving Flask app "{0}"'.format(app_import_path)
 


### PR DESCRIPTION
While inappropriate for a production public webserver, for certain
use-cases, the embedded Werkzeug server is perfectly acceptable and useful.
However, we might not want the messages cluttering up the console output.

This adds an environment variable knob that can be used to silence the
startup output. Set "FLASK_SILENCE_STARTUP" = "true" and the messages
will be skipped.

In an earlier attempt, I tried using the WERKZEUG_RUN_MAIN knob, but it has
other side-effects in Werkzeug and thus was unsuitable. The new knob _only_
has the effect of silencing the messages.

In our use-case, a "real" webserver is inappropriate as Flask is being used to add a REST-style interface to real-time data-analysis program in order to support internal messaging between parts. During the running of this program, some 20+ processes get spawned, with their own Flask interfaces, and in the system, several other related programs run with Flask app interfaces. This is basically being used only for internal messaging in an isolated system as such the reason to not use the embedded server in a "production" system is moot, and the embedded Werkzeug server is perfect for our case. However, the spawning of lots of Flask processes clutters up the startup log of the system making it unpleasant to try to find the actual messages we need to see.

We're using the 1.0.x branch and if this is deemed acceptable, I'll pull-request the same change for 1.0.x and 1.1.x if desired.