### PR TITLE
use ast to parse FLASK_APP

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ Unreleased
     200 OK and an empty file. :issue:`3358`
 -   When using ad-hoc certificates, check for the cryptography library
     instead of PyOpenSSL. :pr:`3492`
+-   When specifying a factory function with ``FLASK_APP``, keyword
+    argument can be passed. :issue:`3553`
 
 
 Version 1.1.2

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -76,8 +76,8 @@ found, the command looks for a factory function named ``create_app`` or
 ``make_app`` that returns an instance.
 
 If parentheses follow the factory name, their contents are parsed as
-Python literals and passed as arguments to the function. This means that
-strings must still be in quotes.
+Python literals and passed as arguments and keyword arguments to the
+function. This means that strings must still be in quotes.
 
 
 Run the Development Server

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -203,7 +203,6 @@ def test_prepare_import(request, value, path, result):
         ("cliapp.factory", None, "app"),
         ("cliapp.factory", "create_app", "app"),
         ("cliapp.factory", "create_app()", "app"),
-        # no script_info
         ("cliapp.factory", 'create_app2("foo", "bar")', "app2_foo_bar"),
         # trailing comma space
         ("cliapp.factory", 'create_app2("foo", "bar", )', "app2_foo_bar"),


### PR DESCRIPTION
This had the nice side effect of parsing keyword arguments too. Refactored `call_factory` to use `inspect.signature`, even though it will go away in 2.1 because it was easier to figure out the args and kwargs checks.

closes #3553