### PR TITLE
static_folder and static_url_path can be different

### DIFF
--- a/docs/patterns/singlepageapplications.rst
+++ b/docs/patterns/singlepageapplications.rst
@@ -10,7 +10,7 @@ The following example demonstrates how to serve an SPA along with an API::
 
     from flask import Flask, jsonify
 
-    app = Flask(__name__, static_folder='app')
+    app = Flask(__name__, static_folder='app', static_url_path="/app")
 
 
     @app.route("/heartbeat")


### PR DESCRIPTION
It's confusing when not adding the `static_url_path` to `Flask` Class.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
