### PR TITLE
Add link to reference docs in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,7 @@ Links
 
 * Website: https://palletsprojects.com/p/flask/
 * Documentation: https://flask.palletsprojects.com/
+* Reference Documentation: https://docs.contour.so/pallets/flask/README
 * Releases: https://pypi.org/project/Flask/
 * Code: https://github.com/pallets/flask
 * Issue tracker: https://github.com/pallets/flask/issues


### PR DESCRIPTION
Hi there!

My name is Leo, a CS student at Brown building an automated platform for editable codebase documentation.

I generated documentation for this repository and placed a link in the README. Please feel free to try it out and let me know what you think!

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
