### PR TITLE
One more attribute required in form file input field

### DIFF
--- a/docs/patterns/fileuploads.rst
+++ b/docs/patterns/fileuploads.rst
@@ -5,7 +5,7 @@ Ah yes, the good old problem of file uploads.  The basic idea of file
 uploads is actually quite simple.  It basically works like this:
 
 1. A ``<form>`` tag is marked with ``enctype=multipart/form-data``
-   and an ``<input type=file>`` is placed in that form.
+   and an ``<input type=file name=file>`` is placed in that form.
 2. The application accesses the file from the :attr:`~flask.request.files`
    dictionary on the request object.
 3. use the :meth:`~werkzeug.datastructures.FileStorage.save` method of the file to save


### PR DESCRIPTION
without the attribute -- name=file -- being present on the file input element in the form, the request object's files attribute was an empty immutablemultidict. The uploaded file was not being found and consequently the "no file part" message was being flashed.

With the addition of name attribute in the template/html form the upload worked as intended.

Thus I suggest this change in the docs

Thank you

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #<issue number>

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
