### PR TITLE
Incorrect grammar

### DIFF
--- a/docs/reqcontext.rst
+++ b/docs/reqcontext.rst
@@ -256,8 +256,9 @@ exceptions where it is good to know that this object is actually a proxy:
 -   The proxy objects cannot fake their type as the actual object types.
     If you want to perform instance checks, you have to do that on the
     object being proxied.
--   If the specific object reference is important, for example for
-    sending :ref:`signals` or passing data to a background thread.
+-   The reference to the proxied object is needed in some situations,
+    such as sending :ref:`signals` or passing data to a background
+    thread.
 
 If you need to access the underlying object that is proxied, use the
 :meth:`~werkzeug.local.LocalProxy._get_current_object` method::


### PR DESCRIPTION
The original sentence has incorrect grammar. The change corrects the grammar error and expresses the intended meaning better

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
