### PR TITLE
Improve CLI docs

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -45,13 +45,13 @@ While ``FLASK_APP`` supports a variety of options for specifying your
 application, most use cases should be simple. Here are the typical values:
 
 (nothing)
-    The file :file:`wsgi.py` is imported, automatically detecting an app
-    (``app``). This provides an easy way to create an app from a factory with
-    extra arguments.
+    The name "app" or "wsgi" is imported (as a ".py" file, or package),
+    automatically detecting an app (``app`` or ``application``) or
+    factory (``create_app`` or ``make_app``).
 
 ``FLASK_APP=hello``
-    The name is imported, automatically detecting an app (``app``) or factory
-    (``create_app``).
+    The given name is imported, automatically detecting an app (``app``
+    or ``application``) or factory (``create_app`` or ``make_app``).
 
 ----
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -50,7 +50,7 @@ to tell your terminal the application to work with by exporting the
 
       .. code-block:: text
 
-         $ export FLASK_APP=hello.py
+         $ export FLASK_APP=hello
          $ flask run
           * Running on http://127.0.0.1:5000/
 
@@ -58,7 +58,7 @@ to tell your terminal the application to work with by exporting the
 
       .. code-block:: text
 
-         > set FLASK_APP=hello.py
+         > set FLASK_APP=hello
          > flask run
           * Running on http://127.0.0.1:5000/
 
@@ -66,9 +66,15 @@ to tell your terminal the application to work with by exporting the
 
       .. code-block:: text
 
-         > $env:FLASK_APP = "hello.py"
+         > $env:FLASK_APP = "hello"
          > flask run
           * Running on http://127.0.0.1:5000/
+
+.. admonition:: Application Discovery Behavior
+
+    As a shortcut, if the file is named ``app.py`` or ``wsgi.py``, you
+    don't have to set the ``FLASK_APP`` environment variable. See
+    :doc:`/cli` for more details.
 
 This launches a very simple builtin server, which is good enough for
 testing but probably not what you want to use in production. For


### PR DESCRIPTION
Rewrite the description for the behaviour when `FLASK_APP` is not set. This PR also will add a tip for application discovery behaviour in the quickstart docs.

Besides, the value of `FLASK_APP` is `hello.py` in the quickstart docs while `hello` is used in the remaining docs, should we update the former to `hello` to make it more consistent?

- fixes #3998

