### PR TITLE
update tests for new Werkzeug client

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,6 @@ jobs:
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
           - {name: '3.6', python: '3.6', os: ubuntu-latest, tox: py36}
           - {name: 'PyPy', python: pypy3, os: ubuntu-latest, tox: pypy3}
-          - {name: Version Range, python: '3.9', os: ubuntu-latest, tox: 'devel'}
           - {name: Docs, python: '3.9', os: ubuntu-latest, tox: docs}
     steps:
       - uses: actions/checkout@v2

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -327,9 +327,9 @@ def test_modified_url_encoding(app, client):
     def index():
         return flask.request.args["foo"]
 
-    rv = client.get("/?foo=정상처리".encode("euc-kr"))
+    rv = client.get("/", query_string={"foo": "정상처리"}, charset="euc-kr")
     assert rv.status_code == 200
-    assert rv.data == "정상처리".encode()
+    assert rv.get_data(as_text=True) == "정상처리"
 
 
 def test_json_key_sorting(app, client):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     py{39,38,37,36,py3}
-    py38-devel
     style
     docs
 skip_missing_interpreters = true
@@ -10,11 +9,11 @@ skip_missing_interpreters = true
 deps =
     -r requirements/tests.txt
 
-    devel: https://github.com/pallets/werkzeug/archive/master.tar.gz
-    devel: https://github.com/pallets/markupsafe/archive/master.tar.gz
-    devel: https://github.com/pallets/jinja/archive/master.tar.gz
-    devel: https://github.com/pallets/itsdangerous/archive/master.tar.gz
-    devel: https://github.com/pallets/click/archive/master.tar.gz
+    https://github.com/pallets/werkzeug/archive/master.tar.gz
+    https://github.com/pallets/markupsafe/archive/master.tar.gz
+    https://github.com/pallets/jinja/archive/master.tar.gz
+    https://github.com/pallets/itsdangerous/archive/master.tar.gz
+    https://github.com/pallets/click/archive/master.tar.gz
 
 commands =
     pip install -q -e examples/tutorial[test]


### PR DESCRIPTION
Flask's `client.open` mirrors Werkzeug's for processing an existing environ. Fix a test that was passing bytes around incorrectly.

Tox always tests with the latest code of the other Pallets projects. This will be changed back once the new versions are released.