### PR TITLE
Add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ _mailinglist
 .pytest_cache/
 .idea/
 docs/_build/
+.vscode
 
 # Coverage reports
 htmlcov/


### PR DESCRIPTION
Adds '.vscode' to .gitignore file.  This will prevent contributors using vscode from accidentally including this directory in their PRs.