### PR TITLE
blueprints: fix nested blueprint url_prefix

### DIFF
--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -354,7 +354,9 @@ class Blueprint(Scaffold):
                 bp_options["url_prefix"] = (
                     state.url_prefix.rstrip("/") + "/" + bp_url_prefix.lstrip("/")
                 )
-            else:
+            elif bp_url_prefix is not None:
+                bp_options["url_prefix"] = bp_url_prefix
+            elif state.url_prefix is not None:
                 bp_options["url_prefix"] = state.url_prefix
 
             bp_options["name_prefix"] = options.get("name_prefix", "") + self.name + "."

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -870,7 +870,7 @@ def test_nested_blueprint_url_prefix(app, client):
     assert client.get("/parent/child/orange/").data == b"Apple"
 
 
-def test_nested_blueprint_url_prefix_only_parent_prefix(app, client):
+def test_nested_blueprint_url_prefix_only_parent_overwrite_prefix(app, client):
     parent = flask.Blueprint("parent", __name__)
     child = flask.Blueprint("child", __name__)
 
@@ -882,3 +882,55 @@ def test_nested_blueprint_url_prefix_only_parent_prefix(app, client):
     app.register_blueprint(parent, url_prefix="/parent")
 
     assert client.get("/parent/child-endpoint").data == b"Child"
+
+
+def test_nested_blueprint_url_prefix_only_child_overwrite_prefix(app, client):
+    parent = flask.Blueprint("parent", __name__)
+    child = flask.Blueprint("child", __name__)
+
+    @child.route("/child-endpoint")
+    def child_index():
+        return "Child"
+
+    parent.register_blueprint(child, url_prefix="/child")
+    app.register_blueprint(parent)
+
+    assert client.get("/child/child-endpoint").data == b"Child"
+
+
+def test_nested_blueprint_url_prefix_only_child_prefix(app, client):
+    parent = flask.Blueprint("parent", __name__, url_prefix="/parent")
+    child = flask.Blueprint("child", __name__)
+
+    @parent.route("/")
+    def parent_index():
+        return "Parent"
+
+    @child.route("/child/")
+    def child_index():
+        return "Child"
+
+    parent.register_blueprint(child)
+    app.register_blueprint(parent)
+
+    assert client.get("/parent/").data == b"Parent"
+    assert client.get("/parent/child/").data == b"Child"
+
+
+def test_nested_blueprint_url_prefix_only_parent_prefix(app, client):
+    parent = flask.Blueprint("parent", __name__)
+    child = flask.Blueprint("child", __name__, url_prefix="/child")
+
+    @parent.route("/parent/")
+    def parent_index():
+        return "Parent"
+
+    @child.route("/")
+    def child_index():
+        return "Child"
+
+    parent.register_blueprint(child)
+    app.register_blueprint(parent)
+
+    assert client.get("/parent/").data == b"Parent"
+    assert client.get("/child/").data == b"Child"


### PR DESCRIPTION
The url_prefix would only be propagated if the parent blueprint or overwrite had an url_prefix.

Fixes #4062
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->



<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
