### PR TITLE
Nested blueprints

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,7 @@ Unreleased
     ``@app.route("/login", methods=["POST"])``. :pr:`3907`
 -   Support async views, error handlers, before and after request, and
     teardown functions. :pr:`3412`
+-   Support nesting blueprints. :issue:`593, 1548`, :pr:`3923`
 
 
 Version 1.1.2

--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -120,6 +120,31 @@ On top of that you can register blueprints multiple times though not every
 blueprint might respond properly to that.  In fact it depends on how the
 blueprint is implemented if it can be mounted more than once.
 
+Nesting Blueprints
+------------------
+
+It is possible to register a blueprint on another blueprint.
+
+.. code-block:: python
+
+    parent = Blueprint("parent", __name__, url_prefix="/parent")
+    child = Blueprint("child", __name__, url_prefix="/child)
+    parent.register_blueprint(child)
+    app.register_blueprint(parent)
+
+The child blueprint will gain the parent's name as a prefix to its
+name, and child URLs will be prefixed with the parent's URL prefix.
+
+.. code-block:: python
+
+    url_for('parent.child.create')
+    /parent/child/create
+
+Blueprint-specific before request functions, etc. registered with the
+parent will trigger for the child. If a child does not have an error
+handler that can handle a given exception, the parent's will be tried.
+
+
 Blueprint Resources
 -------------------
 

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -850,3 +850,52 @@ def test_app_url_processors(app, client):
 
     assert client.get("/de/").data == b"/de/about"
     assert client.get("/de/about").data == b"/de/"
+
+
+def test_nested_blueprint(app, client):
+    parent = flask.Blueprint("parent", __name__)
+    child = flask.Blueprint("child", __name__)
+    grandchild = flask.Blueprint("grandchild", __name__)
+
+    @parent.errorhandler(403)
+    def forbidden(e):
+        return "Parent no", 403
+
+    @parent.route("/")
+    def parent_index():
+        return "Parent yes"
+
+    @parent.route("/no")
+    def parent_no():
+        flask.abort(403)
+
+    @child.route("/")
+    def child_index():
+        return "Child yes"
+
+    @child.route("/no")
+    def child_no():
+        flask.abort(403)
+
+    @grandchild.errorhandler(403)
+    def grandchild_forbidden(e):
+        return "Grandchild no", 403
+
+    @grandchild.route("/")
+    def grandchild_index():
+        return "Grandchild yes"
+
+    @grandchild.route("/no")
+    def grandchild_no():
+        flask.abort(403)
+
+    child.register_blueprint(grandchild, url_prefix="/grandchild")
+    parent.register_blueprint(child, url_prefix="/child")
+    app.register_blueprint(parent, url_prefix="/parent")
+
+    assert client.get("/parent/").data == b"Parent yes"
+    assert client.get("/parent/child/").data == b"Child yes"
+    assert client.get("/parent/child/grandchild/").data == b"Grandchild yes"
+    assert client.get("/parent/no").data == b"Parent no"
+    assert client.get("/parent/child/no").data == b"Parent no"
+    assert client.get("/parent/child/grandchild/no").data == b"Grandchild no"


### PR DESCRIPTION
This allows blueprints to be nested within blueprints via a new
Blueprint.register_blueprint method. This should provide a use case
that has been desired for the past ~10 years.

This works by setting the endpoint name to be the blueprint names,
from parent to child delimeted by "." and then iterating over the
blueprint names in reverse order in the app (from most specific to
most general). This means that the expectation of nesting a blueprint
within a nested blueprint is met.

- fixes #593
- fixes #1548

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
