### PR TITLE
Update changelog for send_from_directory change

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,8 @@ Released 2021-05-11
     deprecated. ``attachment_filename`` is renamed to ``download_name``.
     ``cache_timeout`` is renamed to ``max_age``. ``add_etags`` is
     renamed to ``etag``. :pr:`3828, 3883`
+-   The ``filename`` parameter in ``send_from_directory`` has been renamed
+    to ``path``. :pr:`3828`
 -   ``send_file`` passes ``download_name`` even if
     ``as_attachment=False`` by using ``Content-Disposition: inline``.
     :pr:`3828`

--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -666,6 +666,9 @@ def send_from_directory(directory: str, path: str, **kwargs: t.Any) -> "Response
         ``directory``.
     :param kwargs: Arguments to pass to :func:`send_file`.
 
+    .. versionchanged:: 2.0
+        ``path`` replaces the ``filename`` parameter.
+
     .. versionadded:: 2.0
         Moved the implementation to Werkzeug. This is now a wrapper to
         pass some Flask-specific arguments.


### PR DESCRIPTION
The parameter `filename` has been renamed to `path` (accidentally?).