### PR TITLE
set maximum versions for 1.1.x to avoid new major versions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,13 +2,15 @@
 
 
 
-Version 1.1.x
+Version 1.1.3
 -------------
 
-Not yet released.
+Unreleased
 
--   Officially support passing a :class:`pathlib.Path` for
-    ``static_folder`` which stopped working in 1.1.2. :pr:`3579`
+-   Set maximum versions of Werkzeug, Jinja, Click, and ItsDangerous.
+    :issue:`4043`
+-   Re-add support for passing a ``pathlib.Path`` for ``static_folder``.
+    :pr:`3579`
 
 
 Version 1.1.2

--- a/setup.py
+++ b/setup.py
@@ -53,10 +53,10 @@ setup(
     include_package_data=True,
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     install_requires=[
-        "Werkzeug>=0.15",
-        "Jinja2>=2.10.1",
-        "itsdangerous>=0.24",
-        "click>=5.1",
+        "Werkzeug >= 0.15, < 2.0",
+        "Jinja2 >= 2.10.1, < 3.0",
+        "itsdangerous >= 0.24, < 2.0",
+        "click >= 5.1, < 8.0",
     ],
     extras_require={
         "dotenv": ["python-dotenv"],

--- a/src/flask/__init__.py
+++ b/src/flask/__init__.py
@@ -57,4 +57,4 @@ from .signals import template_rendered
 from .templating import render_template
 from .templating import render_template_string
 
-__version__ = "1.1.2"
+__version__ = "1.1.3.dev0"


### PR DESCRIPTION
Our *strong* advice to all maintainers of applications experiencing issues with upgrades is to pin dependencies using a tool such as [pip-compile](https://pypi.org/project/pip-tools/). Issues can happen with any transitive dependencies in your stack, not only Flask's, so applications need to pin to control when they get updates.

In this *specific* case, because we intend the 2.0, etc. releases to be a new baseline and are immediately not supporting the 1.1.x line, we will make a new release to set maximum versions. We do not intend to do this in general for future releases.

fixes #4043