### PR TITLE
Include samesite and secure keys when removing session cookie

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,8 @@ Unreleased
     attributes just like ``Flask``, rather than opaque lambda functions.
     This is intended to improve consistency and maintainability.
     :issue:`3215`
+-   Include ``samesite`` and ``secure`` options when removing the
+    session cookie. :pr:`3726`
 
 
 Version 1.1.x

--- a/src/flask/sessions.py
+++ b/src/flask/sessions.py
@@ -351,12 +351,16 @@ class SecureCookieSessionInterface(SessionInterface):
         name = self.get_cookie_name(app)
         domain = self.get_cookie_domain(app)
         path = self.get_cookie_path(app)
+        secure = self.get_cookie_secure(app)
+        samesite = self.get_cookie_samesite(app)
 
         # If the session is modified to be empty, remove the cookie.
         # If the session is empty, return without setting the cookie.
         if not session:
             if session.modified:
-                response.delete_cookie(name, domain=domain, path=path)
+                response.delete_cookie(
+                    name, domain=domain, path=path, secure=secure, samesite=samesite
+                )
 
             return
 
@@ -368,8 +372,6 @@ class SecureCookieSessionInterface(SessionInterface):
             return
 
         httponly = self.get_cookie_httponly(app)
-        secure = self.get_cookie_secure(app)
-        samesite = self.get_cookie_samesite(app)
         expires = self.get_expiration_time(app, session)
         val = self.get_signing_serializer(app).dumps(dict(session))
         response.set_cookie(

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -322,6 +322,19 @@ def test_session_using_session_settings(app, client):
     assert "httponly" not in cookie
     assert "samesite" in cookie
 
+    @app.route("/clear")
+    def clear():
+        flask.session.pop("testing", None)
+        return "Goodbye World"
+
+    rv = client.get("/clear", "http://www.example.com:8080/test/")
+    cookie = rv.headers["set-cookie"].lower()
+    assert "session=;" in cookie
+    assert "domain=.example.com" in cookie
+    assert "path=/" in cookie
+    assert "secure" in cookie
+    assert "samesite" in cookie
+
 
 def test_session_using_samesite_attribute(app, client):
     @app.route("/")


### PR DESCRIPTION
The `samesite` key is required on empty cookies. When a flask `session` is cleared, the delete cookie logic needs to set the configured `samesite` and `secure` keys.

![samesite missing on cookie](https://user-images.githubusercontent.com/5615725/89786111-6aaa4400-dae9-11ea-9071-0d3bf138bc1a.png)

Requires that https://github.com/pallets/werkzeug/pull/1889 is merged first.