### PR TITLE
Fix: update a URL to the newest version

### DIFF
--- a/src/flask/debughelpers.py
+++ b/src/flask/debughelpers.py
@@ -164,7 +164,7 @@ def explain_template_loading_attempts(app, template, attempts):
             'belongs to the blueprint "%s".' % blueprint
         )
         info.append("  Maybe you did not place a template in the right folder?")
-        info.append("  See http://flask.pocoo.org/docs/blueprints/#templates")
+        info.append("  See https://flask.palletsprojects.com/en/1.1.x/tutorial/views/")
 
     app.logger.info("\n".join(info))
 

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -426,7 +426,7 @@ def test_template_loader_debugging(test_apps, monkeypatch):
             assert (
                 "looked up from an endpoint that belongs to " 'the blueprint "frontend"'
             ) in text
-            assert "See http://flask.pocoo.org/docs/blueprints/#templates" in text
+            assert "See https://flask.palletsprojects.com/en/1.1.x/tutorial/views/" in text
 
     with app.test_client() as c:
         monkeypatch.setitem(app.config, "EXPLAIN_TEMPLATE_LOADING", True)


### PR DESCRIPTION
Link now goes to `palletsprojects.com` instead of `pocoo.org`