### PR TITLE
adding an assertion to catch a mistake I made

### DIFF
--- a/docs/tutorial/tests.rst
+++ b/docs/tutorial/tests.rst
@@ -469,6 +469,7 @@ should show an error message on invalid data.
         auth.login()
         response = client.post(path, data={'title': '', 'body': ''})
         assert b'Title is required.' in response.data
+	assert post['body'] == ''
 
 The ``delete`` view should redirect to the index URL and the post should
 no longer exist in the database.


### PR DESCRIPTION
When I followed the tutorial I made a silly mistake in my code, and loaded the title for both title and body in the update function.  When saving an update, this meant the title was mirrored in the body, and the body was thrown away.  After I figured out my problem, I added this text to catch it, then fixed it with this code.  It is a small change, but may help the next developer running through the tutorial.

I actually changed `test_update` to the following, but couldn't decide if it made the tutorial easier or harder to understand:

```
def test_update(client, auth, app):
    auth.login()
    assert client.get('/1/update').status_code == 200
    new_values = {'title': 'updated', 'body': ''}
    client.post('/1/update', data=new_values)

    with app.app_context():
        db = get_db()
        post = db.execute('SELECT * FROM post WHERE id = 1').fetchone()

        for field, value in new_values.items():
            assert post[field] == value
```