### PR TITLE
Missing slash in app route

### DIFF
--- a/docs/tutorial/factory.rst
+++ b/docs/tutorial/factory.rst
@@ -62,7 +62,7 @@ directory should be treated as a package.
             pass
 
         # a simple page that says hello
-        @app.route('/hello')
+        @app.route('/hello/')
         def hello():
             return 'Hello, World!'
 


### PR DESCRIPTION
The missing `/` in the `@app.route('/hello')` statement makes the example raise a 404 when accessing the page. To fix it I just added it to the `route`.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
