### PR TITLE
Fix function name in example

### DIFF
--- a/docs/tutorial/views.rst
+++ b/docs/tutorial/views.rst
@@ -265,13 +265,13 @@ applied to.
 
     def login_required(view):
         @functools.wraps(view)
-        def wrapped_view(**kwargs):
+        def wrapper_view(**kwargs):
             if g.user is None:
                 return redirect(url_for('auth.login'))
 
             return view(**kwargs)
 
-        return wrapped_view
+        return wrapper_view
 
 This decorator returns a new view function that wraps the original view
 it's applied to. The new function checks if a user is loaded and


### PR DESCRIPTION
The function returned by the decorator should be called "wrapper_view" instead of "wrapped_view" because it wraps the original view. It's not wrapped by it.

The example in Python docs use the same wording: https://docs.python.org/2/library/functools.html#functools.wraps

Describe what this patch does to fix the issue.

Link to any relevant issues or pull requests.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
