### PR TITLE
Fix typo in pop documentation

### DIFF
--- a/src/flask/ctx.py
+++ b/src/flask/ctx.py
@@ -61,7 +61,7 @@ class _AppCtxGlobals(object):
 
         :param name: Name of attribute to pop.
         :param default: Value to return if the attribute is not present,
-            instead of raise a ``KeyError``.
+            instead of raising a ``KeyError``.
 
         .. versionadded:: 0.11
         """


### PR DESCRIPTION

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->

Just fixes a minor typo I noticed while reading the docs.