### PR TITLE
Set default encoding to UTF-8 for load_dotenv

### DIFF
--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -619,6 +619,9 @@ def load_dotenv(path=None):
         Returns ``False`` when python-dotenv is not installed, or when
         the given path isn't a file.
 
+    .. versionchanged:: 2.0
+        When loading the env files, set the default encoding to UTF-8.
+
     .. versionadded:: 1.0
     """
     if dotenv is None:
@@ -636,7 +639,7 @@ def load_dotenv(path=None):
     # else False
     if path is not None:
         if os.path.isfile(path):
-            return dotenv.load_dotenv(path)
+            return dotenv.load_dotenv(path, encoding="utf-8")
 
         return False
 
@@ -651,7 +654,7 @@ def load_dotenv(path=None):
         if new_dir is None:
             new_dir = os.path.dirname(path)
 
-        dotenv.load_dotenv(path)
+        dotenv.load_dotenv(path, encoding="utf-8")
 
     return new_dir is not None  # at least one file was located and loaded
 

--- a/tests/test_apps/.env
+++ b/tests/test_apps/.env
@@ -1,3 +1,4 @@
 FOO=env
 SPAM=1
 EGGS=2
+HAM=火腿

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -505,7 +505,7 @@ need_dotenv = pytest.mark.skipif(dotenv is None, reason="dotenv is not installed
 @need_dotenv
 def test_load_dotenv(monkeypatch):
     # can't use monkeypatch.delitem since the keys don't exist yet
-    for item in ("FOO", "BAR", "SPAM"):
+    for item in ("FOO", "BAR", "SPAM", "HAM"):
         monkeypatch._setitem.append((os.environ, item, notset))
 
     monkeypatch.setenv("EGGS", "3")
@@ -520,7 +520,8 @@ def test_load_dotenv(monkeypatch):
     assert os.environ["SPAM"] == "1"
     # set manually, files don't overwrite
     assert os.environ["EGGS"] == "3"
-
+    # test env file encoding
+    assert os.environ["HAM"] == "火腿"
     # Non existent file should not load
     assert not load_dotenv("non-existent-file")
 


### PR DESCRIPTION
This PR will set encoding to UTF-8 when calling `dotenv.load_dotenv()`.

Is it necessary to add a `encoding` argument for `cli.load_dotenv`?

fixes #3931 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
