### PR TITLE
Add tip for startup of development server

### DIFF
--- a/docs/server.rst
+++ b/docs/server.rst
@@ -38,6 +38,12 @@ disabled::
     ``FLASK_DEBUG=1``. This can still be used to control debug mode, but
     you should prefer setting the development environment as shown
     above.
+    
+Troubleshooting
+    When running into an error like ``No module named flask``, run flask 
+    explicitely as a python module::
+    
+    $ python -m flask run
 
 In Code
 -------


### PR DESCRIPTION
An Windows, it is not possible for me to run `flask run` in development mode. I always run into
```
python.exe: No module named C:\Users\...\flask
```
This holds for PowerShell as well as for Git Bash.

I think it could be helpful to provide the solution to this issue in this docu.

