### PR TITLE
Fixes #1902

### DIFF
--- a/examples/tutorial/README.rst
+++ b/examples/tutorial/README.rst
@@ -68,7 +68,7 @@ Test
 ::
 
     $ pip install '.[test]'
-    $ pytest
+    $ python -m pytest
 
 Run with coverage report::
 


### PR DESCRIPTION
Uses "Python -m pytest" to fix the issue with flaskr being unavailable in the tutorial.