### PR TITLE
Add cli_group_help parameter for Blueprint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,8 @@ Unreleased
     instead of PyOpenSSL. :pr:`3492`
 -   When specifying a factory function with ``FLASK_APP``, keyword
     argument can be passed. :issue:`3553`
+-   Add ``cli_group_help`` parameter for blueprint when register
+    blueprint level commands.
 
 
 Version 1.1.2

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -362,6 +362,20 @@ commands directly to the application's level:
 
     $ flask create alice
 
+You can set the group help text with the ``cli_group_help`` parameter
+when creating the :class:`Blueprint` object, or later with
+:meth:`app.register_blueprint(bp, cli_group_help='...') <Flask.register_blueprint>`.
+The following are equivalent:
+
+.. code-block:: python
+
+    bp = Blueprint('students', __name__, cli_group_help='custom group help text')
+    # or
+    app.register_blueprint(bp, cli_group_help='custom group help text')
+
+If not set, the default help text for the command group will be
+"A command group for <blueprint's name> blueprint.".
+
 
 Application Context
 ~~~~~~~~~~~~~~~~~~~

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -166,6 +166,7 @@ class Blueprint(_PackageBoundObject):
         url_defaults=None,
         root_path=None,
         cli_group=_sentinel,
+        cli_group_help=None,
     ):
         _PackageBoundObject.__init__(
             self, import_name, template_folder, root_path=root_path
@@ -180,6 +181,7 @@ class Blueprint(_PackageBoundObject):
             url_defaults = {}
         self.url_values_defaults = url_defaults
         self.cli_group = cli_group
+        self.cli_group_help = cli_group_help
 
     def record(self, func):
         """Registers a function that is called when the blueprint is
@@ -245,17 +247,22 @@ class Blueprint(_PackageBoundObject):
             deferred(state)
 
         cli_resolved_group = options.get("cli_group", self.cli_group)
+        cli_group_help = options.get("cli_group_help", self.cli_group_help)
 
         if not self.cli.commands:
             return
 
+        if cli_group_help is None:
+            cli_group_help = f"A command group for {self.name} blueprint."
         if cli_resolved_group is None:
             app.cli.commands.update(self.cli.commands)
         elif cli_resolved_group is _sentinel:
             self.cli.name = self.name
+            self.cli.help = cli_group_help
             app.cli.add_command(self.cli)
         else:
             self.cli.name = cli_resolved_group
+            self.cli.help = cli_group_help
             app.cli.add_command(self.cli)
 
     def route(self, rule, **options):

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -97,6 +97,10 @@ class Blueprint(_PackageBoundObject):
         The ``cli_group`` parameter controls the name of the group under
         the ``flask`` command.
 
+    .. versionchanged:: 2.0.0
+        Add ``cli_group_help`` parameter to set the help text of blueprint
+        command group.
+
     .. versionadded:: 0.7
 
     :param name: The name of the blueprint. Will be prepended to each

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -258,15 +258,16 @@ class Blueprint(_PackageBoundObject):
 
         if cli_group_help is None:
             cli_group_help = f"A command group for {self.name} blueprint."
+        self.cli.help = cli_group_help
+        self.cli.short_help = cli_group_help
+
         if cli_resolved_group is None:
             app.cli.commands.update(self.cli.commands)
         elif cli_resolved_group is _sentinel:
             self.cli.name = self.name
-            self.cli.help = cli_group_help
             app.cli.add_command(self.cli)
         else:
             self.cli.name = cli_resolved_group
-            self.cli.help = cli_group_help
             app.cli.add_command(self.cli)
 
     def route(self, rule, **options):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -654,3 +654,36 @@ def test_cli_empty(app):
 
     result = app.test_cli_runner().invoke(args=["blue", "--help"])
     assert result.exit_code == 2, f"Unexpected success:\n\n{result.output}"
+
+
+def test_cli_blueprint_command_group_help(app):
+    "Test blueprint command group help text."
+    default = Blueprint("default", __name__)
+    custom = Blueprint("custom", __name__, cli_group_help="My custom help text.")
+    late = Blueprint("late", __name__)
+
+    app_runner = app.test_cli_runner()
+
+    @default.cli.command("default")
+    def default_command():
+        pass
+
+    app.register_blueprint(default)
+    result = app_runner.invoke(args=["--help"])
+    assert f"A command group for {default.name} blueprint" in result.output
+
+    @custom.cli.command("custom")
+    def custom_command():
+        pass
+
+    app.register_blueprint(custom)
+    result = app_runner.invoke(args=["--help"])
+    assert "My custom help text." in result.output
+
+    @late.cli.command("late")
+    def late_command():
+        pass
+
+    app.register_blueprint(late, cli_group_help="late help")
+    result = app_runner.invoke(args=["--help"])
+    assert "late help" in result.output


### PR DESCRIPTION
This PR will add a `cli_group_help` parameter for the blueprint. When register blueprint level commands, you can use it to set command group help text.

If not set, the default help text for the blueprint command group will be `A command group for <blueprint's name> blueprint.`.

ref: https://github.com/pallets/flask/issues/3608
