### PR TITLE
Add feature flask.cli.with_testrequestcontext,

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -396,6 +396,28 @@ If you're sure a command doesn't need the context, you can disable it::
         ...
 
 
+
+Request Context
+~~~~~~~~~~~~~~~
+Commands requiring a request context can use
+:meth:`~cli.with_testrequestcontext` to to simulate a full request. ::
+
+    import click
+    from flask import request
+    from flask.cli import with_testrequestcontext
+
+    @click.command()
+    @with_testrequestcontext("/make_report/2017")
+    def do_work():
+        print(request.path)
+        // "/make_report/2017"
+        ...
+
+    app.cli.add_command(do_work)
+
+All arguments passed to :meth:`~cli.withtestrequestcontext` are directly passed
+to the underlying :meth:`~Flask.test_request_context`.
+
 Plugins
 -------
 

--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -428,6 +428,26 @@ def with_appcontext(f):
     return update_wrapper(decorator, f)
 
 
+def with_testrequestcontext(*args, **kwargs):
+    """Wraps a callback so that it's guaranteed to be executed with the
+    script's request context.  If callbacks are registered directly
+    to the ``app.cli`` object then they are wrapped with this function
+    by default unless it's disabled.
+    """
+
+    def wrapper(f):
+        @click.pass_context
+        def decorator(__ctx, *inner_args, **inner_kwargs):
+            with __ctx.ensure_object(ScriptInfo).load_app().test_request_context(
+                *args, **kwargs
+            ):
+                return __ctx.invoke(f, *inner_args, **inner_kwargs)
+
+        return update_wrapper(decorator, f)
+
+    return wrapper
+
+
 class AppGroup(click.Group):
     """This works similar to a regular click :class:`~click.Group` but it
     changes the behavior of the :meth:`command` decorator so that it

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,7 @@ from click.testing import CliRunner
 from flask import Blueprint
 from flask import current_app
 from flask import Flask
+from flask import request
 from flask.cli import AppGroup
 from flask.cli import dotenv
 from flask.cli import find_best_app
@@ -36,6 +37,7 @@ from flask.cli import prepare_import
 from flask.cli import run_command
 from flask.cli import ScriptInfo
 from flask.cli import with_appcontext
+from flask.cli import with_testrequestcontext
 
 cwd = os.getcwd()
 test_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "test_apps"))
@@ -339,6 +341,30 @@ def test_with_appcontext(runner):
     result = runner.invoke(testcmd, obj=obj)
     assert result.exit_code == 0
     assert result.output == "testapp\n"
+
+
+def test_with_testrequestcontext(runner):
+    """Test of with_testrequestcontext."""
+
+    @click.command()
+    @with_testrequestcontext()
+    def testcmd():
+        click.echo(request.path)
+
+    @click.command()
+    @with_testrequestcontext("/make_report/2017/")
+    def testcmd2():
+        click.echo(request.path)
+
+    obj = ScriptInfo(create_app=lambda info: Flask("testapp"))
+
+    result = runner.invoke(testcmd, obj=obj)
+    assert result.exit_code == 0
+    assert result.output == "/\n"
+
+    result = runner.invoke(testcmd2, obj=obj)
+    assert result.exit_code == 0
+    assert result.output == "/make_report/2017/\n"
 
 
 def test_appgroup(runner):


### PR DESCRIPTION
For a project of mine I had the need to have a request context available in a cli command. This PR adds the code used, together with test and relevant code.

I have not added the ``versionadded`` yet, should it contain 1.1.2?
