### PR TITLE
Add support for IPython shell when using `flask shell`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,9 @@ Unreleased
     instead of PyOpenSSL. :pr:`3492`
 -   When specifying a factory function with ``FLASK_APP``, keyword
     argument can be passed. :issue:`3553`
-
+-   Add support for a ``-i / --interface`` flag for the ``flask shell`` cli
+    command, dropping the user into the specified shell. Currently supported is
+    the standard shell and IPython.
 
 Version 1.1.2
 -------------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -101,7 +101,10 @@ Open a Shell
 
 To explore the data in your application, you can start an interactive Python
 shell with the :func:`shell <cli.shell_command>` command. An application
-context will be active, and the app instance will be imported. ::
+context will be active, and the app instance will be imported.
+You can specify a shell with the ``-i / --interface`` flag, e.g. if you want to
+use IPython instead of the standard python shell.
+Currently, only the default python shell and IPython are supported ::
 
     $ flask shell
     Python 3.6.2 (default, Jul 20 2017, 03:52:27)
@@ -109,6 +112,16 @@ context will be active, and the app instance will be imported. ::
     App: example
     Instance: /home/user/Projects/hello/instance
     >>>
+
+    $ flask shell -i ipython
+    Python 3.8.2 (default, Apr  8 2020, 14:31:25)
+    [GCC 9.3.0] on linux
+    IPython 7.13.0
+    App: example
+    Instance: /home/user/Projects/hello/instance
+
+    In [1]:
+
 
 Use :meth:`~Flask.shell_context_processor` to add other automatic imports.
 


### PR DESCRIPTION
When running `flask run -i ipython`, drop the user into an IPython shell with
the `app` instance imported and the context active just like in the regular
shell.

This makes magic methods as well as native autocomplete available to the user.

Update the docs to reflect this change

Commit checklist:

* add tests that fail without the patch
The function was untested before, I dont really know a good way to test this.
* ensure all tests pass with ``pytest``
the tests fail on master as well (on my machine).
* add documentation to the relevant docstrings or pages
Done
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
How do I do this when the feature might only be in master at some point? I cant predict the next version number :)
* add a changelog entry if this patch changes code
Done

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
