### PR TITLE
Fix app.run() when port is not specified and `SERVER_NAME` contains only host name

### DIFF
--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -962,6 +962,7 @@ class Flask(_PackageBoundObject):
 
         _host = "127.0.0.1"
         _port = 5000
+
         server_name = self.config.get("SERVER_NAME")
         sn_host, sn_port = None, None
 
@@ -969,8 +970,9 @@ class Flask(_PackageBoundObject):
             sn_host, _, sn_port = server_name.partition(":")
 
         host = host or sn_host or _host
+
         # pick the first value that's not None (0 is allowed)
-        port = int(next((p for p in (port, sn_port) if p is not None), _port))
+        port = port if port is not None else int(sn_port) if sn_port else _port
 
         options.setdefault("use_reloader", self.debug)
         options.setdefault("use_debugger", self.debug)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1923,6 +1923,8 @@ def test_run_server_port(monkeypatch, app):
         ("localhost", 0, "localhost:8080", "localhost", 0),
         (None, None, "localhost:8080", "localhost", 8080),
         (None, None, "localhost:0", "localhost", 0),
+        (None, None, "localhost", "localhost", 5000),
+        (None, None, None, "127.0.0.1", 5000),
     ),
 )
 def test_run_from_config(


### PR DESCRIPTION
Fix app.run() when port is not specified and `SERVER_NAME` contains only host name
Fixes #3457

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
