### PR TITLE
Consolidated error docs

### DIFF
--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -243,6 +243,8 @@ you can use relative redirects by prefixing the endpoint with a dot only::
 This will link to ``admin.index`` for instance in case the current request
 was dispatched to any other admin blueprint endpoint.
 
+.. _my-blueprint-error-label:
+
 Error Handlers
 --------------
 

--- a/docs/errorhandling.rst
+++ b/docs/errorhandling.rst
@@ -70,15 +70,21 @@ Follow-up reads:
 
 .. _error-handlers:
 
-Error handlers
+Error Handlers
 --------------
 
 You might want to show custom error pages to the user when an error occurs.
 This can be done by registering error handlers.
 
-An error handler is a normal view function that returns a response, but instead
-of being registered for a route, it is registered for an exception or HTTP
-status code that would be raised while trying to handle a request.
+An error handler is a function that returns a response when a type of error is
+raised, similar to how a view is a function that returns a response when a
+request URL is matched. It is passed the instance of the error being handled,
+which is most likely a :exc:`~werkzeug.exceptions.HTTPException`. 
+
+The status code of the response will not be set to the handler's code. Make
+sure to provide the appropriate HTTP status code when returning a response from
+a handler.
+
 
 Registering
 ```````````
@@ -139,6 +145,7 @@ raises the exception. However, the blueprint cannot handle 404 routing errors
 because the 404 occurs at the routing level before the blueprint can be
 determined.
 
+For more information on Blueprint error handling see :ref:`my-blueprint-error-label`.
 
 Generic Exception Handlers
 ``````````````````````````
@@ -227,6 +234,84 @@ errors, use ``getattr`` to get access it for compatibility.
         # wrapped unhandled error
         return render_template("500_unhandled.html", e=original), 500
 
+An error handler for "500 Internal Server Error" will be passed uncaught exceptions in
+addition to explicit 500 errors. In debug mode, a handler for "500 Internal Server Error" will not be used. 
+Instead, the interactive debugger will be shown.
+
+Custom Error Pages
+------------------
+
+Flask comes with a handy :func:`~flask.abort` function that aborts a
+request with an HTTP error code early.  It will also provide a plain black
+and white error page for you with a basic description, but nothing fancy.
+
+Depending on the error code it is less or more likely for the user to
+actually see such an error.
+
+Here is an example implementation for a "404 Page Not Found" exception::
+
+    from flask import render_template
+
+    @app.errorhandler(404)
+    def page_not_found(e):
+        # note that we set the 404 status explicitly
+        return render_template('404.html'), 404
+
+When using the :ref:`application factory pattern <app-factories>`::
+
+    from flask import Flask, render_template
+
+    def page_not_found(e):
+      return render_template('404.html'), 404
+
+    def create_app(config_filename):
+        app = Flask(__name__)
+        app.register_error_handler(404, page_not_found)
+        return app
+
+An example template might be this:
+
+.. sourcecode:: html+jinja
+
+    {% extends "layout.html" %}
+    {% block title %}Page Not Found{% endblock %}
+    {% block body %}
+      <h1>Page Not Found</h1>
+      <p>What you were looking for is just not there.
+      <p><a href="{{ url_for('index') }}">go somewhere nice</a>
+    {% endblock %}
+
+Common Error Codes
+``````````````````
+
+The following error codes are some that are often displayed to the user,
+even if the application behaves correctly:
+
+*404 Not Found*
+    The good old "chap, you made a mistake typing that URL" message.  So
+    common that even novices to the internet know that 404 means: damn,
+    the thing I was looking for is not there.  It's a very good idea to
+    make sure there is actually something useful on a 404 page, at least a
+    link back to the index.
+
+*403 Forbidden*
+    If you have some kind of access control on your website, you will have
+    to send a 403 code for disallowed resources.  So make sure the user
+    is not lost when they try to access a forbidden resource.
+
+*410 Gone*
+    Did you know that there the "404 Not Found" has a brother named "410
+    Gone"?  Few people actually implement that, but the idea is that
+    resources that previously existed and got deleted answer with 410
+    instead of 404.  If you are not deleting documents permanently from
+    the database but just mark them as deleted, do the user a favour and
+    use the 410 code instead and display a message that what they were
+    looking for was deleted for all eternity.
+
+*500 Internal Server Error*
+    Usually happens on programming errors or if the server is overloaded.
+    A terribly good idea is to have a nice page there, because your
+    application *will* fail sooner or later
 
 Logging
 -------
@@ -295,3 +380,92 @@ you could have something like::
        use_debugger = app.debug and not(app.config.get('DEBUG_WITH_APTANA'))
        app.run(use_debugger=use_debugger, debug=app.debug,
                use_reloader=use_debugger, host='0.0.0.0')
+
+Implementing API Exceptions
+===========================
+
+It's very common to implement RESTful APIs on top of Flask.  One of the
+first things that developers run into is the realization that the builtin
+exceptions are not expressive enough for APIs and that the content type of
+:mimetype:`text/html` they are emitting is not very useful for API consumers.
+
+The better solution than using ``abort`` to signal errors for invalid API
+usage is to implement your own exception type and install an error handler
+for it that produces the errors in the format the user is expecting.
+
+Simple Exception Class
+----------------------
+
+The basic idea is to introduce a new exception that can take a proper
+human readable message, a status code for the error and some optional
+payload to give more context for the error.
+
+This is a simple example::
+
+    from flask import jsonify
+
+    class InvalidUsage(Exception):
+        status_code = 400
+
+        def __init__(self, message, status_code=None, payload=None):
+            Exception.__init__(self)
+            self.message = message
+            if status_code is not None:
+                self.status_code = status_code
+            self.payload = payload
+
+        def to_dict(self):
+            rv = dict(self.payload or ())
+            rv['message'] = self.message
+            return rv
+
+A view can now raise that exception with an error message.  Additionally
+some extra payload can be provided as a dictionary through the `payload`
+parameter.
+
+Registering an Error Handler
+----------------------------
+
+At that point views can raise that error, but it would immediately result
+in an internal server error.  The reason for this is that there is no
+handler registered for this error class.  That however is easy to add::
+
+    @app.errorhandler(InvalidUsage)
+    def handle_invalid_usage(error):
+        response = jsonify(error.to_dict())
+        response.status_code = error.status_code
+        return response
+
+Usage in Views
+--------------
+
+Here is how a view can use that functionality::
+
+    @app.route('/foo')
+    def get_foo():
+        raise InvalidUsage('This view is gone', status_code=410)
+
+Returning API Errors as JSON
+----------------------------
+
+When using Flask for web APIs, you can use the same techniques as above
+to return JSON responses to API errors.  :func:`~flask.abort` is called
+with a ``description`` parameter. The :meth:`~flask.errorhandler` will
+use that as the JSON error message, and set the status code to 404.
+
+.. code-block:: python
+
+    from flask import abort, jsonify
+
+    @app.errorhandler(404)
+    def resource_not_found(e):
+        return jsonify(error=str(e)), 404
+
+    @app.route("/cheese")
+    def get_one_cheese():
+        resource = get_resource()
+
+        if resource is None:
+            abort(404, description="Resource not found")
+
+        return jsonify(resource)

--- a/docs/patterns/errorpages.rst
+++ b/docs/patterns/errorpages.rst
@@ -98,6 +98,27 @@ An example template might be this:
       <p><a href="{{ url_for('index') }}">go somewhere nice</a>
     {% endblock %}
 
+Registering an Error Handler
+----------------------------
+
+At that point views can raise that error, but it would immediately result
+in an internal server error.  The reason for this is that there is no
+handler registered for this error class.  That however is easy to add::
+
+    @app.errorhandler(InvalidUsage)
+    def handle_invalid_usage(error):
+        response = jsonify(error.to_dict())
+        response.status_code = error.status_code
+        return response
+
+Usage in Views
+--------------
+
+Here is how a view can use that functionality::
+
+    @app.route('/foo')
+    def get_foo():
+        raise InvalidUsage('This view is gone', status_code=410)
 
 Returning API errors as JSON
 ----------------------------


### PR DESCRIPTION
This pull request consolidates information from multiple error docs into one file so users can find everything in one place. As of right now, the extraneous docs are still there until my solution is approved. The only file significantly modified was errorhandling.rst. I also added a reference to blueprints.rst error handling section.

See #3573 

I plan to update the sections about blueprint error handling with better examples but wanted to submit this PR before tackling that part.
 
<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
