### PR TITLE
Fix: add closing dt tag in example

### DIFF
--- a/docs/patterns/wtforms.rst
+++ b/docs/patterns/wtforms.rst
@@ -82,7 +82,7 @@ Here's an example :file:`_formhelpers.html` template with such a macro:
 .. sourcecode:: html+jinja
 
     {% macro render_field(field) %}
-      <dt>{{ field.label }}
+      <dt>{{ field.label }}</dt>
       <dd>{{ field(**kwargs)|safe }}
       {% if field.errors %}
         <ul class=errors>


### PR DESCRIPTION
`<dt>` is not closed in `render_field()` example so this PR adds the missing `</dt>`.
