### PR TITLE
Docs: Sentry is not open source any more

### DIFF
--- a/docs/errorhandling.rst
+++ b/docs/errorhandling.rst
@@ -34,7 +34,7 @@ Sending error mails, even if just for critical ones, can become
 overwhelming if enough users are hitting the error and log files are
 typically never looked at. This is why we recommend using `Sentry
 <https://sentry.io/>`_ for dealing with application errors. It's
-available as an Open Source project `on GitHub
+available as a source-available project `on GitHub
 <https://github.com/getsentry/sentry>`_ and is also available as a `hosted version
 <https://sentry.io/signup/>`_ which you can try for free. Sentry
 aggregates duplicate errors, captures the full stack trace and local


### PR DESCRIPTION
Sentry is still referenced as *Open Source* in the error handling documentation. The new license (Business Source License) is not an open source license ([1](https://blog.sentry.io/2019/11/06/relicensing-sentry/), [2](https://forum.sentry.io/t/re-licensing-sentry-faq-discussion/8044)).