### PR TITLE
Increased hand-holding for Windows users

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -54,10 +54,12 @@ If you are on Windows, the environment variable syntax depends on command line
 interpreter. On Command Prompt::
 
     C:\path\to\app>set FLASK_APP=hello.py
+    C:\path\to\app>flask run
 
 And on PowerShell::
 
     PS C:\path\to\app> $env:FLASK_APP = "hello.py"
+    PS C:\path\to\app> flask run
 
 Alternatively you can use :command:`python -m flask`::
 


### PR DESCRIPTION
I added "C:\path\to\app>flask run" to both Command Prompt and PowerShell. 

I am unsure if the PowerShell command is correct, it threw an error "Could not import "hello"." My reasoning is that it might not be immediately obvious to use "flask run" after the "set" command, which could lead to frustration as the user doesn't know what to do and searching online for the issue does not yield the required result (execute flask run). I think it's a basic Quality of Life change for new people to Flask.