### PR TITLE
improve typing for `stream_with_context`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,7 @@ Unreleased
     same blueprint to be registered multiple times with unique names for
     ``url_for``. Registering the same blueprint with the same name
     multiple times is deprecated. :issue:`1091`
+-   Improve typing for ``stream_with_context``. :issue:`4052`
 
 
 Version 2.0.0

--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -64,8 +64,10 @@ def get_load_dotenv(default: bool = True) -> bool:
 
 
 def stream_with_context(
-    generator_or_function: t.Union[t.Generator, t.Callable]
-) -> t.Generator:
+    generator_or_function: t.Union[
+        t.Iterator[t.AnyStr], t.Callable[..., t.Iterator[t.AnyStr]]
+    ]
+) -> t.Iterator[t.AnyStr]:
     """Request contexts disappear when the response is started on the server.
     This is done for efficiency reasons and to make it less likely to encounter
     memory leaks with badly written WSGI middlewares.  The downside is that if


### PR DESCRIPTION
Use `Iterator[AnyStr]` instead of `Generator[Any, Any, Any]` for argument and return value.

- fixes #4052 