### PR TITLE
Fix a bug that the static endpoint will unexpectedly catch all

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 
 -   Work around an issue when running the ``flask`` command with an
     external debugger on Windows. :issue:`3297`
+-   The static route will not catch all URLs if the ``Flask``
+    ``static_folder`` argument ends with a slash. :issue:`3452`
 
 
 Version 1.1.1

--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -1000,6 +1000,8 @@ class _PackageBoundObject(object):
 
     @static_folder.setter
     def static_folder(self, value):
+        if value is not None:
+            value = value.rstrip("/\\")
         self._static_folder = value
 
     @property
@@ -1013,7 +1015,7 @@ class _PackageBoundObject(object):
             return self._static_url_path
 
         if self.static_folder is not None:
-            basename = os.path.basename(self.static_folder.rstrip("/"))
+            basename = os.path.basename(self.static_folder)
             return ("/" + basename).rstrip("/")
 
     @static_url_path.setter

--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -1013,7 +1013,7 @@ class _PackageBoundObject(object):
             return self._static_url_path
 
         if self.static_folder is not None:
-            basename = os.path.basename(self.static_folder)
+            basename = os.path.basename(self.static_folder.rstrip("/"))
             return ("/" + basename).rstrip("/")
 
     @static_url_path.setter

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1425,6 +1425,17 @@ def test_static_url_empty_path_default(app):
     rv.close()
 
 
+def test_static_folder_with_ending_slash():
+    app = flask.Flask(__name__, static_folder="static/")
+
+    @app.route("/<path:path>")
+    def catch_all(path):
+        return path
+
+    rv = app.test_client().get("/catch/all")
+    assert rv.data == b"catch/all"
+
+
 def test_static_route_with_host_matching():
     app = flask.Flask(__name__, host_matching=True, static_host="example.com")
     c = app.test_client()


### PR DESCRIPTION
Fixes #3452

Strip the ending slash when passed to `os.path.basename`, so that the last part can be used for static url path correctly.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
