### PR TITLE
Common API between Flask + Blueprint

### DIFF
--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -2045,7 +2045,7 @@ class Flask(_PackageBoundObject):
 
         # extend existing headers with provided headers
         if headers:
-            rv.headers.extend(headers)
+            rv.headers.update(headers)
 
         return rv
 

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -120,9 +120,13 @@ class Skeleton(_PackageBoundObject):
         self.static_url_path = static_url_path
         self.static_folder = static_folder
     
-    def route(self, rule, **options, endpoint_name):
+    def route(self, rule, **options, use_none=False):
         def decorator(f):
-            endpoint = options.pop("endpoint", endpoint_name)
+            if use_none:
+                endpoint = options.pop("endpoint", None)
+            else:
+                endpoint = options.pop("endpoint", f.__name__)
+                
             self.add_url_rule(rule, endpoint, f, **options)
             return f
         
@@ -1279,36 +1283,39 @@ class Flask(Skeleton):
             self.view_functions[endpoint] = view_func
 
     def route(self, rule, **options):
-        """A decorator that is used to register a view function for a
-        given URL rule.  This does the same thing as :meth:`add_url_rule`
-        but is intended for decorator usage::
+        return super().route(self, rule, **options, use_none=True)
 
-            @app.route('/')
-            def index():
-                return 'Hello World'
+    # def route(self, rule, **options):
+    #     """A decorator that is used to register a view function for a
+    #     given URL rule.  This does the same thing as :meth:`add_url_rule`
+    #     but is intended for decorator usage::
 
-        For more information refer to :ref:`url-route-registrations`.
+    #         @app.route('/')
+    #         def index():
+    #             return 'Hello World'
 
-        :param rule: the URL rule as string
-        :param endpoint: the endpoint for the registered URL rule.  Flask
-                         itself assumes the name of the view function as
-                         endpoint
-        :param options: the options to be forwarded to the underlying
-                        :class:`~werkzeug.routing.Rule` object.  A change
-                        to Werkzeug is handling of method options.  methods
-                        is a list of methods this rule should be limited
-                        to (``GET``, ``POST`` etc.).  By default a rule
-                        just listens for ``GET`` (and implicitly ``HEAD``).
-                        Starting with Flask 0.6, ``OPTIONS`` is implicitly
-                        added and handled by the standard request handling.
-        """
+    #     For more information refer to :ref:`url-route-registrations`.
 
-        def decorator(f):
-            endpoint = options.pop("endpoint", None)
-            self.add_url_rule(rule, endpoint, f, **options)
-            return f
+    #     :param rule: the URL rule as string
+    #     :param endpoint: the endpoint for the registered URL rule.  Flask
+    #                      itself assumes the name of the view function as
+    #                      endpoint
+    #     :param options: the options to be forwarded to the underlying
+    #                     :class:`~werkzeug.routing.Rule` object.  A change
+    #                     to Werkzeug is handling of method options.  methods
+    #                     is a list of methods this rule should be limited
+    #                     to (``GET``, ``POST`` etc.).  By default a rule
+    #                     just listens for ``GET`` (and implicitly ``HEAD``).
+    #                     Starting with Flask 0.6, ``OPTIONS`` is implicitly
+    #                     added and handled by the standard request handling.
+    #     """
 
-        return decorator
+    #     def decorator(f):
+    #         endpoint = options.pop("endpoint", None)
+    #         self.add_url_rule(rule, endpoint, f, **options)
+    #         return f
+
+    #     return decorator
 
     @setupmethod
     def endpoint(self, endpoint):

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -85,7 +85,35 @@ def setupmethod(f):
 
 
 class Skeleton(_PackageBoundObject):
-    pass
+
+    #: Skeleton local JSON decoder class to use.
+    #: Set to ``None`` to use the app's :class:`~flask.app.Flask.json_encoder`.
+    json_encoder = None
+    #: Skeleton local JSON decoder class to use.
+    #: Set to ``None`` to use the app's :class:`~flask.app.Flask.json_decoder`.
+    json_decoder = None
+
+    #: The name of the package or module that this app belongs to. Do not
+    #: change this once it is set by the constructor.
+    import_name = None
+
+    #: Location of the template files to be added to the template lookup.
+    #: ``None`` if templates should not be added.
+    template_folder = None
+
+    #: Absolute path to the package on the filesystem. Used to look up
+    #: resources contained in the package.
+    root_path = None
+
+    def __init__(
+        self,
+        import_name,
+        template_folder=None,
+        root_path=None,
+    ):
+        _PackageBoundObject.__init__(
+            self, import_name, template_folder=template_folder, root_path=root_path
+        )
 
 
 class Flask(_PackageBoundObject):

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -84,6 +84,10 @@ def setupmethod(f):
     return update_wrapper(wrapper_func, f)
 
 
+class Skeleton(_PackageBoundObject):
+    pass
+
+
 class Flask(_PackageBoundObject):
     """The flask object implements a WSGI application and acts as the central
     object.  It is passed the name of the module or package of the

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -2045,7 +2045,7 @@ class Flask(_PackageBoundObject):
 
         # extend existing headers with provided headers
         if headers:
-            rv.headers.update(headers)
+            rv.headers.extend(headers)
 
         return rv
 

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -108,7 +108,7 @@ class Skeleton(_PackageBoundObject):
     def __init__(
         self,
         import_name,
-        template_folder=None,
+        template_folder,
         root_path=None,
     ):
         _PackageBoundObject.__init__(
@@ -116,7 +116,7 @@ class Skeleton(_PackageBoundObject):
         )
 
 
-class Flask(_PackageBoundObject):
+class Flask(Skeleton):
     """The flask object implements a WSGI application and acts as the central
     object.  It is passed the name of the module or package of the
     application.  Once it is created it will act as a central registry for

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -119,6 +119,29 @@ class Skeleton(_PackageBoundObject):
 
         self.static_url_path = static_url_path
         self.static_folder = static_folder
+    
+    def route(self, rule, **options, endpoint_name):
+        def decorator(f):
+            endpoint = options.pop("endpoint", endpoint_name)
+            self.add_url_rule(rule, endpoint, f, **options)
+            return f
+        
+        return decorator
+
+    def add_url_rule(self, rule, endpoint=None, view_func=None, provide_automatic_options=None, **options):  # only Flask uses PAO
+        raise NotImplementedError()
+
+    def endpoint(self, endpoint):
+        raise NotImplementedError()
+
+    def before_request(self, f):
+        raise NotImplementedError()
+
+    def after_request(self, f):
+        raise NotImplementedError()
+
+    def teardown_request(self, f):
+        raise NotImplementedError()
 
     def context_processor(self, f):
         raise NotImplementedError()

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -110,10 +110,30 @@ class Skeleton(_PackageBoundObject):
         import_name,
         template_folder,
         root_path=None,
+        static_url_path=None,
+        static_folder="static"
     ):
         _PackageBoundObject.__init__(
             self, import_name, template_folder=template_folder, root_path=root_path
         )
+
+        self.static_url_path = static_url_path
+        self.static_folder = static_folder
+
+    def context_processor(self, f):
+        raise NotImplementedError()
+
+    def url_value_preprocessor(self, f):
+        raise NotImplementedError()
+
+    def url_defaults(self, f):
+        raise NotImplementedError()
+
+    def errorhandler(self, code_or_exception):
+        raise NotImplementedError()
+
+    def register_error_handler(self, code_or_exception, f):
+        raise NotImplementedError()
 
 
 class Flask(Skeleton):
@@ -426,12 +446,9 @@ class Flask(Skeleton):
         instance_relative_config=False,
         root_path=None,
     ):
-        _PackageBoundObject.__init__(
-            self, import_name, template_folder=template_folder, root_path=root_path
+        Skeleton.__init__(
+            self, import_name, template_folder, root_path=root_path, static_url_path=static_url_path, static_folder=static_folder
         )
-
-        self.static_url_path = static_url_path
-        self.static_folder = static_folder
 
         if instance_path is None:
             instance_path = self.auto_find_instance_path()

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -258,17 +258,20 @@ class Blueprint(Skeleton):
             self.cli.name = cli_resolved_group
             app.cli.add_command(self.cli)
 
-    def route(self, rule, **options):
-        """Like :meth:`Flask.route` but for a blueprint.  The endpoint for the
-        :func:`url_for` function is prefixed with the name of the blueprint.
-        """
+    def route():
+        return super().route()
 
-        def decorator(f):
-            endpoint = options.pop("endpoint", f.__name__)
-            self.add_url_rule(rule, endpoint, f, **options)
-            return f
+    # def route(self, rule, **options):
+    #     """Like :meth:`Flask.route` but for a blueprint.  The endpoint for the
+    #     :func:`url_for` function is prefixed with the name of the blueprint.
+    #     """
 
-        return decorator
+    #     def decorator(f):
+    #         endpoint = options.pop("endpoint", f.__name__)
+    #         self.add_url_rule(rule, endpoint, f, **options)
+    #         return f
+
+    #     return decorator
 
     def add_url_rule(self, rule, endpoint=None, view_func=None, **options):
         """Like :meth:`Flask.add_url_rule` but for a blueprint.  The endpoint for

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -1,5 +1,6 @@
 from functools import update_wrapper
 
+from .app import Skeleton
 from .helpers import _endpoint_from_view_func
 from .helpers import _PackageBoundObject
 
@@ -76,7 +77,7 @@ class BlueprintSetupState:
         )
 
 
-class Blueprint(_PackageBoundObject):
+class Blueprint(Skeleton):
     """Represents a blueprint, a collection of routes and other
     app-related functions that can be registered on a real application
     later.

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -168,14 +168,13 @@ class Blueprint(Skeleton):
         root_path=None,
         cli_group=_sentinel,
     ):
-        _PackageBoundObject.__init__(
-            self, import_name, template_folder, root_path=root_path
+        Skeleton.__init__(
+            self, import_name, template_folder, root_path=root_path, static_url_path=static_url_path, static_folder=static_folder
         )
         self.name = name
         self.url_prefix = url_prefix
         self.subdomain = subdomain
-        self.static_folder = static_folder
-        self.static_url_path = static_url_path
+       
         self.deferred_functions = []
         if url_defaults is None:
             url_defaults = {}


### PR DESCRIPTION
Resolves #3215 

**Similar functions between Flask and Blueprint:**
**Chris:**
- [x] route
- [ ] add_url_rule
- [ ] endpoint
- [x] before_request
- [x] after_request
- [ ] teardown_request

**Yanlam:**
- [x] init
- [x] context_processor
- [x] url_value_preprocessor
- [x] url_defaults
- [x] errorhandler
- [x] register_error_handler
