### PR TITLE
Update `versionadded` for `Config.from_file`

### DIFF
--- a/src/flask/config.py
+++ b/src/flask/config.py
@@ -194,7 +194,7 @@ class Config(dict):
             implements a ``read`` method.
         :param silent: Ignore the file if it doesn't exist.
 
-        .. versionadded:: 1.2
+        .. versionadded:: 2.0
         """
         filename = os.path.join(self.root_path, filename)
 


### PR DESCRIPTION
According to the change log at https://github.com/pallets/flask/blob/master/CHANGES.rst, the release `Config.from_file` will be published with is now 2.0.0 rather than 1.2.0.
