### PR TITLE
fix typo in flask shell help

### DIFF
--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -859,7 +859,7 @@ def run_command(
 def shell_command():
     """Run an interactive Python shell in the context of a given
     Flask application.  The application will populate the default
-    namespace of this shell according to it's configuration.
+    namespace of this shell according to its configuration.
 
     This is useful for executing small snippets of management code
     without having to manually configure the application.


### PR DESCRIPTION
The Flask shell banner (i.e. the thing that appears on the console
when I run `$ flask shell`) contains a grammatical error. This branch
contains a fixed version.