### PR TITLE
Update testing.rst

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -29,6 +29,9 @@ First, we need an application to test; we will use the application from
 the :ref:`tutorial`.  If you don't have that application yet, get the
 source code from :gh:`the examples <examples/tutorial>`.
 
+So that we can import the module ``flaskr`` correctly, we need to run
+``pip install -e .`` in the folder ``tutorial``.
+
 The Testing Skeleton
 --------------------
 
@@ -46,7 +49,7 @@ the application for testing and initializes a new database::
 
     import pytest
 
-    from flaskr import flaskr
+    from flaskr import create_app
 
 
     @pytest.fixture


### PR DESCRIPTION
It now describes how to install flaskr using pip so that all tests pass.

All tests in examples/tutorial/tests failed because the module flaskr could not be loaded, so I added a line describing how to install flaskr as an editable module. This should fix #2833 .