### PR TITLE
Utilise defaultdicts

### DIFF
--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -430,13 +430,13 @@ class Flask(Scaffold):
         #: .. versionadded:: 0.11
         self.shell_context_processors = []
 
-        #: all the attached blueprints in a dictionary by name.  Blueprints
-        #: can be attached multiple times so this dictionary does not tell
-        #: you how often they got attached.
+        #: Maps registered blueprint names to blueprint objects. The
+        #: dict retains the order the blueprints were registered in.
+        #: Blueprints can be registered multiple times, this dict does
+        #: not track how often they were attached.
         #:
         #: .. versionadded:: 0.7
         self.blueprints = {}
-        self._blueprint_order = []
 
         #: a place where extensions can store application specific state.  For
         #: example this is where an extension could store database engines and
@@ -997,7 +997,6 @@ class Flask(Scaffold):
             )
         else:
             self.blueprints[blueprint.name] = blueprint
-            self._blueprint_order.append(blueprint)
             first_registration = True
 
         blueprint.register(self, options, first_registration)
@@ -1007,7 +1006,7 @@ class Flask(Scaffold):
 
         .. versionadded:: 0.11
         """
-        return iter(self._blueprint_order)
+        return self.blueprints.values()
 
     @setupmethod
     def add_url_rule(

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1292,7 +1292,7 @@ class Flask(Scaffold):
             (request.blueprint, None),
             (None, None),
         ):
-            handler_map = self.error_handler_spec.setdefault(name, {}).get(c)
+            handler_map = self.error_handler_spec[name][c]
 
             if not handler_map:
                 continue
@@ -1753,10 +1753,10 @@ class Flask(Scaffold):
 
         .. versionadded:: 0.7
         """
-        funcs = self.url_default_functions.get(None, ())
+        funcs = self.url_default_functions[None]
         if "." in endpoint:
             bp = endpoint.rsplit(".", 1)[0]
-            funcs = chain(funcs, self.url_default_functions.get(bp, ()))
+            funcs = chain(funcs, self.url_default_functions[bp])
         for func in funcs:
             func(endpoint, values)
 
@@ -1794,13 +1794,13 @@ class Flask(Scaffold):
 
         bp = _request_ctx_stack.top.request.blueprint
 
-        funcs = self.url_value_preprocessors.get(None, ())
+        funcs = self.url_value_preprocessors[None]
         if bp is not None and bp in self.url_value_preprocessors:
             funcs = chain(funcs, self.url_value_preprocessors[bp])
         for func in funcs:
             func(request.endpoint, request.view_args)
 
-        funcs = self.before_request_funcs.get(None, ())
+        funcs = self.before_request_funcs[None]
         if bp is not None and bp in self.before_request_funcs:
             funcs = chain(funcs, self.before_request_funcs[bp])
         for func in funcs:
@@ -1857,7 +1857,7 @@ class Flask(Scaffold):
         """
         if exc is _sentinel:
             exc = sys.exc_info()[1]
-        funcs = reversed(self.teardown_request_funcs.get(None, ()))
+        funcs = reversed(self.teardown_request_funcs[None])
         bp = _request_ctx_stack.top.request.blueprint
         if bp is not None and bp in self.teardown_request_funcs:
             funcs = chain(funcs, reversed(self.teardown_request_funcs[bp]))

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -251,7 +251,7 @@ class Blueprint(Scaffold):
             """
             for key, values in self_dict.items():
                 key = self.name if key is None else f"{self.name}.{key}"
-                app_dict.setdefault(key, []).extend(values)
+                app_dict[key].extend(values)
 
         def merge_dict_nested(self_dict, app_dict):
             """Merges self_dict into app_dict. Replaces None keys with self.name.


### PR DESCRIPTION
This code originates from the Python 2.4 supporting version of Flask,
with defaultdicts being added in 2.5. Using defaultdict makes the
intentional usage clearer, and slightly simplifies the code.
