### PR TITLE
Disallow werkzeug>=1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     include_package_data=True,
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     install_requires=[
-        "Werkzeug>=0.15",
+        "Werkzeug~=0.15",
         "Jinja2>=2.10.1",
         "itsdangerous>=0.24",
         "click>=5.1",


### PR DESCRIPTION
Due to depracation of top level imports (https://github.com/pallets/werkzeug/commit/08536c457c7125c05e0947e62487fbc4bcf51717), e.g. `from werkzeug import secure_filename` won't work anymore:

```
File "/usr/local/lib/python3.7/site-packages/flask_admin/model/__init__.py", line 2, in <module>
from .base import BaseModelView
File "/usr/local/lib/python3.7/site-packages/flask_admin/model/base.py", line 8, in <module>
from werkzeug import secure_filename
ImportError: cannot import name 'secure_filename' from 'werkzeug' (/usr/local/lib/python3.7/site-packages/werkzeug/__init__.py)
```

Since werkzeug has just been released, it's safe to pin here until flask has been thoroughly tested with werkzeug 1.0.0.
<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
