### PR TITLE
Update docs changelog URL to "/changes"

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,4 +1,4 @@
-Changelog
-=========
+Changes
+=======
 
 .. include:: ../CHANGES.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -88,6 +88,6 @@ Design notes, legal information and changelog are here for the interested.
    extensiondev
    styleguide
    upgrading
-   changelog
+   changes
    license
    contributing


### PR DESCRIPTION
[This commit](https://github.com/pallets/flask/commit/9e7d3a6b694b27f997266889ae463e06dd83a189) changes the URL of the changelog page from `/changelog` to `/changes`, this will break the URL in the [version warning banner](https://flask.palletsprojects.com/en/master/changes/#version-2-0-0) for non-stable versions. This PR will update the URL in old docs. It will be ideal to add a redirect entry on [readthedocs's redirects setting page](https://readthedocs.org/dashboard/flask/redirects/).