### PR TITLE
Fix typo in the example of nesting blueprint docs

### DIFF
--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -127,8 +127,8 @@ It is possible to register a blueprint on another blueprint.
 
 .. code-block:: python
 
-    parent = Blueprint("parent", __name__, url_prefix="/parent")
-    child = Blueprint("child", __name__, url_prefix="/child)
+    parent = Blueprint('parent', __name__, url_prefix='/parent')
+    child = Blueprint('child', __name__, url_prefix='/child')
     parent.register_blueprint(child)
     app.register_blueprint(parent)
 


### PR DESCRIPTION
- Add missing closing quote after `url_prefix='/child`.
- Use single quotes for consistency.

Supersedes #4013