### PR TITLE
Fix the contibution docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -79,7 +79,8 @@ First time setup
 
         pip install -e ".[dev]"
 
-- Install the pre-commit hooks:
+- Install the `pre-commit framework`_.
+- Install the pre-commit hooks::
 
         pre-commit install --install-hooks
 
@@ -89,6 +90,7 @@ First time setup
 .. _email: https://help.github.com/en/articles/setting-your-commit-email-address-in-git
 .. _Fork: https://github.com/pallets/flask/fork
 .. _Clone: https://help.github.com/en/articles/fork-a-repo#step-2-create-a-local-clone-of-your-fork
+.. _pre-commit framework: https://pre-commit.com/#install
 
 Start coding
 ~~~~~~~~~~~~


### PR DESCRIPTION
The guidelines for the first time setup of Flask for development lacks any details about the installation of pre-commit module. The command to install the pre-commit hooks is not set as a code block and is rendered as a quote.
As someone who decided to make a few contributions on the framework, this is a quite irritating start of the journey 😄 I've added a link to the official guide for the installation of the pre-commit and fixed the markdown to make the command a code block.