### PR TITLE
Add Qovery option to deploy Flask

### DIFF
--- a/docs/deploying/index.rst
+++ b/docs/deploying/index.rst
@@ -19,6 +19,7 @@ Hosted options
 - `Deploying Flask on AWS Elastic Beanstalk <https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create-deploy-python-flask.html>`_
 - `Deploying on Azure (IIS) <https://docs.microsoft.com/en-us/azure/app-service/containers/how-to-configure-python>`_
 - `Deploying on PythonAnywhere <https://help.pythonanywhere.com/pages/Flask/>`_
+- `Deploying Flask on Qovery <https://docs.qovery.com/guides/tutorial/deploy-flask-with-postgresql/>`_
 
 Self-hosted options
 -------------------

--- a/docs/deploying/index.rst
+++ b/docs/deploying/index.rst
@@ -19,7 +19,7 @@ Hosted options
 - `Deploying Flask on AWS Elastic Beanstalk <https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create-deploy-python-flask.html>`_
 - `Deploying on Azure (IIS) <https://docs.microsoft.com/en-us/azure/app-service/containers/how-to-configure-python>`_
 - `Deploying on PythonAnywhere <https://help.pythonanywhere.com/pages/Flask/>`_
-- `Deploying Flask on Qovery <https://docs.qovery.com/guides/tutorial/deploy-flask-with-postgresql/>`_
+- `Deploying Flask on Qovery <https://docs.qovery.com/guides/tutorial/deploy-flask-with-postgresql/>`_ 
 
 Self-hosted options
 -------------------

--- a/docs/deploying/index.rst
+++ b/docs/deploying/index.rst
@@ -19,7 +19,7 @@ Hosted options
 - `Deploying Flask on AWS Elastic Beanstalk <https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create-deploy-python-flask.html>`_
 - `Deploying on Azure (IIS) <https://docs.microsoft.com/en-us/azure/app-service/containers/how-to-configure-python>`_
 - `Deploying on PythonAnywhere <https://help.pythonanywhere.com/pages/Flask/>`_
-- `Deploying Flask on Qovery <https://docs.qovery.com/guides/tutorial/deploy-flask-with-postgresql/>`_ 
+- `Deploying Flask on Qovery <https://docs.qovery.com/guides/tutorial/deploy-flask-with-postgresql/>`_
 
 Self-hosted options
 -------------------


### PR DESCRIPTION
Hi the Flask maintainers,

I added docs on deploying Flask on Qovery. We already have more than 100 developers deploying their Flask app on Qovery. - feedback is welcome.

Romaric.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
