### PR TITLE
Change docs to use f-strings

### DIFF
--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -70,7 +70,7 @@ implement a blueprint that does simple rendering of static templates::
     @simple_page.route('/<page>')
     def show(page):
         try:
-            return render_template('pages/%s.html' % page)
+            return render_template(f'pages/{page}.html')
         except TemplateNotFound:
             abort(404)
 

--- a/docs/patterns/fabric.rst
+++ b/docs/patterns/fabric.rst
@@ -49,16 +49,16 @@ virtual environment::
     def deploy():
         # figure out the package name and version
         dist = local('python setup.py --fullname', capture=True).strip()
-        filename = '%s.tar.gz' % dist
+        filename = f'{dist}.tar.gz'
 
         # upload the package to the temporary folder on the server
-        put('dist/%s' % filename, '/tmp/%s' % filename)
+        put(f'dist/{filename}', f'/tmp/{filename}')
 
         # install the package in the application's virtualenv with pip
-        run('/var/www/yourapplication/env/bin/pip install /tmp/%s' % filename)
+        run(f'/var/www/yourapplication/env/bin/pip install /tmp/{filename}')
 
         # remove the uploaded package
-        run('rm -r /tmp/%s' % filename)
+        run(f'rm -r /tmp/{filename}')
 
         # touch the .wsgi file to trigger a reload in mod_wsgi
         run('touch /var/www/yourapplication.wsgi')

--- a/docs/patterns/sqlalchemy.rst
+++ b/docs/patterns/sqlalchemy.rst
@@ -86,7 +86,7 @@ Here is an example model (put this into :file:`models.py`, e.g.)::
             self.email = email
 
         def __repr__(self):
-            return '<User %r>' % (self.name)
+            return f'<User {self.name!r}>'
 
 To create the database you can use the `init_db` function:
 
@@ -159,7 +159,7 @@ Here is an example table and model (put this into :file:`models.py`)::
             self.email = email
 
         def __repr__(self):
-            return '<User %r>' % (self.name)
+            return f'<User {self.name!r}>'
 
     users = Table('users', metadata,
         Column('id', Integer, primary_key=True),

--- a/docs/patterns/viewdecorators.rst
+++ b/docs/patterns/viewdecorators.rst
@@ -82,11 +82,11 @@ Here the code::
     from functools import wraps
     from flask import request
 
-    def cached(timeout=5 * 60, key='view/%s'):
+    def cached(timeout=5 * 60, key='view/{}'):
         def decorator(f):
             @wraps(f)
             def decorated_function(*args, **kwargs):
-                cache_key = key % request.path
+                cache_key = key.format(request.path)
                 rv = cache.get(cache_key)
                 if rv is not None:
                     return rv

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -179,7 +179,7 @@ With Blinker 1.1 you can also easily subscribe to signals by using the new
 
     @template_rendered.connect_via(app)
     def when_template_rendered(sender, template, context, **extra):
-        print 'Template %s is rendered with %s' % (template.name, context)
+        print f'Template {template.name} is rendered with {context}'
 
 Core Signals
 ------------

--- a/docs/styleguide.rst
+++ b/docs/styleguide.rst
@@ -51,11 +51,11 @@ Blank lines:
   segments in code.  Example::
 
     def hello(name):
-        print 'Hello %s!' % name
+        print f'Hello {name}!'
 
 
     def goodbye(name):
-        print 'See you %s.' % name
+        print f'See you {name}.'
 
 
     class MyClass(object):

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -231,7 +231,7 @@ registration code::
         app.add_url_rule(url, defaults={pk: None},
                          view_func=view_func, methods=['GET',])
         app.add_url_rule(url, view_func=view_func, methods=['POST',])
-        app.add_url_rule('%s<%s:%s>' % (url, pk_type, pk), view_func=view_func,
+        app.add_url_rule(f'{url}<{pk_type}:{pk}>', view_func=view_func,
                          methods=['GET', 'PUT', 'DELETE'])
 
     register_api(UserAPI, 'user_api', '/users/', pk='user_id')


### PR DESCRIPTION
I noticed old printf style string formatting in quite a few places in the documentation.
When I cloned to fix the quick start guide, I noticed it was already changed to f-strings style formatting in quickstart so I changed the rest too. 