### PR TITLE
simplify the way we get subdomain and url_prefix at blueprints

### DIFF
--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -42,20 +42,13 @@ class BlueprintSetupState(object):
         #: out if the blueprint was registered in the past already.
         self.first_registration = first_registration
 
-        subdomain = self.options.get("subdomain")
-        if subdomain is None:
-            subdomain = self.blueprint.subdomain
-
         #: The subdomain that the blueprint should be active for, ``None``
         #: otherwise.
-        self.subdomain = subdomain
+        self.subdomain = self.options.get("subdomain") or self.blueprint.subdomain
 
-        url_prefix = self.options.get("url_prefix")
-        if url_prefix is None:
-            url_prefix = self.blueprint.url_prefix
         #: The prefix that should be used for all URLs defined on the
         #: blueprint.
-        self.url_prefix = url_prefix
+        self.url_prefix = self.options.get("url_prefix") or self.blueprint.url_prefix
 
         #: A dictionary with URL defaults that is added to each and every
         #: URL that was defined with the blueprint.


### PR DESCRIPTION
Here is an subtle improvement of simplifying the way we get `subdomain` and `url_prefix` at `blueprints.py`

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
