### PR TITLE
Add support for decorating MethodViews with @Blueprint.route()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Unreleased
 -   Add :meth:`Config.from_file` to load config using arbitrary file
     loaders, such as ``toml.load`` or ``json.load``.
     :meth:`Config.from_json` is deprecated in favor of this. :pr:`3398`
+-   Add support for decorating :class:`~flask.views.MethodView` with
+    blueprints' :meth:`flask.blueprint.Blueprint.route` method. :issue:`3404`
 
 
 Version 1.1.2

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -136,6 +136,28 @@ That way you also don't have to provide the
 :attr:`~flask.views.View.methods` attribute.  It's automatically set based
 on the methods defined in the class.
 
+If you're using :ref:`blueprints`, you can decorate a
+:class:`~flask.views.MethodView` with the blueprint's ``@route`` decorator
+instead of manually adding the url rule to the ``app`` object. This lets you
+leverage the benefits of blueprints such as ``url_prefix``::
+
+    from flask import Blueprint
+    from flask.views import MethodView
+
+    bp = Blueprint("api", __name__, url_prefix="/api/v1")
+
+    @bp.route("/users")
+    class UserAPI(MethodView):
+
+        def get(self):
+            users = User.query.all()
+            ...
+
+        def post(self):
+            user = User.from_form_data(request.form)
+            ...
+
+
 Decorating Views
 ----------------
 

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -105,6 +105,10 @@ class Blueprint(_PackageBoundObject):
 
     See :ref:`blueprints` for more information.
 
+    ..versionchanged:: 2.0.0
+        Assed support for decorating :class:`~flask.views.MethodView` classes
+        with the :meth:`flask.blueprints.Blueprint.route` method.
+
     .. versionchanged:: 1.1.0
         Blueprints have a ``cli`` group to register nested CLI commands.
         The ``cli_group`` parameter controls the name of the group under

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -11,10 +11,9 @@
 """
 from functools import update_wrapper
 
-from .views import MethodViewType
-
 from .helpers import _endpoint_from_view_func
 from .helpers import _PackageBoundObject
+from .views import MethodViewType
 
 # a singleton sentinel value for parameter defaults
 _sentinel = object()

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -11,6 +11,8 @@
 """
 from functools import update_wrapper
 
+from .views import MethodViewType
+
 from .helpers import _endpoint_from_view_func
 from .helpers import _PackageBoundObject
 
@@ -276,6 +278,11 @@ class Blueprint(_PackageBoundObject):
 
         def decorator(f):
             endpoint = options.pop("endpoint", f.__name__)
+
+            # Support decorating MethodView classes. See Issue #3404
+            if isinstance(f, MethodViewType):
+                f = f.as_view(endpoint)
+
             self.add_url_rule(rule, endpoint, f, **options)
             return f
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -250,3 +250,23 @@ def test_remove_method_from_parent(app, client):
     assert client.get("/").data == b"GET"
     assert client.post("/").status_code == 405
     assert sorted(View.methods) == ["GET"]
+
+
+def test_methodview_with_blueprint(app, client):
+
+    from flask.blueprints import Blueprint
+
+    bp = Blueprint("test", __name__)
+
+    @bp.route("/foo")
+    class Foo(flask.views.MethodView):
+        def get(self):
+            return "GET"
+
+        def post(self):
+            return "POST"
+
+    app.register_blueprint(bp)
+    assert client.get("foo").data == b"GET"
+    assert client.get("/foo").data == b"GET"
+    assert client.post("/foo").data == b"POST"


### PR DESCRIPTION
This updates the `Blueprint.route` decorator to support decorating `MethodView` classes.

Fixes Issue #3404.

#### Comments
+ I assume this will be part of the v2.0.0 release, so that's what I used for `versionchanged` and the changelog entry. If this is incorrect please let me know.
+ I wasn't sure where to put the tests - the code changes are part of `blueprints.py` but really only effect `views`, so I put it in `view.py`.
+ Let me know what other tests should be added.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
