### PR TITLE
Improve decorator factory typing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ Unreleased
     available in custom URL converters. :issue:`4053`
 -   Re-add deprecated ``Config.from_json``, which was accidentally
     removed early. :issue:`4078`
+-   Improve typing for some functions using ``Callable`` in their type
+    signatures, focusing on decorator factories. :issue:`4060`
 
 
 Version 2.0.0

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1089,7 +1089,9 @@ class Flask(Scaffold):
             self.view_functions[endpoint] = view_func
 
     @setupmethod
-    def template_filter(self, name: t.Optional[str] = None) -> t.Callable:
+    def template_filter(
+        self, name: t.Optional[str] = None
+    ) -> t.Callable[[TemplateFilterCallable], TemplateFilterCallable]:
         """A decorator that is used to register custom template filter.
         You can specify a name for the filter, otherwise the function
         name will be used. Example::
@@ -1121,7 +1123,9 @@ class Flask(Scaffold):
         self.jinja_env.filters[name or f.__name__] = f
 
     @setupmethod
-    def template_test(self, name: t.Optional[str] = None) -> t.Callable:
+    def template_test(
+        self, name: t.Optional[str] = None
+    ) -> t.Callable[[TemplateTestCallable], TemplateTestCallable]:
         """A decorator that is used to register custom template test.
         You can specify a name for the test, otherwise the function
         name will be used. Example::
@@ -1162,7 +1166,9 @@ class Flask(Scaffold):
         self.jinja_env.tests[name or f.__name__] = f
 
     @setupmethod
-    def template_global(self, name: t.Optional[str] = None) -> t.Callable:
+    def template_global(
+        self, name: t.Optional[str] = None
+    ) -> t.Callable[[TemplateGlobalCallable], TemplateGlobalCallable]:
         """A decorator that is used to register a custom template global function.
         You can specify a name for the global function, otherwise the function
         name will be used. Example::

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -387,7 +387,9 @@ class Blueprint(Scaffold):
             )
         )
 
-    def app_template_filter(self, name: t.Optional[str] = None) -> t.Callable:
+    def app_template_filter(
+        self, name: t.Optional[str] = None
+    ) -> t.Callable[[TemplateFilterCallable], TemplateFilterCallable]:
         """Register a custom template filter, available application wide.  Like
         :meth:`Flask.template_filter` but for a blueprint.
 
@@ -417,7 +419,9 @@ class Blueprint(Scaffold):
 
         self.record_once(register_template)
 
-    def app_template_test(self, name: t.Optional[str] = None) -> t.Callable:
+    def app_template_test(
+        self, name: t.Optional[str] = None
+    ) -> t.Callable[[TemplateTestCallable], TemplateTestCallable]:
         """Register a custom template test, available application wide.  Like
         :meth:`Flask.template_test` but for a blueprint.
 
@@ -451,7 +455,9 @@ class Blueprint(Scaffold):
 
         self.record_once(register_template)
 
-    def app_template_global(self, name: t.Optional[str] = None) -> t.Callable:
+    def app_template_global(
+        self, name: t.Optional[str] = None
+    ) -> t.Callable[[TemplateGlobalCallable], TemplateGlobalCallable]:
         """Register a custom template global, available application wide.  Like
         :meth:`Flask.template_global` but for a blueprint.
 

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -365,6 +365,7 @@ class Blueprint(Scaffold):
         rule: str,
         endpoint: t.Optional[str] = None,
         view_func: t.Optional[t.Callable] = None,
+        provide_automatic_options: t.Optional[bool] = None,
         **options: t.Any,
     ) -> None:
         """Like :meth:`Flask.add_url_rule` but for a blueprint.  The endpoint for
@@ -376,7 +377,15 @@ class Blueprint(Scaffold):
         if view_func and hasattr(view_func, "__name__") and "." in view_func.__name__:
             raise ValueError("'view_func' name may not contain a dot '.' character.")
 
-        self.record(lambda s: s.add_url_rule(rule, endpoint, view_func, **options))
+        self.record(
+            lambda s: s.add_url_rule(
+                rule,
+                endpoint,
+                view_func,
+                provide_automatic_options=provide_automatic_options,
+                **options,
+            )
+        )
 
     def app_template_filter(self, name: t.Optional[str] = None) -> t.Callable:
         """Register a custom template filter, available application wide.  Like

--- a/src/flask/scaffold.py
+++ b/src/flask/scaffold.py
@@ -644,7 +644,7 @@ class Scaffold:
     @setupmethod
     def errorhandler(
         self, code_or_exception: t.Union[t.Type[Exception], int]
-    ) -> t.Callable:
+    ) -> t.Callable[[ErrorHandlerCallable], ErrorHandlerCallable]:
         """Register a function to handle errors by code or exception class.
 
         A decorator that is used to register a function given an

--- a/src/flask/scaffold.py
+++ b/src/flask/scaffold.py
@@ -443,7 +443,7 @@ class Scaffold:
         view_func: t.Optional[t.Callable] = None,
         provide_automatic_options: t.Optional[bool] = None,
         **options: t.Any,
-    ) -> t.Callable:
+    ) -> None:
         """Register a rule for routing incoming requests and building
         URLs. The :meth:`route` decorator is a shortcut to call this
         with the ``view_func`` argument. These are equivalent:

--- a/src/flask/scaffold.py
+++ b/src/flask/scaffold.py
@@ -33,8 +33,10 @@ if t.TYPE_CHECKING:
 # a singleton sentinel value for parameter defaults
 _sentinel = object()
 
+F = t.TypeVar("F", bound=t.Callable[..., t.Any])
 
-def setupmethod(f: t.Callable) -> t.Callable:
+
+def setupmethod(f: F) -> F:
     """Wraps a method so that it performs a check in debug mode if the
     first request was already handled.
     """
@@ -53,7 +55,7 @@ def setupmethod(f: t.Callable) -> t.Callable:
             )
         return f(self, *args, **kwargs)
 
-    return update_wrapper(wrapper_func, f)
+    return t.cast(F, update_wrapper(wrapper_func, f))
 
 
 class Scaffold:


### PR DESCRIPTION
I added type parameters to `Callable` types in decorator factories. This required changing the type annotations for `setupmethod()`, which was removing type information from the functions it was called on. I also fixed the signatures for `add_url_rule()` because my changes to `setupmethod()` revealed some errors there.

There is still more room for improvement in usage of `Callable` elsewhere throughout the codebase, but this is at least a step forward.

- fixes #4060

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
