### PR TITLE
Add repl.it to list of deployment hosting options

### DIFF
--- a/docs/deploying/index.rst
+++ b/docs/deploying/index.rst
@@ -21,6 +21,7 @@ Hosted options
 - `Deploying Flask on AWS Elastic Beanstalk <https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create-deploy-python-flask.html>`_
 - `Deploying on Azure (IIS) <https://docs.microsoft.com/en-us/azure/app-service/containers/how-to-configure-python>`_
 - `Deploying on PythonAnywhere <https://help.pythonanywhere.com/pages/Flask/>`_
+- `Deploying on repl.it <https://docs.repl.it/repls/http-servers>`_
 
 Self-hosted options
 -------------------


### PR DESCRIPTION
This change adds repl.it to the list of deployment hosting options. @replit ([https://repl.it/](https://repl.it/)) supports hosting Flask servers and allows you to make changes in a web browser.

Commit checklist:
**(none of these seem to be relevant to my commit, but if I missed anything please let me know! 😄)**
- [x] ~add tests that fail without the patch~
- [x] ~ensure all tests pass with ``pytest``~
- [x] ~add documentation to the relevant docstrings or pages~
- [x] ~add ``versionadded`` or ``versionchanged`` directives to relevant docstrings~
- [x] ~add a changelog entry if this patch changes code~