### PR TITLE
add function REGEXP

### DIFF
--- a/examples/tutorial/flaskr/db.py
+++ b/examples/tutorial/flaskr/db.py
@@ -1,3 +1,4 @@
+import re
 import sqlite3
 
 import click
@@ -5,6 +6,9 @@ from flask import current_app
 from flask import g
 from flask.cli import with_appcontext
 
+def regexp(expr, item):
+    reg = re.compile(expr)
+    return reg.search(item) is not None
 
 def get_db():
     """Connect to the application's configured database. The connection
@@ -15,6 +19,7 @@ def get_db():
         g.db = sqlite3.connect(
             current_app.config["DATABASE"], detect_types=sqlite3.PARSE_DECLTYPES
         )
+        g.db.create_function("REGEXP", 2, regexp)
         g.db.row_factory = sqlite3.Row
 
     return g.db


### PR DESCRIPTION
**add function REGEXP for sqlite3 which can support regex search.**

When using such sql 
```sql
SELECT word FROM words WHERE word REGEXP ".*go"
````
the following error will happen
```py
sqlite3.OperationalError: no such function: REGEXP
```
and this PR can fix the error.

References:
https://www.sqlite.org/lang_expr.html#regexp
https://stackoverflow.com/questions/5365451/problem-with-regexp-python-and-sqlite
