### PR TITLE
CLI checks for cryptography library

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Unreleased
 -   :func:`send_file` raises a :exc:`ValueError` when passed an
     :mod:`io` object in text mode. Previously, it would respond with
     200 OK and an empty file. :issue:`3358`
+-   When using ad-hoc certificates, check for the cryptography library
+    instead of PyOpenSSL. :pr:`3492`
 
 
 Version 1.1.2

--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -713,10 +713,12 @@ class CertParamType(click.ParamType):
 
             if value == "adhoc":
                 try:
-                    import OpenSSL  # noqa: F401
+                    import cryptography  # noqa: F401
                 except ImportError:
                     raise click.BadParameter(
-                        "Using ad-hoc certificates requires pyOpenSSL.", ctx, param
+                        "Using ad-hoc certificates requires the cryptography library.",
+                        ctx,
+                        param,
                     )
 
                 return value
@@ -743,7 +745,7 @@ def _validate_key(ctx, param, value):
     if sys.version_info < (2, 7, 9):
         is_context = cert and not isinstance(cert, (text_type, bytes))
     else:
-        is_context = isinstance(cert, ssl.SSLContext)
+        is_context = ssl and isinstance(cert, ssl.SSLContext)
 
     if value is not None:
         if is_adhoc:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -566,14 +566,14 @@ def test_run_cert_path():
 
 
 def test_run_cert_adhoc(monkeypatch):
-    monkeypatch.setitem(sys.modules, "OpenSSL", None)
+    monkeypatch.setitem(sys.modules, "cryptography", None)
 
-    # pyOpenSSL not installed
+    # cryptography not installed
     with pytest.raises(click.BadParameter):
         run_command.make_context("run", ["--cert", "adhoc"])
 
-    # pyOpenSSL installed
-    monkeypatch.setitem(sys.modules, "OpenSSL", types.ModuleType("OpenSSL"))
+    # cryptography installed
+    monkeypatch.setitem(sys.modules, "cryptography", types.ModuleType("cryptography"))
     ctx = run_command.make_context("run", ["--cert", "adhoc"])
     assert ctx.params["cert"] == "adhoc"
 


### PR DESCRIPTION
The check was already happening in Werkzeug, this updates the Flask CLI so it doesn't require PyOpenSS.