### PR TITLE
deprecate `helpers.total_seconds`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,8 @@ Unreleased
 -   Support nesting blueprints. :issue:`593, 1548`, :pr:`3923`
 -   ``flask shell`` sets up tab and history completion like the default
     ``python`` shell if ``readline`` is installed. :issue:`3941`
+-   ``helpers.total_seconds()`` is deprecated. Use
+    ``timedelta.total_seconds()`` instead. :pr:`3962`
 
 
 Version 1.1.2

--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -18,13 +18,6 @@ from .globals import request
 from .globals import session
 from .signals import message_flashed
 
-# what separators does this operating system provide that are not a slash?
-# this is used by the send_from_directory function to ensure that nobody is
-# able to access files from outside the filesystem.
-_os_alt_seps = list(
-    sep for sep in [os.path.sep, os.path.altsep] if sep not in (None, "/")
-)
-
 
 def get_env():
     """Get the environment the app is running in, indicated by the

--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -709,7 +709,17 @@ def total_seconds(td):
 
     :returns: number of seconds
     :rtype: int
+
+    .. deprecated:: 2.0
+        Will be removed in Flask 2.1. Use
+        :meth:`timedelta.total_seconds` instead.
     """
+    warnings.warn(
+        "'total_seconds' is deprecated and will be removed in Flask"
+        " 2.1. Use 'timedelta.total_seconds' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return td.days * 60 * 60 * 24 + td.seconds
 
 

--- a/src/flask/sessions.py
+++ b/src/flask/sessions.py
@@ -8,7 +8,6 @@ from itsdangerous import URLSafeTimedSerializer
 from werkzeug.datastructures import CallbackDict
 
 from .helpers import is_ip
-from .helpers import total_seconds
 from .json.tag import TaggedJSONSerializer
 
 
@@ -340,7 +339,7 @@ class SecureCookieSessionInterface(SessionInterface):
         val = request.cookies.get(self.get_cookie_name(app))
         if not val:
             return self.session_class()
-        max_age = total_seconds(app.permanent_session_lifetime)
+        max_age = int(app.permanent_session_lifetime.total_seconds())
         try:
             data = s.loads(val, max_age=max_age)
             return self.session_class(data)


### PR DESCRIPTION
`timedelta.total_seconds()` was added in Python 3.2.

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
