### PR TITLE
Fix bad intersphinx link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ intersphinx_mapping = {
     "jinja": ("https://jinja.palletsprojects.com/", None),
     "itsdangerous": ("https://itsdangerous.palletsprojects.com/", None),
     "sqlalchemy": ("https://docs.sqlalchemy.org/", None),
-    "wtforms": ("https://wtforms.readthedocs.io/en/stable/", None),
+    "wtforms": ("https://wtforms.readthedocs.io/", None),
     "blinker": ("https://pythonhosted.org/blinker/", None),
 }
 issues_github_path = "pallets/flask"


### PR DESCRIPTION
WTForms has removed the documentation of the stable version, it causes the 404 error when building documentation. This PR changes the stable URL to the default URL (`https://wtforms.readthedocs.io/`).