### PR TITLE
Clarification added to the tutorial

### DIFF
--- a/docs/tutorial/static.rst
+++ b/docs/tutorial/static.rst
@@ -64,8 +64,11 @@ screenshot below.
     :alt: screenshot of login page
 
 You can read more about CSS from `Mozilla's documentation <CSS_>`_. If
-you change a static file, refresh the browser page. If the change
-doesn't show up, try clearing your browser's cache.
+you change a static file, refresh the browser page. 
+
+.. admontation:: Flask 2.0 renewal
+    Starting with version 2.0, you no longer need to clear your
+    browser cache to display changes to a static file.
 
 .. _CSS: https://developer.mozilla.org/docs/Web/CSS
 

--- a/docs/tutorial/static.rst
+++ b/docs/tutorial/static.rst
@@ -64,7 +64,8 @@ screenshot below.
     :alt: screenshot of login page
 
 You can read more about CSS from `Mozilla's documentation <CSS_>`_. If
-you change a static file, refresh the browser page. 
+you change a static file, refresh the browser page. If the change
+doesn’t show up, try clearing your browser’s cache.
 
 .. admontation:: Flask 2.0 renewal
     Starting with version 2.0, you no longer need to clear your


### PR DESCRIPTION
This is due to the new version of Flask, where when serving static files, browsers will cache based on content rather than based on a 12 hour timer. This means changes to static content such as CSS styles will be reflected immediately on reload without having to clear the cache.