### PR TITLE
Fix the request blueprint method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,9 @@ Unreleased
 -   Roll back a change to the order that URL matching was done. The
     URL is again matched after the session is loaded, so the session is
     available in custom URL converters. :issue:`4053`
-
+-   Fix the request ``blueprint`` method to ensure it returns the
+    current blueprint name. A ``blueprints`` method is added to
+    replace any functionality lost in this fix. :pr:`4059`
 
 Version 2.0.0
 -------------

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1783,8 +1783,10 @@ class Flask(Scaffold):
         """
         funcs: t.Iterable[URLDefaultCallable] = self.url_default_functions[None]
         if "." in endpoint:
-            bp = endpoint.rsplit(".", 1)[0]
-            funcs = chain(funcs, self.url_default_functions[bp])
+            bps = reversed(endpoint.split(".")[:-1])
+            for bp in bps:
+                funcs = chain(funcs, self.url_default_functions[bp])
+
         for func in funcs:
             func(endpoint, values)
 

--- a/src/flask/wrappers.py
+++ b/src/flask/wrappers.py
@@ -1,6 +1,7 @@
 import typing as t
 
 from werkzeug.exceptions import BadRequest
+from werkzeug.utils import cached_property
 from werkzeug.wrappers import Request as RequestBase
 from werkzeug.wrappers import Response as ResponseBase
 
@@ -73,9 +74,23 @@ class Request(RequestBase):
     def blueprint(self) -> t.Optional[str]:
         """The name of the current blueprint"""
         if self.url_rule and "." in self.url_rule.endpoint:
-            return self.url_rule.endpoint.rsplit(".", 1)[0]
+            return self.url_rule.endpoint.split(".")[-2]
         else:
             return None
+
+    @cached_property
+    def blueprints(self) -> t.List[str]:
+        """Return the names of the current blueprints.
+
+        The returned list is ordered from the current blueprint,
+        upwards through parent blueprints.
+        """
+        if self.url_rule and "." in self.url_rule.endpoint:
+            bps = self.url_rule.endpoint.split(".")[:-1]
+            bps.reverse()
+            return bps
+        else:
+            return []
 
     def _load_form_data(self) -> None:
         RequestBase._load_form_data(self)


### PR DESCRIPTION
Previously for a nested blueprint it would return the parent_name.name
rather than the name of the current blueprint. This is fixed and
another blueprints method is added in order to get the parent_name and
name. The latter is made use of in the app.

I've used a cached_property as this method is called a few times per
request (by the app methods).

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
