### PR TITLE
Missing Flask module import and Flask app variable

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -368,7 +368,9 @@ method.  All you have to do is provide the name of the template and the
 variables you want to pass to the template engine as keyword arguments.
 Here's a simple example of how to render a template::
 
-    from flask import render_template
+    from flask import Flask, render_template
+
+    app = Flask(__name__)
 
     @app.route('/hello/')
     @app.route('/hello/<name>')

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -323,7 +323,9 @@ a route only answers to ``GET`` requests. You can use the ``methods`` argument
 of the :meth:`~flask.Flask.route` decorator to handle different HTTP methods.
 ::
 
-    from flask import request
+    from flask import Flask, request
+
+    app = Flask(__name__)
 
     @app.route('/login', methods=['GET', 'POST'])
     def login():


### PR DESCRIPTION
Describe what this patch does to fix the issue.
Flask module is not imported in the example and app of Flask object is not instantiated

Link to any relevant issues or pull requests.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
