### PR TITLE
Fix flake8 repo url in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://gitlab.com/pycqa/flake8.git
     rev: 3.7.9
     hooks:
       - id: flake8


### PR DESCRIPTION
When using git version `1.8.3.1`, users cannot use .git-less remote URLs for cloning on gitlab, which will cause failure on pre-commit tool initialization.

Reproduce environment:
CentOS Linux release 7.6.1810 (Core)
git version 1.8.3.1

Logs while running `pre-commit run --all-file` in a newly cloned flask project:
```
[INFO] Initializing environment for https://gitlab.com/pycqa/flake8.
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags')
return code: 128
expected return code: 0
stdout: (none)
stderr:
    error: RPC failed; result=22, HTTP code = 404
    fatal: The remote end hung up unexpectedly

Check the log at /home/magine/.cache/pre-commit/pre-commit.log
```

See also:
https://gitlab.com/gitlab-org/gitlab/issues/29629