### PR TITLE
Add venv and .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.pyc
 *.pyo
 env/
+venv/
+.venv/
 env*
 dist/
 build/


### PR DESCRIPTION
Although we use `python -m venv env` in the contributing guide as the example, we don't need to force the contributor to use `env`.