### PR TITLE
Fix: avoid duplicate loop key in err handler search

### DIFF
--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1276,7 +1276,7 @@ class Flask(Scaffold):
         """
         exc_class, code = self._get_exc_class_and_code(type(e))
 
-        for c in [code, None]:
+        for c in [code, None] if code is not None else [None]:
             for name in chain(request.blueprints, [None]):
                 handler_map = self.error_handler_spec[name][c]
 


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

Very minimal change. The code is self-explanation. `code` in `for c in [code, None]` may be `None`. Made a deduplication before do the loop.

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
