### PR TITLE
Fix issue arising when tojson or flask.json.dumps is applied on dict with key None

### DIFF
--- a/src/flask/json/__init__.py
+++ b/src/flask/json/__init__.py
@@ -9,6 +9,7 @@ flask.json
 import codecs
 import io
 import uuid
+import warnings
 from datetime import date
 from datetime import datetime
 
@@ -208,6 +209,13 @@ def dumps(obj, app=None, **kwargs):
     """
     _dump_arg_defaults(kwargs, app=app)
     encoding = kwargs.pop("encoding", None)
+
+    if isinstance(obj, dict) and None in obj:
+        warnings.warn(
+            "sort_keys falls back to False because `None` is found as key in obj"
+        )
+        kwargs["sort_keys"] = False
+
     rv = _json.dumps(obj, **kwargs)
     if encoding is not None and isinstance(rv, text_type):
         rv = rv.encode(encoding)
@@ -218,6 +226,13 @@ def dump(obj, fp, app=None, **kwargs):
     """Like :func:`dumps` but writes into a file object."""
     _dump_arg_defaults(kwargs, app=app)
     encoding = kwargs.pop("encoding", None)
+
+    if isinstance(obj, dict) and None in obj:
+        warnings.warn(
+            "sort_keys falls back to False because `None` is found as key in obj"
+        )
+        kwargs["sort_keys"] = False
+
     if encoding is not None:
         fp = _wrap_writer_for_text(fp, encoding)
     _json.dump(obj, fp, **kwargs)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -262,6 +262,26 @@ class TestJSON(object):
         )
         assert rv.data == b"3"
 
+    def test_json_dumps_key_none(self, app, req_ctx):
+        rv = flask.json.dumps({"Y": "abc", "X": 123})
+        assert rv == '{"X": 123, "Y": "abc"}'
+
+        with pytest.warns(UserWarning) as record:
+            rv = flask.json.dumps({None: "abc", "X": 123})
+        assert len(record) == 1
+        assert record[0].message.args[0] == 'sort_keys falls back to False' \
+                                            ' because `None` is found as key in obj'
+        assert rv == '{"null": "abc", "X": 123}' or \
+               rv == '{"X": 123, "null": "abc"}'
+
+    def test_json_dump_key_none(self, app, req_ctx, tmpdir):
+        with pytest.warns(UserWarning) as record:
+            p = tmpdir.mkdir("sub").join("result.json")
+            flask.json.dump({None: "abc", "X": 123}, p)
+        assert len(record) == 1
+        assert record[0].message.args[0] == 'sort_keys falls back to False' \
+                                            ' because `None` is found as key in obj'
+
     def test_template_escaping(self, app, req_ctx):
         render = flask.render_template_string
         rv = flask.json.htmlsafe_dumps("</script>")


### PR DESCRIPTION
This PR aims for fixing #3599


<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
