### PR TITLE
fixed typo in logging docstring

### DIFF
--- a/src/flask/logging.py
+++ b/src/flask/logging.py
@@ -72,7 +72,7 @@ def _has_config(logger):
 
 
 def create_logger(app):
-    """Get the Flask apps's logger and configure it if needed.
+    """Get the Flask app's logger and configure it if needed.
 
     The logger name will be the same as
     :attr:`app.import_name <flask.Flask.name>`.

--- a/src/flask/logging.py
+++ b/src/flask/logging.py
@@ -72,7 +72,7 @@ def _has_config(logger):
 
 
 def create_logger(app):
-    """Get the the Flask apps's logger and configure it if needed.
+    """Get the Flask apps's logger and configure it if needed.
 
     The logger name will be the same as
     :attr:`app.import_name <flask.Flask.name>`.


### PR DESCRIPTION
Really groundbreaking stuff here, noticed this when I was glancing at the logging source.  Just a simple typo fix.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
