### PR TITLE
Updating external_url_handler example to Python 3

### DIFF
--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -239,7 +239,7 @@ def url_for(endpoint, **values):
                 # Re-raise the BuildError, in context of original traceback.
                 exc_type, exc_value, tb = sys.exc_info()
                 if exc_value is error:
-                    raise exc_type, exc_value, tb
+                    raise exc_type(exc_value).with_traceback(tb)
                 else:
                     raise error
             # url_for will use this result, instead of raising BuildError.


### PR DESCRIPTION
The external_url_handler in the documentation for `flask.url_for`
example [1] now uses Python 3 compatible `E(V).with_traceback(T)`
instead of the old `raise E, V, T`.

[1]: https://flask.palletsprojects.com/en/1.1.x/api/#flask.url_for

See also
https://docs.python.org/3/library/2to3.html?highlight=raise#2to3fixer-raise