### PR TITLE
Make the documentation build reproducibly

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -31,6 +31,7 @@ Incoming Request Data
 .. autoclass:: Request
    :members:
    :inherited-members:
+   :exclude-members: json_module
 
    .. attribute:: environ
 


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort we noticed that flask could not be built reproducibly.

This is because it includes an absolute build directory in the documentation as the `json_module` attribute points to a Python class/module which has a string representation including its path.

This commit skips this (inherited) member from the documentation.

(This was originally filed in Debian as [#943674](https://bugs.debian.org/943674).)