### PR TITLE
make_response uses headers.update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,9 +27,14 @@ Unreleased
     instead of PyOpenSSL. :pr:`3492`
 -   When specifying a factory function with ``FLASK_APP``, keyword
     argument can be passed. :issue:`3553`
--   When loading a ``.env`` or ``.flaskenv`` file on top level directory,
-    Flask will not change current work directory to the location of dotenv
-    files, in order to prevent potential confusion. :pr:`3560`
+-   When loading a ``.env`` or ``.flaskenv`` file, the current working
+    directory is no longer changed to the location of the file.
+    :pr:`3560`
+-   When returning a ``(response, headers)`` tuple from a view, the
+    headers replace rather than extend existing headers on the response.
+    For example, this allows setting the ``Content-Type`` for
+    ``jsonify()``. Use ``response.headers.extend()`` if extending is
+    desired. :issue:`3628`
 
 
 Version 1.1.x

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -2045,7 +2045,7 @@ class Flask(_PackageBoundObject):
 
         # extend existing headers with provided headers
         if headers:
-            rv.headers.extend(headers)
+            rv.headers.update(headers)
 
         return rv
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1117,8 +1117,10 @@ def test_response_types(app, client):
     @app.route("/response_headers")
     def from_response_headers():
         return (
-            flask.Response("Hello world", 404, {"X-Foo": "Baz"}),
-            {"X-Foo": "Bar", "X-Bar": "Foo"},
+            flask.Response(
+                "Hello world", 404, {"Content-Type": "text/html", "X-Foo": "Baz"}
+            ),
+            {"Content-Type": "text/plain", "X-Foo": "Bar", "X-Bar": "Foo"},
         )
 
     @app.route("/response_status")
@@ -1155,7 +1157,8 @@ def test_response_types(app, client):
 
     rv = client.get("/response_headers")
     assert rv.data == b"Hello world"
-    assert rv.headers.getlist("X-Foo") == ["Baz", "Bar"]
+    assert rv.content_type == "text/plain"
+    assert rv.headers.getlist("X-Foo") == ["Bar"]
     assert rv.headers["X-Bar"] == "Foo"
     assert rv.status_code == 404
 


### PR DESCRIPTION
fixes #3628

Changed `make_response` to use `headers.update` instead of `headers.extend`.