### PR TITLE
Disable required attributes overriding error output

### DIFF
--- a/examples/tutorial/flaskr/templates/auth/login.html
+++ b/examples/tutorial/flaskr/templates/auth/login.html
@@ -7,9 +7,9 @@
 {% block content %}
   <form method="post">
     <label for="username">Username</label>
-    <input name="username" id="username" required>
+    <input name="username" id="username">
     <label for="password">Password</label>
-    <input type="password" name="password" id="password" required>
+    <input type="password" name="password" id="password">
     <input type="submit" value="Log In">
   </form>
 {% endblock %}

--- a/examples/tutorial/flaskr/templates/auth/register.html
+++ b/examples/tutorial/flaskr/templates/auth/register.html
@@ -7,9 +7,9 @@
 {% block content %}
   <form method="post">
     <label for="username">Username</label>
-    <input name="username" id="username" required>
+    <input name="username" id="username">
     <label for="password">Password</label>
-    <input type="password" name="password" id="password" required>
+    <input type="password" name="password" id="password">
     <input type="submit" value="Register">
   </form>
 {% endblock %}

--- a/examples/tutorial/flaskr/templates/blog/create.html
+++ b/examples/tutorial/flaskr/templates/blog/create.html
@@ -7,7 +7,7 @@
 {% block content %}
   <form method="post">
     <label for="title">Title</label>
-    <input name="title" id="title" value="{{ request.form['title'] }}" required>
+    <input name="title" id="title" value="{{ request.form['title'] }}">
     <label for="body">Body</label>
     <textarea name="body" id="body">{{ request.form['body'] }}</textarea>
     <input type="submit" value="Save">

--- a/examples/tutorial/flaskr/templates/blog/update.html
+++ b/examples/tutorial/flaskr/templates/blog/update.html
@@ -7,7 +7,7 @@
 {% block content %}
   <form method="post">
     <label for="title">Title</label>
-    <input name="title" id="title" value="{{ request.form['title'] or post['title'] }}" required>
+    <input name="title" id="title" value="{{ request.form['title'] or post['title'] }}">
     <label for="body">Body</label>
     <textarea name="body" id="body">{{ request.form['body'] or post['body'] }}</textarea>
     <input type="submit" value="Save">


### PR DESCRIPTION
Error messages were being overriden with a popup, "Please fill out this field", because of the required attribute from the respective templates. Preserved custom error messages by disabling the required attribute.