### PR TITLE
Discover app factory deterministically

### DIFF
--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -60,7 +60,7 @@ def find_best_app(script_info, module):
         )
 
     # Search for app factory functions.
-    for attr_name in {"create_app", "make_app"}:
+    for attr_name in ("create_app", "make_app"):
         app_factory = getattr(module, attr_name, None)
 
         if inspect.isfunction(app_factory):


### PR DESCRIPTION
Commit 2ae740dd4903bbe5f3864384bcdf2ab2d4638bce probably inadvertently
changed to iterate over a set of "create_app", "make_app" to discover
application factory functions. As sets don't guarantee order,
differences in the implementation of the type can make it
non-deterministic which factory function is used if a project implements
both. Revert to using a tuple.