### PR TITLE
Fix docs link for Flask-Uploads

### DIFF
--- a/docs/patterns/fileuploads.rst
+++ b/docs/patterns/fileuploads.rst
@@ -185,4 +185,4 @@ applications dealing with uploads, there is also a Flask extension called
 blacklisting of extensions and more.
 
 .. _jQuery: https://jquery.com/
-.. _Flask-Uploads: https://pythonhosted.org/Flask-Uploads/
+.. _Flask-Uploads: https://flask-uploads.readthedocs.io/en/latest/


### PR DESCRIPTION
The docs link is out of date.

This updates to point at the correct location.

Alternatively, there are now multiple extensions for managing file uploads, so could change to saying "there are several extensions for managing file uploads" as that way you don't risk recommending specific libs which may at some point get abandoned, as happened for a time with this lib (#1493).