### PR TITLE
Added escape

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -200,6 +200,9 @@ You can add variable sections to a URL by marking sections with
 as a keyword argument. Optionally, you can use a converter to specify the type
 of the argument like ``<converter:variable_name>``. ::
 
+    from flask import Flask, escape
+    app = Flask(__name__)
+    
     @app.route('/user/<username>')
     def show_user_profile(username):
         # show the user profile for that user


### PR DESCRIPTION
Example 3 (user | post | path) currently fails because 'escape' has not yet been imported. Either re-insert the import here, or add 'escape' to the original import at the top.

Describe what this patch does to fix the issue.

Link to any relevant issues or pull requests.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
