### PR TITLE
Fix property name in description

### DIFF
--- a/docs/errorhandling.rst
+++ b/docs/errorhandling.rst
@@ -210,7 +210,7 @@ behavior.
 If there is an error handler registered for ``InternalServerError``,
 this will be invoked. As of Flask 1.1.0, this error handler will always
 be passed an instance of ``InternalServerError``, not the original
-unhandled error. The original error is available as ``e.original_error``.
+unhandled error. The original error is available as ``e.original_exception``.
 Until Werkzeug 1.0.0, this attribute will only exist during unhandled
 errors, use ``getattr`` to get access it for compatibility.
 


### PR DESCRIPTION
Previously, the description referred to a property named `original_error`. However, both the code sample that followed it _and_ the Werkzeug documentation refer to it as `original_exception` instead.

In this commit, I change the description to use the same property name as is used in the code sample and the Werkzeug documentation.

Here's a link to the Werkzeug documentation of that property:
- https://werkzeug.palletsprojects.com/en/1.0.x/exceptions/#werkzeug.exceptions.InternalServerError.original_exception

Fixes https://github.com/pallets/flask/issues/3520

Thanks, @davidism, for referring me to the relevant section of the Werkzeug docs. 

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
