### PR TITLE
Lucas/add head short route

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,9 @@ Unreleased
 -   Roll back a change to the order that URL matching was done. The
     URL is again matched after the session is loaded, so the session is
     available in custom URL converters. :issue:`4053`
+-   Add support for HEAD method to sugar route syntax:
+    ``@app.head("/file-info")`` is a shortcut for
+    ``@app.route("/file-info", methods=["HEAD"])``. :pr:`4058`
 
 
 Version 2.0.0

--- a/src/flask/scaffold.py
+++ b/src/flask/scaffold.py
@@ -376,6 +376,13 @@ class Scaffold:
         """
         return self._method_route("GET", rule, options)
 
+    def head(self, rule: str, **options: t.Any) -> t.Callable:
+        """Shortcut for :meth:`route` with ``methods=["HEAD"]``.
+
+        .. versionadded:: 2.0
+        """
+        return self._method_route("HEAD", rule, options)
+
     def post(self, rule: str, **options: t.Any) -> t.Callable:
         """Shortcut for :meth:`route` with ``methods=["POST"]``.
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -60,6 +60,16 @@ def test_method_route(app, client, method):
     assert client_method("/").data == b"Hello"
 
 
+def test_head_method_route(app, client):
+    @app.head("/")
+    def index():
+        return flask.request.method
+
+    rv = client.head("/")
+    assert rv.status_code == 200
+    assert not rv.data
+
+
 def test_method_route_no_methods(app):
     with pytest.raises(TypeError):
         app.get("/", methods=["GET", "POST"])


### PR DESCRIPTION
Inspired by this awesome change #3907 I believe the http method HEAD also deserve to be represented as a shortcut.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
