### PR TITLE
update click minimum version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Version 2.1.0
 
 Unreleased
 
+-   Update Click dependency to >= 8.0.
+
 
 Version 2.0.1
 -------------

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
         "Werkzeug>=2.0",
         "Jinja2>=3.0",
         "itsdangerous>=2.0",
-        "click>=7.1.2",
+        "click>=8.0",
     ],
     extras_require={
         "async": ["asgiref>=3.2"],


### PR DESCRIPTION
This was left at > 7.1.2 for the Flask 2.0 release for compatibility with some external projects, and would show a deprecation warning if not > 8.0. It is now a hard dependency.