### PR TITLE
docs: Change max content length value to megabyte

### DIFF
--- a/docs/patterns/fileuploads.rst
+++ b/docs/patterns/fileuploads.rst
@@ -147,7 +147,7 @@ config key::
     from flask import Flask, Request
 
     app = Flask(__name__)
-    app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024
+    app.config['MAX_CONTENT_LENGTH'] = 16 * 1000 * 1000
 
 The code above will limit the maximum allowed payload to 16 megabytes.
 If a larger file is transmitted, Flask will raise a


### PR DESCRIPTION
16 * 1024 * 1024 = 16 MiB (Mebibyte)
16 * 1000 * 1000 = 16 MB (Megabyte)

The example is in megabytes, not in mebibytes.