### PR TITLE
swapping self.assert_equal for assert

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -312,7 +312,7 @@ And then to use it::
         with app.test_client() as c:
             resp = c.get('/users/me')
             data = json.loads(resp.data)
-            self.assert_equal(data['username'], my_user.username)
+            assert data['username'] == my_user.username
 
 
 Keeping the Context Around


### PR DESCRIPTION
`self.assert_equal(data['username'], my_user.username)` is not in a class and is ambiguous. 

I think this line is technically incorrect in the context of the example snippet: `self.assert_equal` means nothing without a greater context (which isn't shared) whereas `assert` is explicit and clear.

I know that in the grand scheme of things this detail is inconsequential and that the docs aren't supposed to production code, but rather a design aid. However, as someone who has leant flask from the docs, I know that detail matters and it's better to be explicit and clear rather than ambiguous and confusing. 


