### PR TITLE
remove lowest version test until next release

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,7 @@ jobs:
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
           - {name: '3.6', python: '3.6', os: ubuntu-latest, tox: py36}
           - {name: 'PyPy', python: pypy3, os: ubuntu-latest, tox: pypy3}
-          - {name: Version Range, python: '3.8', os: ubuntu-latest, tox: 'devel,lowest'}
+          - {name: Version Range, python: '3.8', os: ubuntu-latest, tox: 'devel'}
           - {name: Style, python: '3.8', os: ubuntu-latest, tox: style}
           - {name: Docs, python: '3.8', os: ubuntu-latest, tox: docs}
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{38,37,36,py3}
-    py38-{devel,lowest}
+    py38-devel
     style
     docs
 skip_missing_interpreters = true
@@ -9,11 +9,6 @@ skip_missing_interpreters = true
 [testenv]
 deps =
     -r requirements/tests.txt
-
-    lowest: Werkzeug==0.15.5
-    lowest: Jinja2==2.10
-    lowest: itsdangerous==0.24
-    lowest: Click==5.1
 
     devel: https://github.com/pallets/werkzeug/archive/master.tar.gz
     devel: https://github.com/pallets/markupsafe/archive/master.tar.gz


### PR DESCRIPTION
The next major release will depend on the next major releases of all the other libraries, which is equivalent to devel right now. Remove lowest, to be added back after the release.