### PR TITLE
updated doc for mod_wsgi

### DIFF
--- a/docs/deploying/mod_wsgi.rst
+++ b/docs/deploying/mod_wsgi.rst
@@ -27,7 +27,7 @@ follows:
 
 .. sourcecode:: text
 
-    $ apt-get install libapache2-mod-wsgi
+    $ apt-get install libapache2-mod-wsgi-py3
 
 If you are using a yum based distribution (Fedora, OpenSUSE, etc..) you
 can install it as follows:
@@ -41,7 +41,7 @@ using pkg_add:
 
 .. sourcecode:: text
 
-    $ pkg install ap22-mod_wsgi2
+    $ pkg install ap24-py37-mod_wsgi
 
 If you are using pkgsrc you can install `mod_wsgi` by compiling the
 `www/ap2-wsgi` package.


### PR DESCRIPTION
This PR is related to issue #3696, I've changed the instructions to install mod_wsgi from python2.x to python3.x for apt and pkg (FreeBSD).

I verified package names from here
- [FreeBSD](https://pkgs.org/search/?q=mod_wsgi)
- [Debian](https://pkgs.org/download/libapache2-mod-wsgi-py3)

Let me know if I this needs some correction, Thanks 😄 

closes #3696