### PR TITLE
Update env to venv for consistency with the rest docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -102,15 +102,15 @@ First time setup
 
           .. code-block:: text
 
-             $ python3 -m venv env
-             $ . env/bin/activate
+             $ python3 -m venv venv
+             $ . venv/bin/activate
 
        .. group-tab:: Windows
 
           .. code-block:: text
 
-             > py -3 -m venv env
-             > env\Scripts\activate
+             > py -3 -m venv venv
+             > venv\Scripts\activate
 
 -   Install the development dependencies, then install Flask in editable
     mode.


### PR DESCRIPTION
`venv` is used in `docs/cli.rst`, `docs/installation.rst`, the tutorial part and example part.

This PR makes it consistent with the rest Flask docs.

Supplement #4028 