### PR TITLE
cleaner message when CLI can't load app

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Unreleased
 -   Passing ``script_info`` to app factory functions is deprecated. This
     was not portable outside the ``flask`` command. Use
     ``click.get_current_context().obj`` if it's needed. :issue:`3552`
+-   The CLI shows better error messages when the app failed to load
+    when looking up commands. :issue:`2741`
 -   Add :meth:`sessions.SessionInterface.get_cookie_name` to allow
     setting the session cookie name dynamically. :pr:`3369`
 -   Add :meth:`Config.from_file` to load config using arbitrary file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,9 +73,15 @@ def client(app):
 
 @pytest.fixture
 def test_apps(monkeypatch):
-    monkeypatch.syspath_prepend(
-        os.path.abspath(os.path.join(os.path.dirname(__file__), "test_apps"))
-    )
+    monkeypatch.syspath_prepend(os.path.join(os.path.dirname(__file__), "test_apps"))
+    original_modules = set(sys.modules.keys())
+
+    yield
+
+    # Remove any imports cached during the test. Otherwise "import app"
+    # will work in the next test even though it's no longer on the path.
+    for key in sys.modules.keys() - original_modules:
+        sys.modules.pop(key)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
When loading the app fails for the `--help` command, only the error message is shown, then the help text. The full traceback is still shown for other exceptions. Also show the message when loading fails while getting a command, instead of only "command not found". The error message goes to `stderr` to match other error behavior, and is in red with an extra newline to make it more obvious next to the help text.

Also fixes an issue with the `test_apps` fixture that caused an imported app to still be importable after the test was over and the path was reset. Now the module cache is reset as well. This was causing an issue with the new tests, because previous tests had imported `test_apps/helloworld/wsgi`, one of the default imports that is tried if `FLASK_APP` isn't set, which caused the test to import an app successfully even though it should have failed and shown an error. This also revealed an issue with an existing test relying on the cached behavior.

fixes #2741 