### PR TITLE
re-add deprecated `Config.from_json` method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Unreleased
 -   Roll back a change to the order that URL matching was done. The
     URL is again matched after the session is loaded, so the session is
     available in custom URL converters. :issue:`4053`
+-   Re-add deprecated ``Config.from_json``, which was accidentally
+    removed early. :issue:`4078`
 
 
 Version 2.0.0

--- a/src/flask/config.py
+++ b/src/flask/config.py
@@ -202,6 +202,31 @@ class Config(dict):
 
         return self.from_mapping(obj)
 
+    def from_json(self, filename: str, silent: bool = False) -> bool:
+        """Update the values in the config from a JSON file. The loaded
+        data is passed to the :meth:`from_mapping` method.
+
+        :param filename: The path to the JSON file. This can be an
+            absolute path or relative to the config root path.
+        :param silent: Ignore the file if it doesn't exist.
+
+        .. deprecated:: 2.0.0
+            Will be removed in Flask 2.1. Use :meth:`from_file` instead.
+            This was removed early in 2.0.0, was added back in 2.0.1.
+
+        .. versionadded:: 0.11
+        """
+        import warnings
+        from . import json
+
+        warnings.warn(
+            "'from_json' is deprecated and will be removed in Flask"
+            " 2.1. Use 'from_file(path, json.load)' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.from_file(filename, json.load, silent=silent)
+
     def from_mapping(
         self, mapping: t.Optional[t.Mapping[str, t.Any]] = None, **kwargs: t.Any
     ) -> bool:


### PR DESCRIPTION
This was removed accidentally, it's deprecated until Flask 2.1.

- fixes #4078 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
