### PR TITLE
feat: support secret key has callable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Version 2.0.0
 
 Unreleased
 
--   Superset `SECRET_KEY` has a callable
+-   Support `SECRET_KEY` has a callable
 -   Drop support for Python 2 and 3.5.
 -   JSON support no longer uses simplejson. To use another JSON module,
     override ``app.json_encoder`` and ``json_decoder``. :issue:`3555`

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 2.0.0
 
 Unreleased
 
+-   Superset `SECRET_KEY` has a callable
 -   Drop support for Python 2 and 3.5.
 -   JSON support no longer uses simplejson. To use another JSON module,
     override ``app.json_encoder`` and ``json_decoder``. :issue:`3555`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -177,8 +177,9 @@ The following configuration values are used internally by Flask:
 
     A secret key that will be used for securely signing the session cookie
     and can be used for any other security related needs by extensions or your
-    application. It should be a long random ``bytes`` or ``str``. For
-    example, copy the output of this to your config::
+    application. It should be a long random ``bytes`` or ``str`` or a callable
+    that returns the previous types. For example,
+    copy the output of this to your config::
 
         $ python -c 'import os; print(os.urandom(16))'
         b'_5#y2L"F4Q8z\n\xec]/'

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -61,6 +61,10 @@ def _make_timedelta(value):
     return timedelta(seconds=value)
 
 
+def _call_if_callable(value):
+    return value if not callable(value) else value()
+
+
 class Flask(Scaffold):
     """The flask object implements a WSGI application and acts as the central
     object.  It is passed the name of the module or package of the
@@ -216,7 +220,7 @@ class Flask(Scaffold):
     #:
     #: This attribute can also be configured from the config with the
     #: :data:`SECRET_KEY` configuration key. Defaults to ``None``.
-    secret_key = ConfigAttribute("SECRET_KEY")
+    secret_key = ConfigAttribute("SECRET_KEY", get_converter=_call_if_callable)
 
     #: The secure cookie uses this for the name of the session cookie.
     #:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -253,6 +253,27 @@ def test_session(app, client):
     assert client.get("/get").data == b"42"
 
 
+def test_session_callable_secret():
+    def dynamic_secret_key():
+        from flask import request
+
+        return request.host
+
+    app = flask.Flask(__name__)
+    app.config.from_mapping({"SECRET_KEY": dynamic_secret_key})
+    client = app.test_client()
+
+    @app.route("/")
+    def index():
+        flask.session["testing"] = 42
+        return "Hello World"
+
+    with app.test_request_context():
+        assert app.secret_key == "localhost"
+
+    assert client.get("/").data == b"Hello World"
+
+
 def test_session_using_server_name(app, client):
     app.config.update(SERVER_NAME="example.com")
 


### PR DESCRIPTION
Supports the configuration of `Flask` secret key has a callable.

Following #3950 feature request.

Checklist:

- [X] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [X] Add or update relevant docs, in the docs folder and in code.
- [X] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [X] Run `pre-commit` hooks and fix any issues.
- [X] Run `pytest` and `tox`, no tests failed.
