### PR TITLE
Updated outdated link in errorhandling documentation  

### DIFF
--- a/docs/errorhandling.rst
+++ b/docs/errorhandling.rst
@@ -66,7 +66,7 @@ Follow-up reads:
   similar fashion.  See the `Python SDK docs
   <https://docs.sentry.io/platforms/python/>`_ for more information.
 * `Getting started with Sentry <https://docs.sentry.io/quickstart/?platform=python>`_
-* `Flask-specific documentation <https://docs.sentry.io/platforms/python/flask/>`_.
+* `Flask-specific documentation <https://docs.sentry.io/platforms/python/guides/flask/>`_.
 
 .. _error-handlers:
 


### PR DESCRIPTION
Fixed the link in documentation section [error-logging-tools](https://flask.palletsprojects.com/en/1.1.x/errorhandling/#error-logging-tools) for flask-specific-documentation to the proper url: https://docs.sentry.io/platforms/python/guides/flask/
Fixes #3787 
