### PR TITLE
Fixing small html issues in flashing patterns docs

### DIFF
--- a/docs/patterns/flashing.rst
+++ b/docs/patterns/flashing.rst
@@ -110,7 +110,7 @@ categories.  The loop looks slightly different in that situation then:
 
 .. sourcecode:: html+jinja
 
-   {% with messages = get_flashed_messages(with_categories=true) %}
+   {% with messages = get_flashed_messages(with_categories=True) %}
      {% if messages %}
        <ul class="flashes">
        {% for category, message in messages %}

--- a/docs/patterns/flashing.rst
+++ b/docs/patterns/flashing.rst
@@ -79,14 +79,13 @@ And here is the :file:`login.html` template which also inherits from
        <p class="error"><strong>Error:</strong> {{ error }}
      {% endif %}
      <form method="post">
-       <dl>
-         <dt>Username:
-         <dd><input type="text" name="username" value="{{
-             request.form.username }}">
-         <dt>Password:
-         <dd><input type="password" name="password">
-       </dl>
-       <p><input type="submit" value="Login">
+       <label for="username">Username:</label>
+       <input type="text" name="username" id="username"
+              value="{{ request.form.username }}">
+       <label for="password">Password:</label>
+       <input type="password" name="password" id="password">
+
+        <input type="submit" value="Login">
      </form>
    {% endblock %}
 

--- a/docs/patterns/flashing.rst
+++ b/docs/patterns/flashing.rst
@@ -48,7 +48,7 @@ And here is the :file:`layout.html` template which does the magic:
    <title>My Application</title>
    {% with messages = get_flashed_messages() %}
      {% if messages %}
-       <ul class=flashes>
+       <ul class="flashes">
        {% for message in messages %}
          <li>{{ message }}</li>
        {% endfor %}
@@ -76,17 +76,17 @@ And here is the :file:`login.html` template which also inherits from
    {% block body %}
      <h1>Login</h1>
      {% if error %}
-       <p class=error><strong>Error:</strong> {{ error }}
+       <p class="error"><strong>Error:</strong> {{ error }}
      {% endif %}
-     <form method=post>
+     <form method="post">
        <dl>
          <dt>Username:
-         <dd><input type=text name=username value="{{
+         <dd><input type="text" name="username" value="{{
              request.form.username }}">
          <dt>Password:
-         <dd><input type=password name=password>
+         <dd><input type="password" name="password">
        </dl>
-       <p><input type=submit value=Login>
+       <p><input type="submit" value="Login">
      </form>
    {% endblock %}
 
@@ -113,7 +113,7 @@ categories.  The loop looks slightly different in that situation then:
 
    {% with messages = get_flashed_messages(with_categories=true) %}
      {% if messages %}
-       <ul class=flashes>
+       <ul class="flashes">
        {% for category, message in messages %}
          <li class="{{ category }}">{{ message }}</li>
        {% endfor %}


### PR DESCRIPTION
Fixing some simple syntax in flashing patterns.

The examples in https://flask.palletsprojects.com/en/1.1.x/patterns/flashing/ are shown as:
`<ul class=flashes>`
but rather should be:
`<ul class="flashes">`

More examples of this throughout the page. Just fixing it up.

Also touching up some HTML by removing unnecessary p tag and swapping dl tags for input/label tags as they're better for screen readers and improve accessability.