### PR TITLE
Use list in methods instead of tuple

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -548,7 +548,7 @@ transmitted in a ``POST`` or ``PUT`` request) you can use the
 :attr:`~flask.Request.form` attribute.  Here is a full example of the two
 attributes mentioned above::
 
-    @app.route('/login', methods=['POST', 'GET'])
+    @app.route('/login', methods=['GET', 'POST'])
     def login():
         error = None
         if request.method == 'POST':

--- a/docs/tutorial/blog.rst
+++ b/docs/tutorial/blog.rst
@@ -142,7 +142,7 @@ will be redirected to the login page.
 .. code-block:: python
     :caption: ``flaskr/blog.py``
 
-    @bp.route('/create', methods=('GET', 'POST'))
+    @bp.route('/create', methods=['GET', 'POST'])
     @login_required
     def create():
         if request.method == 'POST':
@@ -228,7 +228,7 @@ doesn't matter because they're not modifying the post.
 .. code-block:: python
     :caption: ``flaskr/blog.py``
 
-    @bp.route('/<int:id>/update', methods=('GET', 'POST'))
+    @bp.route('/<int:id>/update', methods=['GET', 'POST'])
     @login_required
     def update(id):
         post = get_post(id)
@@ -320,7 +320,7 @@ to the ``index`` view.
 .. code-block:: python
     :caption: ``flaskr/blog.py``
 
-    @bp.route('/<int:id>/delete', methods=('POST',))
+    @bp.route('/<int:id>/delete', methods=['POST',])
     @login_required
     def delete(id):
         get_post(id)

--- a/docs/tutorial/views.rst
+++ b/docs/tutorial/views.rst
@@ -79,7 +79,7 @@ write templates to generate the HTML form.
 .. code-block:: python
     :caption: ``flaskr/auth.py``
 
-    @bp.route('/register', methods=('GET', 'POST'))
+    @bp.route('/register', methods=['GET', 'POST'])
     def register():
         if request.method == 'POST':
             username = request.form['username']
@@ -171,7 +171,7 @@ This view follows the same pattern as the ``register`` view above.
 .. code-block:: python
     :caption: ``flaskr/auth.py``
 
-    @bp.route('/login', methods=('GET', 'POST'))
+    @bp.route('/login', methods=['GET', 'POST'])
     def login():
         if request.method == 'POST':
             username = request.form['username']


### PR DESCRIPTION
To be consistent with the rest of documents.

In API doc, `route` function docstring states that
`methods is a list of methods this rule should be limited to (GET, POST etc.)`

Using list also avoid confusing when using a tuple of 1 element, when new
user tries to remove a method from ('GET', 'POST')
and removed the `,` would make it no longer a tuple.
