### PR TITLE
View returned none exception contains endpoint name

### DIFF
--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -2078,9 +2078,9 @@ class Flask(_PackageBoundObject):
         # the body must not be None
         if rv is None:
             raise TypeError(
-                "The view function did not return a valid response. The"
+                'The view function for "{}" did not return a valid response. The'
                 " function either returned None or ended without a return"
-                " statement."
+                " statement.".format(request.endpoint)
             )
 
         # make sure the body is an instance of the response class

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1221,6 +1221,7 @@ def test_response_type_errors():
     with pytest.raises(TypeError) as e:
         c.get("/none")
         assert "returned None" in str(e.value)
+        assert "from_none" in str(e.value)
 
     with pytest.raises(TypeError) as e:
         c.get("/small_tuple")


### PR DESCRIPTION
Describe what this patch does to fix the issue.
Adds request.endpoint to the error message. 

Link to any relevant issues or pull requests.
fixes https://github.com/pallets/flask/issues/3445

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
