### PR TITLE
Unused escape import

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -246,7 +246,7 @@ of the argument like ``<converter:variable_name>``. ::
     @app.route('/user/<username>')
     def show_user_profile(username):
         # show the user profile for that user
-        return f'User {username}'
+        return f'User {escape(username)}'
 
     @app.route('/post/<int:post_id>')
     def show_post(post_id):
@@ -256,7 +256,7 @@ of the argument like ``<converter:variable_name>``. ::
     @app.route('/path/<path:subpath>')
     def show_subpath(subpath):
         # show the subpath after /path/
-        return f'Subpath {subpath}'
+        return f'Subpath {escape(subpath)}'
 
 Converter types:
 


### PR DESCRIPTION
Use previously unused escape function in the "Variable Rules" section of the `quickstart` page. 

fixes #4054 

### Before: 
![before](https://user-images.githubusercontent.com/70592708/118321733-dc695100-b4b2-11eb-8e53-a7e1254950c5.jpeg)

### After:
![after](https://user-images.githubusercontent.com/70592708/118321744-e0956e80-b4b2-11eb-83ed-4766e1499154.jpeg)
