### PR TITLE
Add support for gzip compression on json outputs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,8 @@ Unreleased
     instead of PyOpenSSL. :pr:`3492`
 -   When specifying a factory function with ``FLASK_APP``, keyword
     argument can be passed. :issue:`3553`
-
+-   Add :func:`~flask.json.gzonify` to support gzip compression for better web
+    performance (less size and time). Works like :func:`~flask.json.jsonify`.
 
 Version 1.1.2
 -------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -275,6 +275,8 @@ inside ``script`` tags.
 
 .. autofunction:: jsonify
 
+.. autofunction:: gzonify
+
 .. autofunction:: dumps
 
 .. autofunction:: dump

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -776,6 +776,19 @@ more complex applications.
         users = get_all_users()
         return jsonify([user.to_json() for user in users])
 
+Sometimes you want to optimze the output of your JSON responses. In that case
+use the :func:`~flask.json.gzonify` function, which works like
+:func:`~flask.json.jsonify` function but add support for gzip compression.
+Optimizing the response (size and time) for large responses.
+
+.. code-block:: python
+
+    from flask import gzonify
+
+    @app.route("/users")
+    def users_api():
+        users = get_all_users()
+        return gzonify([user.to_json() for user in users])
 
 .. _sessions:
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -318,6 +318,20 @@ And then to use it::
             data = json.loads(resp.data)
             self.assert_equal(data['username'], my_user.username)
 
+or::
+
+    from gzip import decompress as gzip_decompress
+    from flask import json, gzonify
+
+    @app.route('/users/me')
+    def users_me():
+        return gzonify(username=g.user.username)
+
+    with user_set(app, my_user):
+        with app.test_client() as c:
+            resp = c.get('/users/me')
+            data = json.loads(gzip_decompress(resp.data))
+            self.assert_equal(data['username'], my_user.username)
 
 Keeping the Context Around
 --------------------------

--- a/src/flask/__init__.py
+++ b/src/flask/__init__.py
@@ -28,6 +28,7 @@ from .helpers import send_file
 from .helpers import send_from_directory
 from .helpers import stream_with_context
 from .helpers import url_for
+from .json import gzonify
 from .json import jsonify
 from .signals import appcontext_popped
 from .signals import appcontext_pushed

--- a/src/flask/json/__init__.py
+++ b/src/flask/json/__init__.py
@@ -339,9 +339,9 @@ def jsonify(*args, **kwargs):
 
 
 def gzonify(*args, **kwargs):
-    """Works like jsonify but with support of gzip compression.
-    The Content-Encoding: `gzip` is added to :class:`~flask.Response`
-    to enable gzip compression.
+    """Works like :func:`~flask.json.jsonify` function but with support
+    of gzip compression. The `Content-Encoding: gzip` is added to the
+    :class:`~flask.Response` to enable gzip compression.
 
     .. code-block:: python
 
@@ -364,6 +364,8 @@ def gzonify(*args, **kwargs):
           "email": "admin@localhost",
           "id": 42
         }
+
+    .. versionadded:: 2.0
     """
     indent = None
     separators = (",", ":")

--- a/src/flask/json/__init__.py
+++ b/src/flask/json/__init__.py
@@ -374,7 +374,7 @@ def gzonify(*args, **kwargs):
         separators = (", ", ": ")
 
     if args and kwargs:
-        raise TypeError("jsonify() behavior undefined when passed both args and kwargs")
+        raise TypeError("gzonify() behavior undefined when passed both args and kwargs")
     elif len(args) == 1:  # single args are passed directly to dumps()
         data = args[0]
     else:

--- a/src/flask/json/__init__.py
+++ b/src/flask/json/__init__.py
@@ -358,7 +358,6 @@ def gzonify(*args, **kwargs):
     Will return a JSON response like this but with gzip compression:
 
     .. code-block:: javascript
-        // Content-Encoding: gzip
 
         {
           "username": "admin",

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1331,6 +1331,12 @@ def test_jsonify_args_and_kwargs_check(app, req_ctx):
     assert "behavior undefined" in str(e.value)
 
 
+def test_gzonify_args_and_kwargs_check(app, req_ctx):
+    with pytest.raises(TypeError) as e:
+        flask.gzonify("fake args", kwargs="fake")
+    assert "behavior undefined" in str(e.value)
+
+
 def test_url_generation(app, req_ctx):
     @app.route("/hello/<name>", methods=["POST"])
     def hello():


### PR DESCRIPTION
This PR add support for gzip compression on json outputs for large responses compression. Instead of modify the current method for json outputs `flask.json.jsonify`, I created new method called `flask.json.gzonify` with the simple purpose of optimize the size and time of the response for large json responses.

Note: You can find a demo on: https://repl.it/@danilobrinu/flask-jsonify-support-compresion, just click on `Run` button and access to the respective endpoints.  https://honestweepysoftwareagent.danilobrinu.repl.co/without-compression and https://honestweepysoftwareagent.danilobrinu.repl.co/with-compression . Don't forget open the **devtools** and go to the **Network Tab** to select the **Fast 3G** option.

**Without Compression**
![image](https://user-images.githubusercontent.com/1697714/80048133-ea79b780-84d4-11ea-8ce2-e9d78a2e1f1e.png)

**With Compression**
![image](https://user-images.githubusercontent.com/1697714/80048185-0ed59400-84d5-11ea-97f2-b45fc1d4548e.png)

>  **Network - Fast 3G**: We can optimize the size and time: From 160kb and 1.42s to 540B and 176ms