### PR TITLE
Release 1.1.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 Version 1.1.3
 -------------
 
-Unreleased
+Released 2021-05-13
 
 -   Set maximum versions of Werkzeug, Jinja, Click, and ItsDangerous.
     :issue:`4043`

--- a/src/flask/__init__.py
+++ b/src/flask/__init__.py
@@ -57,4 +57,4 @@ from .signals import template_rendered
 from .templating import render_template
 from .templating import render_template_string
 
-__version__ = "1.1.3.dev0"
+__version__ = "1.1.3"


### PR DESCRIPTION
The 1.1.x line is no longer supported. This is solely to prevent unexpected updates for users who were not pinning their dependencies.