### PR TITLE
Remove deprecated `license_file` option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[metadata]
-license_file = LICENSE.rst
-
 [bdist_wheel]
 universal = true
 


### PR DESCRIPTION
Starting with wheel 0.32.0 (2018-09-29), the `license_file` option is
deprecated in favor of `license_files`.

https://wheel.readthedocs.io/en/stable/news.html

The wheel will continue to include `LICENSE`, it is now included
automatically:

https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file

See https://github.com/FactoryBoy/factory_boy/pull/696 for inspiration and more discussion.

Describe what this patch does to fix the issue.

Link to any relevant issues or pull requests.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
