### PR TITLE
use Jinja's tojson filter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,7 @@ Unreleased
 -   The request context does route matching before opening the session.
     This could allow a session interface to change behavior based on
     ``request.endpoint``. :issue:`3776`
+-   Use Jinja's implementation of the ``|tojson`` filter. :issue:`3881`
 
 
 Version 1.1.2

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -250,14 +250,15 @@ for easier customization. By default it handles some extra data types:
 -   :class:`~markupsafe.Markup` (or any object with a ``__html__``
     method) will call the ``__html__`` method to get a string.
 
-:func:`~htmlsafe_dumps` is also available as the ``|tojson`` template
-filter. The filter marks the output with ``|safe`` so it can be used
-inside ``script`` tags.
+Jinja's ``|tojson`` filter is configured to use Flask's :func:`dumps`
+function. The filter marks the output with ``|safe`` automatically. Use
+the filter to render data inside ``<script>`` tags.
 
 .. sourcecode:: html+jinja
 
     <script type=text/javascript>
-        renderChart({{ axis_data|tojson }});
+        const names = {{ names|tosjon }};
+        renderChart(names, {{ axis_data|tojson }});
     </script>
 
 .. autofunction:: jsonify

--- a/docs/patterns/jquery.rst
+++ b/docs/patterns/jquery.rst
@@ -60,26 +60,8 @@ like this:
 .. sourcecode:: html+jinja
 
    <script type=text/javascript>
-     $SCRIPT_ROOT = {{ request.script_root|tojson|safe }};
+     $SCRIPT_ROOT = {{ request.script_root|tojson }};
    </script>
-
-The ``|safe`` is necessary in Flask before 0.10 so that Jinja does not
-escape the JSON encoded string with HTML rules.  Usually this would be
-necessary, but we are inside a ``script`` block here where different rules
-apply.
-
-.. admonition:: Information for Pros
-
-   In HTML the ``script`` tag is declared ``CDATA`` which means that entities
-   will not be parsed.  Everything until ``</script>`` is handled as script.
-   This also means that there must never be any ``</`` between the script
-   tags.  ``|tojson`` is kind enough to do the right thing here and
-   escape slashes for you (``{{ "</script>"|tojson|safe }}`` is rendered as
-   ``"<\/script>"``).
-
-   In Flask 0.10 it goes a step further and escapes all HTML tags with
-   unicode escapes.  This makes it possible for Flask to automatically
-   mark the result as HTML safe.
 
 
 JSON View Functions

--- a/docs/templating.rst
+++ b/docs/templating.rst
@@ -95,37 +95,6 @@ by default:
 
       {% from '_helpers.html' import my_macro with context %}
 
-Standard Filters
-----------------
-
-Flask provides the following Jinja2 filters in addition to the filters provided
-by Jinja2 itself:
-
-.. function:: tojson
-   :noindex:
-
-   This function converts the given object into JSON representation.  This
-   is for example very helpful if you try to generate JavaScript on the
-   fly.
-
-   .. sourcecode:: html+jinja
-
-       <script type=text/javascript>
-           doSomethingWith({{ user.username|tojson }});
-       </script>
-
-   It is also safe to use the output of `|tojson` in a *single-quoted* HTML
-   attribute:
-
-   .. sourcecode:: html+jinja
-
-       <button onclick='doSomethingWith({{ user.username|tojson }})'>
-           Click me
-       </button>
-
-   Note that in versions of Flask prior to 0.10, if using the output of
-   ``|tojson`` inside ``script``, make sure to disable escaping with ``|safe``.
-   In Flask 0.10 and above, this happens automatically.
 
 Controlling Autoescaping
 ------------------------

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -681,7 +681,7 @@ class Flask(Scaffold):
             session=session,
             g=g,
         )
-        rv.filters["tojson"] = json.tojson_filter
+        rv.policies["json.dumps_function"] = json.dumps
         return rv
 
     def create_global_jinja_loader(self):


### PR DESCRIPTION
Set `app.jinja_env.policies["json.dumps_function"]` to have Jinja's `|tojson` filter use Flask's `dumps` function, instead of overriding the filter.

Also have `htmlsafe_dumps` use `jinja2.utils.htmlsafe_json_dumps`. I debated deprecating Flask's implementation, especially since it's not documented as part of the public API. Figured it was still good enough to keep in for now, given that it's not entirely obvious that you would have to pass `dumps=flask.json.dumps` in order to get Flask's behavior.

closes #3881