### PR TITLE
blueprints are registered with nested names, can change registered name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,13 @@ Unreleased
     removed early. :issue:`4078`
 -   Improve typing for some functions using ``Callable`` in their type
     signatures, focusing on decorator factories. :issue:`4060`
+-   Nested blueprints are registered with their dotted name. This allows
+    different blueprints with the same name to be nested at different
+    locations. :issue:`4069`
+-   ``register_blueprint`` takes a ``name`` option to change the
+    (pre-dotted) name the blueprint is registered with. This allows the
+    same blueprint to be registered multiple times with unique names for
+    ``url_for``. :issue:`1091`
 
 
 Version 2.0.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,7 +33,8 @@ Unreleased
 -   ``register_blueprint`` takes a ``name`` option to change the
     (pre-dotted) name the blueprint is registered with. This allows the
     same blueprint to be registered multiple times with unique names for
-    ``url_for``. :issue:`1091`
+    ``url_for``. Registering the same blueprint with the same name
+    multiple times is deprecated. :issue:`1091`
 
 
 Version 2.0.0

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1019,6 +1019,12 @@ class Flask(Scaffold):
             :class:`~flask.blueprints.BlueprintSetupState`. They can be
             accessed in :meth:`~flask.Blueprint.record` callbacks.
 
+        .. versionchanged:: 2.0.1
+            The ``name`` option can be used to change the (pre-dotted)
+            name the blueprint is registered with. This allows the same
+            blueprint to be registered multiple times with unique names
+            for ``url_for``.
+
         .. versionadded:: 0.7
         """
         blueprint.register(self, options)

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -354,7 +354,9 @@ class Blueprint(Scaffold):
                 bp_options["url_prefix"] = (
                     state.url_prefix.rstrip("/") + "/" + bp_url_prefix.lstrip("/")
                 )
-            else:
+            elif bp_url_prefix is not None:
+                bp_options["url_prefix"] = bp_url_prefix
+            elif state.url_prefix is not None:
                 bp_options["url_prefix"] = state.url_prefix
 
             bp_options["name_prefix"] = options.get("name_prefix", "") + self.name + "."

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -274,7 +274,8 @@ class Blueprint(Scaffold):
                 first_registration = False
 
         name_prefix = options.get("name_prefix", "")
-        name = f"{name_prefix}.{self.name}".lstrip(".")
+        self_name = options.get("name", self.name)
+        name = f"{name_prefix}.{self_name}".lstrip(".")
 
         if name in app.blueprints and app.blueprints[name] is not self:
             raise ValueError(

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -67,6 +67,7 @@ class BlueprintSetupState:
         #: blueprint.
         self.url_prefix = url_prefix
 
+        self.name = self.options.get("name", blueprint.name)
         self.name_prefix = self.options.get("name_prefix", "")
 
         #: A dictionary with URL defaults that is added to each and every
@@ -96,9 +97,10 @@ class BlueprintSetupState:
         defaults = self.url_defaults
         if "defaults" in options:
             defaults = dict(defaults, **options.pop("defaults"))
+
         self.app.add_url_rule(
             rule,
-            f"{self.name_prefix}.{self.blueprint.name}.{endpoint}".lstrip("."),
+            f"{self.name_prefix}.{self.name}.{endpoint}".lstrip("."),
             view_func,
             defaults=defaults,
             **options,

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -260,6 +260,8 @@ class Blueprint(Scaffold):
 
         .. versionadded:: 2.0
         """
+        if blueprint is self:
+            raise ValueError("Cannot register a blueprint on itself")
         self._blueprints.append((blueprint, options))
 
     def register(self, app: "Flask", options: dict) -> None:

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -252,6 +252,12 @@ class Blueprint(Scaffold):
         arguments passed to this method will override the defaults set
         on the blueprint.
 
+        .. versionchanged:: 2.0.1
+            The ``name`` option can be used to change the (pre-dotted)
+            name the blueprint is registered with. This allows the same
+            blueprint to be registered multiple times with unique names
+            for ``url_for``.
+
         .. versionadded:: 2.0
         """
         self._blueprints.append((blueprint, options))
@@ -266,6 +272,17 @@ class Blueprint(Scaffold):
             with.
         :param options: Keyword arguments forwarded from
             :meth:`~Flask.register_blueprint`.
+
+        .. versionchanged:: 2.0.1
+            Nested blueprints are registered with their dotted name.
+            This allows different blueprints with the same name to be
+            nested at different locations.
+
+        .. versionchanged:: 2.0.1
+            The ``name`` option can be used to change the (pre-dotted)
+            name the blueprint is registered with. This allows the same
+            blueprint to be registered multiple times with unique names
+            for ``url_for``.
         """
         first_registration = True
 

--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -6,6 +6,7 @@ import typing as t
 import warnings
 from datetime import datetime
 from datetime import timedelta
+from functools import lru_cache
 from functools import update_wrapper
 from threading import RLock
 
@@ -821,3 +822,13 @@ def is_ip(value: str) -> bool:
             return True
 
     return False
+
+
+@lru_cache(maxsize=None)
+def _split_blueprint_path(name: str) -> t.List[str]:
+    out: t.List[str] = [name]
+
+    if "." in name:
+        out.extend(_split_blueprint_path(name.rpartition(".")[0]))
+
+    return out

--- a/src/flask/wrappers.py
+++ b/src/flask/wrappers.py
@@ -1,12 +1,12 @@
 import typing as t
 
 from werkzeug.exceptions import BadRequest
-from werkzeug.utils import cached_property
 from werkzeug.wrappers import Request as RequestBase
 from werkzeug.wrappers import Response as ResponseBase
 
 from . import json
 from .globals import current_app
+from .helpers import _split_blueprint_path
 
 if t.TYPE_CHECKING:
     import typing_extensions as te
@@ -60,38 +60,54 @@ class Request(RequestBase):
 
     @property
     def endpoint(self) -> t.Optional[str]:
-        """The endpoint that matched the request.  This in combination with
-        :attr:`view_args` can be used to reconstruct the same or a
-        modified URL.  If an exception happened when matching, this will
-        be ``None``.
+        """The endpoint that matched the request URL.
+
+        This will be ``None`` if matching failed or has not been
+        performed yet.
+
+        This in combination with :attr:`view_args` can be used to
+        reconstruct the same URL or a modified URL.
         """
         if self.url_rule is not None:
             return self.url_rule.endpoint
-        else:
-            return None
+
+        return None
 
     @property
     def blueprint(self) -> t.Optional[str]:
-        """The name of the current blueprint"""
-        if self.url_rule and "." in self.url_rule.endpoint:
-            return self.url_rule.endpoint.rsplit(".", 1)[0]
-        else:
-            return None
+        """The registered name of the current blueprint.
 
-    @cached_property
-    def blueprints(self) -> t.List[str]:
-        """The names of the current blueprint upwards through parent
-        blueprints.
+        This will be ``None`` if the endpoint is not part of a
+        blueprint, or if URL matching failed or has not been performed
+        yet.
+
+        This does not necessarily match the name the blueprint was
+        created with. It may have been nested, or registered with a
+        different name.
         """
-        if self.blueprint is None:
+        endpoint = self.endpoint
+
+        if endpoint is not None and "." in endpoint:
+            return endpoint.rpartition(".")[0]
+
+        return None
+
+    @property
+    def blueprints(self) -> t.List[str]:
+        """The registered names of the current blueprint upwards through
+        parent blueprints.
+
+        This will be an empty list if there is no current blueprint, or
+        if URL matching failed.
+
+        .. versionadded:: 2.0.1
+        """
+        name = self.blueprint
+
+        if name is None:
             return []
 
-        bps: t.List[str] = [self.blueprint]
-
-        while "." in bps[-1]:
-            bps.append(bps[-1].rpartition(".")[0])
-
-        return bps
+        return _split_blueprint_path(name)
 
     def _load_form_data(self) -> None:
         RequestBase._load_form_data(self)

--- a/src/flask/wrappers.py
+++ b/src/flask/wrappers.py
@@ -1,6 +1,7 @@
 import typing as t
 
 from werkzeug.exceptions import BadRequest
+from werkzeug.utils import cached_property
 from werkzeug.wrappers import Request as RequestBase
 from werkzeug.wrappers import Response as ResponseBase
 
@@ -76,6 +77,21 @@ class Request(RequestBase):
             return self.url_rule.endpoint.rsplit(".", 1)[0]
         else:
             return None
+
+    @cached_property
+    def blueprints(self) -> t.List[str]:
+        """The names of the current blueprint upwards through parent
+        blueprints.
+        """
+        if self.blueprint is None:
+            return []
+
+        bps: t.List[str] = [self.blueprint]
+
+        while "." in bps[-1]:
+            bps.append(bps[-1].rpartition(".")[0])
+
+        return bps
 
     def _load_form_data(self) -> None:
         RequestBase._load_form_data(self)

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -883,3 +883,9 @@ def test_unique_blueprint_names(app, client) -> None:
         app.register_blueprint(bp2)  # different bp, same name, error
 
     app.register_blueprint(bp2, name="alt")  # different bp, different name, ok
+
+
+def test_self_registration(app, client) -> None:
+    bp = flask.Blueprint("bp", __name__)
+    with pytest.raises(ValueError):
+        bp.register_blueprint(bp)

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -866,3 +866,16 @@ def test_nesting_url_prefixes(
 
     response = client.get("/parent/child/")
     assert response.status_code == 200
+
+
+def test_unique_blueprint_names(app, client) -> None:
+    bp = flask.Blueprint("bp", __name__)
+    bp2 = flask.Blueprint("bp", __name__)
+
+    app.register_blueprint(bp)
+    app.register_blueprint(bp)  # same name, same object, no error
+
+    with pytest.raises(ValueError):
+        app.register_blueprint(bp2)  # same name, different object
+
+    app.register_blueprint(bp2, name="alt")  # different name

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -140,7 +140,7 @@ def test_blueprint_url_defaults(app, client):
         return str(bar)
 
     app.register_blueprint(bp, url_prefix="/1", url_defaults={"bar": 23})
-    app.register_blueprint(bp, url_prefix="/2", url_defaults={"bar": 19})
+    app.register_blueprint(bp, name="test2", url_prefix="/2", url_defaults={"bar": 19})
 
     assert client.get("/1/foo").data == b"23/42"
     assert client.get("/2/foo").data == b"19/42"
@@ -873,9 +873,13 @@ def test_unique_blueprint_names(app, client) -> None:
     bp2 = flask.Blueprint("bp", __name__)
 
     app.register_blueprint(bp)
-    app.register_blueprint(bp)  # same name, same object, no error
+
+    with pytest.warns(UserWarning):
+        app.register_blueprint(bp)  # same bp, same name, warning
+
+    app.register_blueprint(bp, name="again")  # same bp, different name, ok
 
     with pytest.raises(ValueError):
-        app.register_blueprint(bp2)  # same name, different object
+        app.register_blueprint(bp2)  # different bp, same name, error
 
-    app.register_blueprint(bp2, name="alt")  # different name
+    app.register_blueprint(bp2, name="alt")  # different bp, different name, ok


### PR DESCRIPTION
- Blueprints are registered with the full nested name, not only the name they were created with. This allows the same blueprint to be nested in different locations. Fixes #4069
- `name` can be passed as an option to `register_blueprint`. It changes the name the blueprint is registered with (or nested with). This allows `url_for` to work if the same blueprint is registered with different prefixes. Fixes #1091