### PR TITLE
Fix typo in the example of nesting bp docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,11 @@
 .. currentmodule:: flask
 
+Version 2.1.0
+-------------
+
+Unreleased
+
+
 Version 2.0.1
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,11 @@
 .. currentmodule:: flask
 
+Version 2.0.1
+-------------
+
+Unreleased
+
+
 Version 2.0.0
 -------------
 

--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -127,8 +127,8 @@ It is possible to register a blueprint on another blueprint.
 
 .. code-block:: python
 
-    parent = Blueprint("parent", __name__, url_prefix="/parent")
-    child = Blueprint("child", __name__, url_prefix="/child)
+    parent = Blueprint('parent', __name__, url_prefix='/parent')
+    child = Blueprint('child', __name__, url_prefix='/child')
     parent.register_blueprint(child)
     app.register_blueprint(parent)
 

--- a/src/flask/__init__.py
+++ b/src/flask/__init__.py
@@ -43,4 +43,4 @@ from .signals import template_rendered
 from .templating import render_template
 from .templating import render_template_string
 
-__version__ = "2.0.0"
+__version__ = "2.0.1.dev0"

--- a/src/flask/__init__.py
+++ b/src/flask/__init__.py
@@ -43,4 +43,4 @@ from .signals import template_rendered
 from .templating import render_template
 from .templating import render_template_string
 
-__version__ = "2.0.1.dev0"
+__version__ = "2.1.0.dev0"


### PR DESCRIPTION
- Add missing closing quote after `url_prefix='/child`.
- Use single quote for consistency.