### PR TITLE
Raise an error if rule starts or ends with a space

### DIFF
--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -295,6 +295,12 @@ class Blueprint(Scaffold):
         """Like :meth:`Flask.add_url_rule` but for a blueprint.  The endpoint for
         the :func:`url_for` function is prefixed with the name of the blueprint.
         """
+
+        assert rule.endswith(" ") is False, "Blueprint rule should not end with space"
+        assert (
+            rule.startswith(" ") is False
+        ), "Blueprint rule should not start with space"
+
         if endpoint:
             assert "." not in endpoint, "Blueprint endpoints should not contain dots"
         if view_func and hasattr(view_func, "__name__"):

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -340,6 +340,34 @@ def test_route_decorator_custom_endpoint(app, client):
     assert client.get("/py/bar/foo").data == b"bp.bar_foo"
 
 
+def test_endpoint_with_space_in_the_end():
+    bp = flask.Blueprint("bp", __name__)
+    try:
+
+        @bp.route("/bar ")
+        def foo_bar():
+            return flask.request.endpoint
+
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("expected AssertionError not raised")
+
+
+def test_endpoint_with_space_in_the_beginning():
+    bp = flask.Blueprint("bp", __name__)
+    try:
+
+        @bp.route(" /bar")
+        def foo_bar():
+            return flask.request.endpoint
+
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("expected AssertionError not raised")
+
+
 def test_route_decorator_custom_endpoint_with_dots(app, client):
     bp = flask.Blueprint("bp", __name__)
 


### PR DESCRIPTION
This PR solves https://github.com/pallets/flask/issues/3780. After this PR is merged creating routes like this will throw an error:

`@bp.route("/bar ")`
`@bp.route(" /bar")`



<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
