### PR TITLE
Forces specific version of Werkzeug to prevent breaking Flask

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     include_package_data=True,
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     install_requires=[
-        "Werkzeug>=0.15",
+        "Werkzeug==0.16",
         "Jinja2>=2.10.1",
         "itsdangerous>=0.24",
         "click>=5.1",


### PR DESCRIPTION
Fixes #3486 

Werkzeug released a new major version. Flasks does not protect the Werkzeug dependency for major releases with breaking changes. This should force to use a version of Werkzeug that does not break Flask before adapting the code of Flask to use the new version of Werkzeug.