### PR TITLE
Adding error message to an assert

### DIFF
--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1270,7 +1270,9 @@ class Flask(_PackageBoundObject):
         else:
             exc_class = exc_class_or_code
 
-        assert issubclass(exc_class, Exception)
+        assert issubclass(
+            exc_class, Exception
+        ), "Custom exceptions must be subclasses of Exception."
 
         if issubclass(exc_class, HTTPException):
             return exc_class, exc_class.code

--- a/tests/test_user_error_handler.py
+++ b/tests/test_user_error_handler.py
@@ -11,10 +11,18 @@ def test_error_handler_no_match(app, client):
     class CustomException(Exception):
         pass
 
+    class UnacceptableCustomException(BaseException):
+        pass
+
     @app.errorhandler(CustomException)
     def custom_exception_handler(e):
         assert isinstance(e, CustomException)
         return "custom"
+
+    with pytest.raises(
+        AssertionError, match="Custom exceptions must be subclasses of Exception."
+    ):
+        app.register_error_handler(UnacceptableCustomException, None)
 
     @app.errorhandler(500)
     def handle_500(e):


### PR DESCRIPTION
Adding an error message to an assertion that I have experienced on two separate occasions, that all custom exceptions must inherit from the builtin Exception class.

This PR will throw the new message to those who decide to create exceptions that aren't subclasses of Exception, e.g. BaseException