### PR TITLE
Check the static URL in advance

### DIFF
--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -396,6 +396,10 @@ class Flask(Scaffold):
         #: to load a config from files.
         self.config = self.make_config(instance_relative_config)
 
+        # Check static file routing in advance and return more detailed traceback information
+        if not static_url_path.startswith("/"):
+            raise ValueError("Static file url must start with a leading slash")
+
         #: A list of functions that are called when :meth:`url_for` raises a
         #: :exc:`~werkzeug.routing.BuildError`.  Each function registered here
         #: is called with `error`, `endpoint` and `values`.  If a function


### PR DESCRIPTION
Usually, we will use `Flask (__name__, static_url_path="static")` to set the path to static files on the website, but if we omit the slash at the beginning of the URL, the following traceback will appear:

``` bash
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.6/dist-packages/flask/app.py", line 605, in __init__
    view_func=self.send_static_file,
  File "/usr/local/lib/python3.6/dist-packages/flask/app.py", line 98, in wrapper_func
    return f(self, *args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/flask/app.py", line 1275, in add_url_rule
    rule = self.url_rule_class(rule, methods=methods, **options)
  File "/usr/local/lib/python3.6/dist-packages/werkzeug/routing.py", line 666, in __init__
    raise ValueError("urls must start with a leading slash")
ValueError: urls must start with a leading slash
```


It is difficult for us to know from Traceback that the slash of the static file URL is missing, so I checked the slash of the static file URL in the `__init__()` of `Flask()` in advance, and returned to Traceback in more detail

🪔 like this:


``` bash
>>> from flask import Flask
>>> Flask(__name__,static_url_path="static")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.6/dist-packages/Flask-2.0.0.dev0-py3.6.egg/flask/app.py", line 392, in __init__
    raise ValueError("Static file url must start with a leading slash")
ValueError: Static file url must start with a leading slash
>>> 
```
