### PR TITLE
Breaking a ref cycle created by default in Flask()

### DIFF
--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import weakref
 from datetime import timedelta
 from itertools import chain
 from threading import Lock
@@ -474,6 +475,7 @@ class Flask(Scaffold):
         # Note we do this without checking if static_folder exists.
         # For one, it might be created while the server is running (e.g. during
         # development). Also, Google App Engine stores static files somewhere
+        self_ref = weakref.ref(self)
         if self.has_static_folder:
             assert (
                 bool(static_host) == host_matching
@@ -482,7 +484,9 @@ class Flask(Scaffold):
                 f"{self.static_url_path}/<path:filename>",
                 endpoint="static",
                 host=static_host,
-                view_func=self.send_static_file,
+                view_func=lambda *args, **kwds: self_ref().send_static_file(
+                    *args, **kwds
+                ),
             )
 
         # Set the name of the Click group in case someone wants to add

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -475,18 +475,18 @@ class Flask(Scaffold):
         # Note we do this without checking if static_folder exists.
         # For one, it might be created while the server is running (e.g. during
         # development). Also, Google App Engine stores static files somewhere
-        self_ref = weakref.ref(self)
         if self.has_static_folder:
             assert (
                 bool(static_host) == host_matching
             ), "Invalid static_host/host_matching combination"
+            # Use a weakref to avoid creating a reference cycle between the app
+            # and the view function (see #3761).
+            self_ref = weakref.ref(self)
             self.add_url_rule(
                 f"{self.static_url_path}/<path:filename>",
                 endpoint="static",
                 host=static_host,
-                view_func=lambda *args, **kwds: self_ref().send_static_file(
-                    *args, **kwds
-                ),
+                view_func=lambda **kw: self_ref().send_static_file(**kw),
             )
 
         # Set the name of the Click group in case someone wants to add

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1982,13 +1982,12 @@ def test_max_cookie_size(app, client, recwarn):
 
 @require_cpython_gc
 def test_app_freed_on_zero_refcount():
-    # Tests that a newly created app does not contain
-    # a circular refrence to itself,
-    # preventing its automatic deletion in CPython
-    # when all external references to it are released.
+    # A Flask instance should not create a reference cycle that prevents CPython
+    # from freeing it when all external references to it are released (see #3761).
     gc.disable()
     try:
         app = flask.Flask(__name__)
+        assert app.view_functions["static"]
         weak = weakref.ref(app)
         assert weak() is not None
         del app


### PR DESCRIPTION
Fixes #3761

Breaks the ref cycle `Flask` -> `view_functions` -> `self.send_static_file` -> `Flask` that is created in the constructor.
