### PR TITLE
Officially support using pathlib.Path for static_folder.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,15 @@ Unreleased
     argument can be passed. :issue:`3553`
 
 
+Version 1.1.x
+-------------
+
+Not yet released.
+
+-   Officially support passing a :class:`pathlib.Path` for
+    ``static_folder`` which stopped working in 1.1.2. :pr:`3579`
+
+
 Version 1.1.2
 -------------
 

--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -980,7 +980,7 @@ class _PackageBoundObject:
     @static_folder.setter
     def static_folder(self, value):
         if value is not None:
-            value = value.rstrip("/\\")
+            value = os.fspath(value).rstrip(r"\/")
         self._static_folder = value
 
     @property

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1406,6 +1406,16 @@ def test_static_url_empty_path_default(app):
     rv.close()
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires Python >= 3.6")
+def test_static_folder_with_pathlib_path(app):
+    from pathlib import Path
+
+    app = flask.Flask(__name__, static_folder=Path("static"))
+    rv = app.test_client().open("/static/index.html", method="GET")
+    assert rv.status_code == 200
+    rv.close()
+
+
 def test_static_folder_with_ending_slash():
     app = flask.Flask(__name__, static_folder="static/")
 


### PR DESCRIPTION
* No longer causes `AttributeError: 'PosixPath' object has no attribute 'rstrip'`.

* This was broken by e6178fe489b7828acc2bb8fd4b56a70b11ab6c6a which was released in 1.1.2.

* Add a regression test that now passes.

See #3557.

(That issue was repurposed for migrating to pathlib internally, which this PR does not resolve. Merely officially supporting Paths for `static_folder` need not require that.)  

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
