### PR TITLE
update code-block typo

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -73,12 +73,12 @@ First time setup
         $ git clone https://github.com/{username}/flask
         $ cd flask
 
--   Add the main repository as a remote to update later::
+-   Add the main repository as a remote to update later.
 
     .. code-block:: text
 
-        git remote add pallets https://github.com/pallets/flask
-        git fetch pallets
+        $ git remote add pallets https://github.com/pallets/flask
+        $ git fetch pallets
 
 -   Create a virtualenv.
 


### PR DESCRIPTION
Describe what this patch does to fix the issue:

Fixes a type that was showing the rst for the code block instead of the actual code as a code block

