### PR TITLE
Update doc about minimal Python version for async support

### DIFF
--- a/docs/async-await.rst
+++ b/docs/async-await.rst
@@ -7,7 +7,8 @@ Using ``async`` and ``await``
 
 Routes, error handlers, before request, after request, and teardown
 functions can all be coroutine functions if Flask is installed with the
-``async`` extra (``pip install flask[async]``). This allows views to be
+``async`` extra (``pip install flask[async]``). It requires Python 3.7+
+where ``contextvars.ContextVar`` is available. This allows views to be
 defined with ``async def`` and use ``await``.
 
 .. code-block:: python

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,6 +8,8 @@ Python Version
 We recommend using the latest version of Python. Flask supports Python
 3.6 and newer.
 
+``async`` support in Flask requires Python 3.7+ for ``contextvars.ContextVar``.
+
 
 Dependencies
 ------------


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

Declare the minimal Python version, 3.7, required by `async` support.
`Flask.async_to_sync()` requires an available `ContextVar`.

I think of this after seeing a question on stackoverflow [Error Running Async Flask 2.0.0 on Python 3.6.10](https://stackoverflow.com/questions/67698544).

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
