### PR TITLE
Docs: fix a broken link

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -876,7 +876,7 @@ Hooking in WSGI Middleware
 
 To add WSGI middleware to your Flask application, wrap the application's
 ``wsgi_app`` attribute. For example, to apply Werkzeug's
-:class:`~werkzeug.middlware.proxy_fix.ProxyFix` middleware for running
+:class:`~werkzeug.middleware.proxy_fix.ProxyFix` middleware for running
 behind Nginx:
 
 .. code-block:: python


### PR DESCRIPTION
Fixed a broken link in `docs/quickstart.rst ` which refers to [`werkzeug.middleware.proxy_fix.ProxyFix`](https://werkzeug.palletsprojects.com/en/1.0.x/middleware/proxy_fix/?highlight=middleware%20proxy_fix%20proxyfix#werkzeug.middleware.proxy_fix.ProxyFix).