### PR TITLE
Fixture url updated

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -96,7 +96,7 @@ Even though it did not run any actual tests, we already know that our
 would have died with an exception.
 
 .. _pytest fixture:
-   https://docs.pytest.org/en/latest/fixture.html
+   https://docs.pytest.org/en/latest/reference/reference.html#pytest.fixture
 
 The First Test
 --------------


### PR DESCRIPTION
URL no longer works.  New link = https://docs.pytest.org/en/latest/reference/reference.html#pytest.fixture

