### PR TITLE
fix typo in request context docs

### DIFF
--- a/docs/reqcontext.rst
+++ b/docs/reqcontext.rst
@@ -170,8 +170,8 @@ will not fail.
 
 During testing, it can be useful to defer popping the contexts after the
 request ends, so that their data can be accessed in the test function.
-Using the :meth:`~Flask.test_client` as a ``with`` block to preserve the
-contexts until the with block exits.
+Use the :meth:`~Flask.test_client` as a ``with`` block to preserve the
+contexts until the ``with`` block exits.
 
 .. code-block:: python
 


### PR DESCRIPTION
Fixed typos I saw in the Request Context documentation.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
