### PR TITLE
Use compat fspath instead of os.fspath in static_folder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,12 @@
 .. currentmodule:: flask
 
+Version 1.1.4
+-------------
+
+Unreleased
+
+-   Update ``static_folder`` to use ``_compat.fspath`` instead of
+    ``os.fspath`` to continue supporting Python <3.6 :issue:`4050`
 
 
 Version 1.1.3

--- a/src/flask/__init__.py
+++ b/src/flask/__init__.py
@@ -57,4 +57,4 @@ from .signals import template_rendered
 from .templating import render_template
 from .templating import render_template_string
 
-__version__ = "1.1.3"
+__version__ = "1.1.4.dev0"

--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -1001,7 +1001,7 @@ class _PackageBoundObject(object):
     @static_folder.setter
     def static_folder(self, value):
         if value is not None:
-            value = os.fspath(value).rstrip(r"\/")
+            value = fspath(value).rstrip(r"\/")
         self._static_folder = value
 
     @property

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1425,7 +1425,6 @@ def test_static_url_empty_path_default(app):
     rv.close()
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires Python >= 3.6")
 def test_static_folder_with_pathlib_path(app):
     from pathlib import Path
 


### PR DESCRIPTION
When #3678 was merged it introduced the usage of os.fspath which is not supported on Python <3.6

This PR updates `static_folder` to use the `fspath` from `_compat` and un-skips the test case.

- fixes #4050 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- ~[ ] Add or update relevant docs, in the docs folder and in code.~
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- ~[ ] Add `.. versionchanged::` entries in any relevant code docs.~
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
