### PR TITLE
Update deprecated set-env ci command

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,7 +44,7 @@ jobs:
           key: pip|${{ runner.os }}|${{ matrix.python }}|${{ hashFiles('setup.py') }}|${{ hashFiles('requirements/*.txt') }}
       - name: set full Python version in PY env var
         # See https://pre-commit.com/#github-actions-example
-        run: echo "::set-env name=PY::$(python -VV | sha256sum | cut -d' ' -f1)"
+        run: echo "name=PY::$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
       - name: cache pre-commit
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
I noticed that recent CI test runs were [failing](https://github.com/pallets/flask/actions/runs/366551315) due to the deprecated `set-env` command. 

These changes update the deprecated command according to [this changelog](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/).