### PR TITLE
Add python 3.9 to CI.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,6 @@ jobs:
           - {name: '3.6', python: '3.6', os: ubuntu-latest, tox: py36}
           - {name: 'PyPy', python: pypy3, os: ubuntu-latest, tox: pypy3}
           - {name: Version Range, python: '3.9', os: ubuntu-latest, tox: 'devel'}
-          - {name: Style, python: '3.9', os: ubuntu-latest, tox: style}
           - {name: Docs, python: '3.9', os: ubuntu-latest, tox: docs}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,15 +16,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: Linux, python: '3.8', os: ubuntu-latest, tox: py38}
-          - {name: Windows, python: '3.8', os: windows-latest, tox: py38}
-          - {name: Mac, python: '3.8', os: macos-latest, tox: py38}
+          - {name: Linux, python: '3.9', os: ubuntu-latest, tox: py39}
+          - {name: Windows, python: '3.9', os: windows-latest, tox: py39}
+          - {name: Mac, python: '3.9', os: macos-latest, tox: py39}
+          - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
           - {name: '3.6', python: '3.6', os: ubuntu-latest, tox: py36}
           - {name: 'PyPy', python: pypy3, os: ubuntu-latest, tox: pypy3}
-          - {name: Version Range, python: '3.8', os: ubuntu-latest, tox: 'devel'}
-          - {name: Style, python: '3.8', os: ubuntu-latest, tox: style}
-          - {name: Docs, python: '3.8', os: ubuntu-latest, tox: docs}
+          - {name: Version Range, python: '3.9', os: ubuntu-latest, tox: 'devel'}
+          - {name: Style, python: '3.9', os: ubuntu-latest, tox: style}
+          - {name: Docs, python: '3.9', os: ubuntu-latest, tox: docs}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/src/flask/wrappers.py
+++ b/src/flask/wrappers.py
@@ -90,7 +90,7 @@ class Request(RequestBase, JSONMixin):
             attach_enctype_error_multidict(self)
 
 
-class Response(ResponseBase, JSONMixin):
+class Response(JSONMixin, ResponseBase):
     """The response object that is used by default in Flask.  Works like the
     response object from Werkzeug but is set to have an HTML mimetype by
     default.  Quite often you don't have to create this object yourself because

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,37,36,py3}
+    py{39,38,37,36,py3}
     py38-devel
     style
     docs


### PR DESCRIPTION
Python 3.9 was released on October 5, 2020. Add 3.9 to CI and tox.

Actions support for Python 3.9 : https://github.com/actions/setup-python/issues/148
