### PR TITLE
Update the example in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Install and update using `pip`_:
 
 .. code-block:: text
 
-    pip install -U Flask
+    $ pip install -U Flask
 
 
 A Simple Example
@@ -28,6 +28,7 @@ A Simple Example
 
 .. code-block:: python
 
+    # save this as app.py
     from flask import Flask
 
     app = Flask(__name__)
@@ -38,9 +39,8 @@ A Simple Example
 
 .. code-block:: text
 
-    $ env FLASK_APP=hello.py flask run
-     * Serving Flask app "hello"
-     * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
+    $ flask run
+      * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
 
 
 Contributing


### PR DESCRIPTION
I don't know if this change is necessary, I just thought that it will be better to keep the example as simple as possible, and make it OS-compatible (the `env` command not available on Windows CMD or Powershell). The new user will learn the details of how to run the application or how the application discovery works in the documentation.