### PR TITLE
Removed misleading DEBUG variable from examples

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -555,7 +555,7 @@ configuration::
     import os
 
     basedir = os.path.abspath(os.path.dirname(__file__))
-    
+
     class Config(object):
         TESTING = False
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -552,17 +552,21 @@ and import different hard-coded files based on that.
 An interesting pattern is also to use classes and inheritance for
 configuration::
 
+    import os
+
+    basedir = os.path.abspath(os.path.dirname(__file__))
+    
     class Config(object):
         TESTING = False
-        DATABASE_URI = 'sqlite:///:memory:'
 
     class ProductionConfig(Config):
         DATABASE_URI = 'mysql://user@localhost/foo'
 
     class DevelopmentConfig(Config):
-        pass
+        DATABASE_URI = "sqlite:///" + os.path.join(basedir, "foo.db")
 
     class TestingConfig(Config):
+        DATABASE_URI = 'sqlite:///:memory:'
         TESTING = True
 
 To enable such a config you just have to call into

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -429,7 +429,6 @@ sure to use uppercase letters for your config keys.
 Here is an example of a configuration file::
 
     # Example configuration
-    DEBUG = False
     SECRET_KEY = b'_5#y2L"F4Q8z\n\xec]/'
 
 Make sure to load the configuration very early on, so that extensions have
@@ -554,7 +553,6 @@ An interesting pattern is also to use classes and inheritance for
 configuration::
 
     class Config(object):
-        DEBUG = False
         TESTING = False
         DATABASE_URI = 'sqlite:///:memory:'
 
@@ -562,7 +560,7 @@ configuration::
         DATABASE_URI = 'mysql://user@localhost/foo'
 
     class DevelopmentConfig(Config):
-        DEBUG = True
+        pass
 
     class TestingConfig(Config):
         TESTING = True
@@ -589,7 +587,6 @@ your configuration classes::
 
     class Config(object):
         """Base config, uses staging database server."""
-        DEBUG = False
         TESTING = False
         DB_SERVER = '192.168.1.56'
 
@@ -603,11 +600,9 @@ your configuration classes::
 
     class DevelopmentConfig(Config):
         DB_SERVER = 'localhost'
-        DEBUG = True
 
     class TestingConfig(Config):
         DB_SERVER = 'localhost'
-        DEBUG = True
         DATABASE_URI = 'sqlite:///:memory:'
 
 There are many different ways and it's up to you how you want to manage

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -552,10 +552,6 @@ and import different hard-coded files based on that.
 An interesting pattern is also to use classes and inheritance for
 configuration::
 
-    import os
-
-    basedir = os.path.abspath(os.path.dirname(__file__))
-
     class Config(object):
         TESTING = False
 
@@ -563,7 +559,7 @@ configuration::
         DATABASE_URI = 'mysql://user@localhost/foo'
 
     class DevelopmentConfig(Config):
-        DATABASE_URI = "sqlite:///" + os.path.join(basedir, "foo.db")
+        DATABASE_URI = "sqlite:////tmp/foo.db"
 
     class TestingConfig(Config):
         DATABASE_URI = 'sqlite:///:memory:'


### PR DESCRIPTION
Describe what this patch does to fix the issue.

The configuragion documentation states that "While it is possible to set :data:`ENV` and :data:`DEBUG` in your config or code, this is strongly discouraged.` So, I believe using the `DEBUG` setting in the examples is misleading, as people are led to believe that that is needed to activate the debug mode. Indeed, basically every tutorial on Flask that you find around has the `DEBUG` variable in the configuration. I propose we get rid of all of them.

