### PR TITLE
add a note about named params for execute()

### DIFF
--- a/docs/patterns/sqlalchemy.rst
+++ b/docs/patterns/sqlalchemy.rst
@@ -214,5 +214,17 @@ You can also pass strings of SQL statements to the
 >>> engine.execute('select * from users where id = :1', [1]).first()
 (1, u'admin', u'admin@localhost')
 
+note: you *MUST* use this stupid [{}] method to pass in arguments for bindparams,
+you apparenlty can't just do 
+
+>>> engine.execute('select * from users where id = :id', id=1).first()
+
+This will break, despite the SQLAlchemy docs implying it works(and it does work outside of Flask).
+to do named parameters:
+
+>>> engine.execute('select * from users where id = :id and name = :name', [{'id':1, 'name':'admin'}]).first()
+(1, u'admin', u'admin@localhost')
+
+
 For more information about SQLAlchemy, head over to the
 `website <https://www.sqlalchemy.org/>`_.


### PR DESCRIPTION
Flask apparently breaks sqlalchemy and requires you to pass named parameters as
[{}] 
no idea why, I'm to upset with Flask at the moment to go figure it out.
feel free to fix Flask for real, or fix this to be more sane, as I haven't gone spelunking, but this is the only way I could make named params actually work.

Describe what this patch does to fix the issue.

Link to any relevant issues or pull requests.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
