### PR TITLE
send_file doesn't allow StringIO

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ Unreleased
 -   The ``flask run`` command will only defer errors on reload. Errors
     present during the initial call will cause the server to exit with
     the traceback immediately. :issue:`3431`
+-   :func:`send_file` raises a :exc:`ValueError` when passed an
+    :mod:`io` object in text mode. Previously, it would respond with
+    200 OK and an empty file. :issue:`3358`
 
 
 Version 1.1.2

--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -489,6 +489,11 @@ def send_file(
     guessing requires a `filename` or an `attachment_filename` to be
     provided.
 
+    When passing a file-like object instead of a filename, only binary
+    mode is supported (``open(filename, "rb")``, :class:`~io.BytesIO`,
+    etc.). Text mode files and :class:`~io.StringIO` will raise a
+    :exc:`ValueError`.
+
     ETags will also be attached automatically if a `filename` is provided. You
     can turn this off by setting `add_etags=False`.
 
@@ -499,53 +504,56 @@ def send_file(
     Please never pass filenames to this function from user sources;
     you should use :func:`send_from_directory` instead.
 
-    .. versionadded:: 0.2
+    .. versionchanged:: 2.0
+        Passing a file-like object that inherits from
+        :class:`~io.TextIOBase` will raise a :exc:`ValueError` rather
+        than sending an empty file.
 
-    .. versionadded:: 0.5
-       The `add_etags`, `cache_timeout` and `conditional` parameters were
-       added.  The default behavior is now to attach etags.
+    .. versionchanged:: 1.1
+        ``filename`` may be a :class:`~os.PathLike` object.
 
-    .. versionchanged:: 0.7
-       mimetype guessing and etag support for file objects was
-       deprecated because it was unreliable.  Pass a filename if you are
-       able to, otherwise attach an etag yourself.  This functionality
-       will be removed in Flask 1.0
+    .. versionchanged:: 1.1
+        Passing a :class:`~io.BytesIO` object supports range requests.
 
-    .. versionchanged:: 0.9
-       cache_timeout pulls its default from application config, when None.
-
-    .. versionchanged:: 0.12
-       The filename is no longer automatically inferred from file objects. If
-       you want to use automatic mimetype and etag support, pass a filepath via
-       `filename_or_fp` or `attachment_filename`.
-
-    .. versionchanged:: 0.12
-       The `attachment_filename` is preferred over `filename` for MIME-type
-       detection.
+    .. versionchanged:: 1.0.3
+        Filenames are encoded with ASCII instead of Latin-1 for broader
+        compatibility with WSGI servers.
 
     .. versionchanged:: 1.0
         UTF-8 filenames, as specified in `RFC 2231`_, are supported.
 
     .. _RFC 2231: https://tools.ietf.org/html/rfc2231#section-4
 
-    .. versionchanged:: 1.0.3
-        Filenames are encoded with ASCII instead of Latin-1 for broader
-        compatibility with WSGI servers.
+    .. versionchanged:: 0.12
+       The filename is no longer automatically inferred from file
+       objects. If you want to use automatic MIME and etag support, pass
+       a filename via ``filename_or_fp`` or ``attachment_filename``.
 
-    .. versionchanged:: 1.1
-        Filename may be a :class:`~os.PathLike` object.
+    .. versionchanged:: 0.12
+       ``attachment_filename`` is preferred over ``filename`` for MIME
+       detection.
 
-    .. versionadded:: 1.1
-        Partial content supports :class:`~io.BytesIO`.
+    .. versionchanged:: 0.9
+       ``cache_timeout`` defaults to
+       :meth:`Flask.get_send_file_max_age`.
 
-    :param filename_or_fp: the filename of the file to send.
-                           This is relative to the :attr:`~Flask.root_path`
-                           if a relative path is specified.
-                           Alternatively a file object might be provided in
-                           which case ``X-Sendfile`` might not work and fall
-                           back to the traditional method.  Make sure that the
-                           file pointer is positioned at the start of data to
-                           send before calling :func:`send_file`.
+    .. versionchanged:: 0.7
+       MIME guessing and etag support for file-like objects was
+       deprecated because it was unreliable. Pass a filename if you are
+       able to, otherwise attach an etag yourself. This functionality
+       will be removed in Flask 1.0.
+
+    .. versionadded:: 0.5
+       The ``add_etags``, ``cache_timeout`` and ``conditional``
+       parameters were added. The default behavior is to add etags.
+
+    .. versionadded:: 0.2
+
+    :param filename_or_fp: The filename of the file to send, relative to
+        :attr:`~Flask.root_path` if a relative path is specified.
+        Alternatively, a file-like object opened in binary mode. Make
+        sure the file pointer is seeked to the start of the data.
+        ``X-Sendfile`` will only be used with filenames.
     :param mimetype: the mimetype of the file if provided. If a file path is
                      given, auto detection happens as fallback, otherwise an
                      error will be raised.
@@ -620,24 +628,28 @@ def send_file(
     if current_app.use_x_sendfile and filename:
         if file is not None:
             file.close()
+
         headers["X-Sendfile"] = filename
         fsize = os.path.getsize(filename)
-        headers["Content-Length"] = fsize
         data = None
     else:
         if file is None:
             file = open(filename, "rb")
             mtime = os.path.getmtime(filename)
             fsize = os.path.getsize(filename)
-            headers["Content-Length"] = fsize
         elif isinstance(file, io.BytesIO):
             try:
                 fsize = file.getbuffer().nbytes
             except AttributeError:
                 # Python 2 doesn't have getbuffer
                 fsize = len(file.getvalue())
-            headers["Content-Length"] = fsize
+        elif isinstance(file, io.TextIOBase):
+            raise ValueError("Files must be opened in binary mode or use BytesIO.")
+
         data = wrap_file(request.environ, file)
+
+    if fsize is not None:
+        headers["Content-Length"] = fsize
 
     rv = current_app.response_class(
         data, mimetype=mimetype, headers=headers, direct_passthrough=True


### PR DESCRIPTION
fixes #3358 

Due to the way `send_file` works, passing a text mode file-like object, such as `io.StringIO` in Python 3, would respond with 200 OK and an empty file, while printing a traceback to the terminal. Even in Python 2, this only worked by accident, and would probably fail if given a `StringIO.StringIO` object with Unicode data that did not encode with the system encoding. It appears `send_file` was only intended to work with binary mode data.

Now, if the object is an instance of `io.TextIOBase` it raises a `ValueError`. This doesn't help for file-like objects that don't use the `io` ABCs (including Python 2), but it should cover most cases.