### PR TITLE
Fix type annotation for `__exit__` methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 -   Fix type annotation for ``teardown_request``. :issue:`4093`
 -   Fix type annotation for ``before_request`` and ``before_app_request``
     decorators. :issue:`4104`
+-   Fix type annotation for ``__exit__`` methods. :pr:`4108`
 
 
 Version 2.0.1

--- a/src/flask/ctx.py
+++ b/src/flask/ctx.py
@@ -258,7 +258,10 @@ class AppContext:
         return self
 
     def __exit__(
-        self, exc_type: type, exc_value: BaseException, tb: TracebackType
+        self,
+        exc_type: t.Optional[t.Type[BaseException]],
+        exc_value: t.Optional[BaseException],
+        tb: t.Optional[TracebackType],
     ) -> None:
         self.pop(exc_value)
 
@@ -464,7 +467,10 @@ class RequestContext:
         return self
 
     def __exit__(
-        self, exc_type: type, exc_value: BaseException, tb: TracebackType
+        self,
+        exc_type: t.Optional[t.Type[BaseException]],
+        exc_value: t.Optional[BaseException],
+        tb: t.Optional[TracebackType],
     ) -> None:
         # do not pop the request stack if we are in debug mode and an
         # exception happened.  This will allow the debugger to still

--- a/src/flask/testing.py
+++ b/src/flask/testing.py
@@ -227,7 +227,10 @@ class FlaskClient(Client):
         return self
 
     def __exit__(
-        self, exc_type: type, exc_value: BaseException, tb: TracebackType
+        self,
+        exc_type: t.Optional[t.Type[BaseException]],
+        exc_value: t.Optional[BaseException],
+        tb: t.Optional[TracebackType],
     ) -> None:
         self.preserve_context = False
 


### PR DESCRIPTION
From [docs](https://docs.python.org/3/reference/datamodel.html#object.__exit__):
```
If the context was exited without an exception, all three arguments will be None.
```

Checklist:

- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
