### PR TITLE
Support loading configuration from toml files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
             "sphinxcontrib-log-cabinet",
             "sphinx-issues",
         ],
+        "toml": ["toml"],
     },
     entry_points={"console_scripts": ["flask = flask.cli:main"]},
 )

--- a/src/flask/config.py
+++ b/src/flask/config.py
@@ -201,6 +201,36 @@ class Config(dict):
             raise
         return self.from_mapping(obj)
 
+    def from_toml(self, filename, silent=False):
+        """Updates the values in the config from a TOML file. This function
+        behaves as if the TOML object was a dictionary and passed to the
+        :meth:`from_mapping` function.
+
+        Note: You will need to install Flask with the toml extra to use
+        this.
+
+        :param filename: the filename of the TOML file.  This can either be an
+                         absolute filename or a filename relative to the
+                         root path.
+        :param silent: set to ``True`` if you want silent failure for missing
+                       files.
+
+        .. versionadded:: 1.2
+        """
+        import toml
+
+        filename = os.path.join(self.root_path, filename)
+
+        try:
+            with open(filename) as json_file:
+                obj = toml.loads(json_file.read())
+        except IOError as e:
+            if silent and e.errno in (errno.ENOENT, errno.EISDIR):
+                return False
+            e.strerror = "Unable to load configuration file (%s)" % e.strerror
+            raise
+        return self.from_mapping(obj)
+
     def from_mapping(self, *mapping, **kwargs):
         """Updates the config like :meth:`update` ignoring items with non-upper
         keys.

--- a/tests/static/config.toml
+++ b/tests/static/config.toml
@@ -1,0 +1,2 @@
+TEST_KEY = "foo"
+SECRET_KEY = "config"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,6 +46,13 @@ def test_config_from_json():
     common_object_test(app)
 
 
+def test_config_from_toml():
+    app = flask.Flask(__name__)
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    app.config.from_toml(os.path.join(current_dir, "static", "config.toml"))
+    common_object_test(app)
+
+
 def test_config_from_mapping():
     app = flask.Flask(__name__)
     app.config.from_mapping({"SECRET_KEY": "config", "TEST_KEY": "foo"})

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     greenlet
     blinker
     python-dotenv
+    toml
 
     lowest: Werkzeug==0.15
     lowest: Jinja2==2.10


### PR DESCRIPTION
TOML is a very popular format now, and is taking hold in the Python
ecosystem via pyproject.toml (among others). This adds toml as an
extra dependency usuable if installed with the toml extra.

I've recently added similar code in [Quart](https://gitlab.com/pgjones/quart/commit/e49d4f6eeaa71f1883f52f4154bb95d9871ef4ed) and I've been using toml configs with Flask and Quart for some time now. In my view TOML has crossed a threshold of usage to warrant direct support in Flask.