### PR TITLE
Fix ci environment command syntax

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,7 +44,7 @@ jobs:
           key: pip|${{ runner.os }}|${{ matrix.python }}|${{ hashFiles('setup.py') }}|${{ hashFiles('requirements/*.txt') }}
       - name: set full Python version in PY env var
         # See https://pre-commit.com/#github-actions-example
-        run: echo "name=PY::$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
       - name: cache pre-commit
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
This change fixes the incorrect syntax introduced by #3835. Sorry about the mixup!
It has just come to my attention that I mistakenly committed the incorrect new syntax:
```
run: echo "name=PY::$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
```
should become
```
run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
```