### PR TITLE
Add separate and more detailed issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,9 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+---
+
 <!-- **This issue tracker is a tool to address bugs in Flask itself.
 Please use the Pallets Discord or Stack Overflow for general questions
 about using Flask or issues not related to Flask.** -->
@@ -8,15 +14,20 @@ Ideally, create an [MCVE](https://stackoverflow.com/help/mcve), which helps us
 understand the problem and helps check that it is not caused by something in
 your code. -->
 
-### Expected Behavior
-<!-- Tell us what should happen. -->
+### Describe the bug
+<!-- A clear and concise description of what the bug is. -->
+
+### To reproduce
 
 ```python
 # Paste a minimal example that causes the problem.
 ```
 
-### Actual Behavior
-<!-- Tell us what happens instead. -->
+### Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+### Actual behavior
+<!-- What happened instead. -->
 
 ```pytb
 Paste the full traceback if there was an exception.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+
+contact_links:
+- name: Questions
+  url: https://stackoverflow.com/questions/tagged/flask?tab=Frequent
+  about: Search for and ask questions about your code on Stack Overflow
+- name: Questions and discussions
+  url: https://discord.gg/t6rrQZH
+  about: Discuss questions about your code on our Discord chat

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+<!-- **This issue tracker is a tool to address bugs in Flask itself.
+Please use the Pallets Discord or Stack Overflow for general questions
+about using Flask or issues not related to Flask.** -->
+
+### Is your feature request related to a problem
+<!-- A clear and concise description of what the problem is. -->
+
+### Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen. -->
+
+### Describe alternatives you've considered
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+### Additional context
+<!-- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
Previously, there was just a single issue template with "bug report" format. This was good for reporting bugs, but not so convenient for feature requests.

However, GitHub allows multiple issue templates and 'config.yml' file for configuring them. So I added new issue template for feature requests and links to Stack Overflow and Discord to issue reporting menu. Template for bug reports is mostly the same as the original template, and template for feature requests is based on default GitHub feature request template but modified a bit to be consistent with the original template. This will also automatically label issues either as 'bug' or as 'enhancement' depending on which template is chosen. Links to Stack Overflow and Discord were added in similar way as in Werkzeug and Jinja repositories.