### PR TITLE
Allow using Click 7 with a DeprecationWarning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,10 @@ Unreleased
 -   Drop support for Python 2 and 3.5.
 -   Bump minimum versions of other Pallets projects: Werkzeug >= 2,
     Jinja2 >= 3, MarkupSafe >= 2, ItsDangerous >= 2, Click >= 8. Be sure
-    to check the change logs for each project.
+    to check the change logs for each project. For better compatibility
+    with other applications (e.g. Celery) that still require Click 7,
+    there is no hard dependency on Click 8 yet, but using Click 7 will
+    trigger a DeprecationWarning and Flask 2.1 will depend on Click 8.
 -   JSON support no longer uses simplejson. To use another JSON module,
     override ``app.json_encoder`` and ``json_decoder``. :issue:`3555`
 -   The ``encoding`` option to JSON functions is deprecated. :pr:`3562`

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
         "Werkzeug>=2.0.0rc4",
         "Jinja2>=3.0.0rc1",
         "itsdangerous>=2.0.0rc2",
-        "click>=8.0.0rc1",
+        "click>=7.1.2",
     ],
     extras_require={
         "async": ["asgiref>=3.2"],

--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -979,6 +979,13 @@ debug mode.
 
 
 def main() -> None:
+    if int(click.__version__[0]) < 8:
+        warnings.warn(
+            "Using the `flask` cli with Click 7 is deprecated and"
+            " will not be supported starting with Flask 2.1."
+            " Please upgrade to Click 8 as soon as possible.",
+            DeprecationWarning,
+        )
     # TODO omit sys.argv once https://github.com/pallets/click/issues/536 is fixed
     cli.main(args=sys.argv[1:])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import ssl
 import sys
 import types
 from functools import partial
+from unittest.mock import patch
 
 import click
 import pytest
@@ -21,6 +22,7 @@ from flask.cli import FlaskGroup
 from flask.cli import get_version
 from flask.cli import load_dotenv
 from flask.cli import locate_app
+from flask.cli import main as cli_main
 from flask.cli import NoAppException
 from flask.cli import prepare_import
 from flask.cli import run_command
@@ -660,3 +662,11 @@ def test_cli_empty(app):
 
     result = app.test_cli_runner().invoke(args=["blue", "--help"])
     assert result.exit_code == 2, f"Unexpected success:\n\n{result.output}"
+
+
+def test_click_7_deprecated():
+    with patch("flask.cli.cli"):
+        if int(click.__version__[0]) < 8:
+            pytest.deprecated_call(cli_main, match=".* Click 7 is deprecated")
+        else:
+            cli_main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     py{39,38,37,36,py3}
+    py39-click7
     style
     typing
     docs
@@ -14,7 +15,9 @@ deps =
     https://github.com/pallets/markupsafe/archive/master.tar.gz
     https://github.com/pallets/jinja/archive/master.tar.gz
     https://github.com/pallets/itsdangerous/archive/master.tar.gz
-    https://github.com/pallets/click/archive/master.tar.gz
+
+    !click7: https://github.com/pallets/click/archive/master.tar.gz
+    click7: click<8
 
     examples/tutorial[test]
     examples/javascript[test]


### PR DESCRIPTION
As long as popular libraries (e.g. Celery) require click 7, depending on Click 8 in Flask makes it hard to test the latest version (and its other dependencies) in existing applications.