### PR TITLE
Fix CLI for latest Werkzeug (2.0.0rc1)

### DIFF
--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -48,7 +48,13 @@ def find_best_app(script_info, module):
             return app
 
     # Otherwise find the only object that is a Flask instance.
-    matches = [v for v in module.__dict__.values() if isinstance(v, Flask)]
+    matches = []
+    for v in module.__dict__.values():
+        try:
+            if isinstance(v, Flask):
+                matches.append(v)
+        except Exception:
+            pass
 
     if len(matches) == 1:
         return matches[0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,8 @@ def test_cli_name(test_apps):
 
 
 def test_find_best_app(test_apps):
+    from werkzeug.local import LocalProxy
+
     script_info = ScriptInfo()
 
     class Module:
@@ -62,6 +64,17 @@ def test_find_best_app(test_apps):
     assert find_best_app(script_info, Module) == Module.myapp
 
     class Module:
+        @staticmethod
+        def create_app():
+            return Flask("appname")
+
+    app = find_best_app(script_info, Module)
+    assert isinstance(app, Flask)
+    assert app.name == "appname"
+
+    class Module:
+        log = LocalProxy(lambda: current_app.logger)
+
         @staticmethod
         def create_app():
             return Flask("appname")


### PR DESCRIPTION
Wrap the `isinstance` check in a try/except to ignore failing objects (LocalProxy outside app context).

"LocalProxy matches the current Python data model special methods, including all r-ops, in-place ops, and async. class is proxied, so the proxy will look like the object in more cases, including isinstance. Use issubclass(type(obj), LocalProxy) to check if an object is actually a proxy. :issue:1754"

- fixes #3909 

Checklist:

- [X] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [X] Run `pre-commit` hooks and fix any issues.
- [X] Run `pytest` and `tox`, no tests failed.
