### PR TITLE
Add signed int and float to docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -608,14 +608,15 @@ Variable parts are passed to the view function as keyword arguments.
 
 The following converters are available:
 
-=========== ===============================================
-`string`    accepts any text without a slash (the default)
-`int`       accepts integers
-`float`     like `int` but for floating point values
-`path`      like the default but also accepts slashes
-`any`       matches one of the items provided
-`uuid`      accepts UUID strings
-=========== ===============================================
+======================   ====================================================
+``string``               (default) accepts any text without a slash
+``int``                  accepts positive integers
+``int(signed=True)``     accepts positive and negative integers
+``float``                accepts positive floating point values
+``float(signed=True)``   accepts positive and negative floating point values
+``path``                 like ``string`` but also accepts slashes
+``uuid``                 accepts UUID strings
+======================   ====================================================
 
 Custom converters can be defined using :attr:`flask.Flask.url_map`.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -225,13 +225,15 @@ of the argument like ``<converter:variable_name>``. ::
 
 Converter types:
 
-========== ==========================================
-``string`` (default) accepts any text without a slash
-``int``    accepts positive integers
-``float``  accepts positive floating point values
-``path``   like ``string`` but also accepts slashes
-``uuid``   accepts UUID strings
-========== ==========================================
+======================   ====================================================
+``string``               (default) accepts any text without a slash
+``int``                  accepts positive integers
+``int(signed=True)``     accepts positive and negative integers
+``float``                accepts positive floating point values
+``float(signed=True)``   accepts positive and negative floating point values
+``path``                 like ``string`` but also accepts slashes
+``uuid``                 accepts UUID strings
+======================   ====================================================
 
 
 Unique URLs / Redirection Behavior


### PR DESCRIPTION
Adds signed int and float converter types to the docs.

Signed ints and floats were added in this PR to werkzeug, but were never added to the flask docs:
https://github.com/pallets/werkzeug/pull/1355

I checked to make sure that these URL paramater types were available in flask, and after testing the following code, I can confirm that they are actually supported.

```
from flask import Flask, request, Response
app = Flask(__name__)
    
@app.route("/int/<int:intParam>", methods=["GET"])
def normalInt(intParam):
    return Response("normalInt: " + str(intParam))

@app.route("/int/<int(signed=True):intParam>", methods=["GET"])
def signedInt(intParam):
    return Response("signedInt: " + str(intParam))
    
@app.route("/float/<float:floatParam>", methods=["GET"])
def normalFloat(floatParam):
    return Response("normalFloat: " + str(floatParam))

@app.route("/float/<float(signed=True):floatParam>", methods=["GET"])
def signedFloat(floatParam):
    return Response("signedFloat: " + str(floatParam))
```