### PR TITLE
get_cookie_name in SessionInterface for easier overriding in SecureCookieSessionInterface

### DIFF
--- a/src/flask/sessions.py
+++ b/src/flask/sessions.py
@@ -173,6 +173,13 @@ class SessionInterface(object):
         """
         return isinstance(obj, self.null_session_class)
 
+    def get_cookie_name(self, app):
+        """Returns the name of the session cookie.
+
+        Uses ``app.session_cookie_name`` which is set to ``SESSION_COOKIE_NAME``
+        """
+        return app.session_cookie_name
+
     def get_cookie_domain(self, app):
         """Returns the domain that should be set for the session cookie.
 
@@ -351,6 +358,7 @@ class SecureCookieSessionInterface(SessionInterface):
             return self.session_class()
 
     def save_session(self, app, session, response):
+        name = self.get_cookie_name(app)
         domain = self.get_cookie_domain(app)
         path = self.get_cookie_path(app)
 
@@ -358,9 +366,7 @@ class SecureCookieSessionInterface(SessionInterface):
         # If the session is empty, return without setting the cookie.
         if not session:
             if session.modified:
-                response.delete_cookie(
-                    app.session_cookie_name, domain=domain, path=path
-                )
+                response.delete_cookie(name, domain=domain, path=path)
 
             return
 
@@ -377,7 +383,7 @@ class SecureCookieSessionInterface(SessionInterface):
         expires = self.get_expiration_time(app, session)
         val = self.get_signing_serializer(app).dumps(dict(session))
         response.set_cookie(
-            app.session_cookie_name,
+            name,
             val,
             expires=expires,
             httponly=httponly,


### PR DESCRIPTION
Most of the other arguments passed into ``response.set_cookie()`` in ``SecureCookieSessionInterface.save_session()`` use the overridable methods of ``SessionInterface`` to fill in each argument. Except for the cookie name, which is statically set to ``app.session_cookie_name``.

Sometimes a cookie name needs to be set dynamically based on the current request, for example, a cookie name that is dependent on the current subpath in the URL. At the moment, the best way of doing this is to override the ``save_session()`` method of ``SecureCookieSessionInterface`` and make it dynamically pass in the cookie name to ``response.set_cookie()``. 

To avoid having to override the whole of ``save_session()`` this PR adds in an overridable ``get_cookie_name()`` method on ``SessionInterface`` to match the other ``get_xxx()`` methods of that class.

Note: I originally posted a question about this in Stackoverflow (_["Something like get_cookie_name in Flask's SessionInterface?"](https://stackoverflow.com/questions/55281983/something-like-get-cookie-name-in-flasks-sessioninterface)_) and also asked the question (using the Stackoverflow link) in the Flask Discord chat. I was not satisfied for the response I got, so I've opened up a PR.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
