### PR TITLE
Prevent duplicate Content-Type header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,8 @@ Unreleased
 -   When loading a ``.env`` or ``.flaskenv`` file on top level directory,
     Flask will not change current work directory to the location of dotenv
     files, in order to prevent potential confusion. :pr:`3560`
+-   Fix duplicate ``Content-Type`` header when setting header for
+    :meth:`jsonify` or ``dict`` response. :pr:`3690`
 
 
 Version 1.1.x

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -2046,7 +2046,10 @@ class Flask(_PackageBoundObject):
         # extend existing headers with provided headers
         if headers:
             rv.headers.extend(headers)
-
+            # prevent duplicate Content-Type header
+            content_type = Headers(headers).get("Content-Type")
+            if content_type:
+                rv.headers.set("Content-Type", content_type)
         return rv
 
     def create_url_adapter(self, request):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1967,3 +1967,32 @@ def test_max_cookie_size(app, client, recwarn):
 
     client.get("/")
     assert len(recwarn) == 0
+
+
+def test_unique_content_type_header(app, client):
+    @app.route("/jsonify")
+    def from_jsonify():
+        return flask.jsonify(hello="world"), {"Content-Type": "foo/bar"}
+
+    @app.route("/dict")
+    def from_dict():
+        return {"hello": "world"}, {"Content-Type": "foo/bar"}
+
+    @app.route("/tuple-header")
+    def from_tuple_header():
+        return {"hello": "world"}, [("Content-Type", "foo/bar")]
+
+    rv = client.get("/jsonify")
+    assert rv.headers["Content-Type"] == "foo/bar"
+    assert rv.status_code == 200
+    assert rv.mimetype == "foo/bar"
+
+    rv = client.get("/dict")
+    assert rv.headers["Content-Type"] == "foo/bar"
+    assert rv.status_code == 200
+    assert rv.mimetype == "foo/bar"
+
+    rv = client.get("/tuple-header")
+    assert rv.headers["Content-Type"] == "foo/bar"
+    assert rv.status_code == 200
+    assert rv.mimetype == "foo/bar"


### PR DESCRIPTION
This PR will make sure the `Content-Type` header is unique. The default `Content-Type` header will be overwritten by user-provided value.

Fix #3628
Related with #3684