### PR TITLE
Docs update: clarify json error handling

### DIFF
--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -270,7 +270,7 @@ at the application level using the ``request`` proxy object::
     @app.errorhandler(405)
     def _handle_api_error(ex):
         if request.path.startswith('/api/'):
-            return jsonify_error(ex)
+            return jsonify(error=str(ex)), ex.code
         else:
             return ex
 


### PR DESCRIPTION
This is a documentation fix. 

There is no `jsonify_error` method in the codebase. The usage here is unclear. Not sure if it is legacy, the user should implement it themselves, it should be imported from another lib, or just a mistype. 

I figured the best fix was to use `jsonify`. This will return a `200` unless otherwise specified, so I also included the error code.

Hope this is helpful.
