### PR TITLE
get_cookie_name in SessionInterface for easier overriding in SecureCookieSessionInterface

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,14 @@
 .. currentmodule:: flask
 
+Version 2.0.0
+-------------
+
+Unreleased
+
+-   Add :meth:`sessions.SessionInterface.get_cookie_name` to allow
+    setting the session cookie name dynamically. :pr:`3369`
+
+
 Version 1.1.2
 -------------
 


### PR DESCRIPTION
Most of the other arguments passed into ``response.set_cookie()`` in ``SecureCookieSessionInterface.save_session()`` use the overridable methods of ``SessionInterface`` to fill in each argument. Except for the cookie name, which is statically set to ``app.session_cookie_name``.

Sometimes a cookie name needs to be set dynamically based on the current request, for example, a cookie name that is dependent on the current subpath in the URL. At the moment, the best way of doing this is to override the ``save_session()`` method of ``SecureCookieSessionInterface`` and make it dynamically pass in the cookie name to ``response.set_cookie()``. 

To avoid having to override the whole of ``save_session()``, this pull request adds in an overridable ``get_cookie_name()`` method on ``SessionInterface`` to match the other ``get_xxx()`` methods of that class.

Note: I originally posted a question about this in Stackoverflow (_["Something like get_cookie_name in Flask's SessionInterface?"](https://stackoverflow.com/questions/55281983/something-like-get-cookie-name-in-flasks-sessioninterface)_) and also asked the question (using the Stackoverflow link) in the Flask Discord chat. I was not satisfied with the response I got, so I've opened up this pull request.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
