### PR TITLE
Stop change CWD to .env/.flaskenv location

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ Unreleased
     instead of PyOpenSSL. :pr:`3492`
 -   When specifying a factory function with ``FLASK_APP``, keyword
     argument can be passed. :issue:`3553`
+-   When loading a ``.env`` or ``.flaskenv`` file on top level directory,
+    Flask will not change current work directory to the location of dotenv
+    files, in order to prevent potential confusion. :pr:`3560`
 
 
 Version 1.1.2

--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -610,10 +610,6 @@ def load_dotenv(path=None):
     If an env var is already set it is not overwritten, so earlier files in the
     list are preferred over later files.
 
-    Changes the current working directory to the location of the first file
-    found, with the assumption that it is in the top level project directory
-    and will be where the Python path should import local packages from.
-
     This is a no-op if `python-dotenv`_ is not installed.
 
     .. _python-dotenv: https://github.com/theskumar/python-dotenv#readme
@@ -658,9 +654,6 @@ def load_dotenv(path=None):
             new_dir = os.path.dirname(path)
 
         dotenv.load_dotenv(path)
-
-    if new_dir and os.getcwd() != new_dir:
-        os.chdir(new_dir)
 
     return new_dir is not None  # at least one file was located and loaded
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -504,7 +504,7 @@ def test_load_dotenv(monkeypatch):
         monkeypatch._setitem.append((os.environ, item, notset))
 
     monkeypatch.setenv("EGGS", "3")
-    monkeypatch.chdir(os.path.join(test_path, "cliapp", "inner1"))
+    monkeypatch.chdir(test_path)
     assert load_dotenv()
     assert os.getcwd() == test_path
     # .flaskenv doesn't overwrite .env


### PR DESCRIPTION
By [the current implementation](https://github.com/pallets/flask/blob/master/src/flask/cli.py#L630), if `.env` or `.flaskenv` was found in the top-level directory, Flask will change the current work directory to the directory that contains the `.env` or `.flaskenv` file. 

When the user accidentally put a `.env` or `.flaskenv` in the top-level directory, then executing `flask run` in the current directory (contains `app.py`) will throw out NoAppException.

See more in #3561.