### PR TITLE
Fix async view handling

### DIFF
--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1,5 +1,3 @@
-import functools
-import inspect
 import logging
 import os
 import sys

--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -1,3 +1,4 @@
+import functools
 import inspect
 import os
 import pkgutil

--- a/src/flask/views.py
+++ b/src/flask/views.py
@@ -1,6 +1,7 @@
 import typing as t
 
 from .globals import request
+from .helpers import ensure_sync
 from .typing import ResponseReturnValue
 
 
@@ -80,7 +81,7 @@ class View:
 
         def view(*args: t.Any, **kwargs: t.Any) -> ResponseReturnValue:
             self = view.view_class(*class_args, **class_kwargs)  # type: ignore
-            return self.dispatch_request(*args, **kwargs)
+            return ensure_sync(self.dispatch_request)(*args, **kwargs)
 
         if cls.decorators:
             view.__name__ = name
@@ -154,4 +155,4 @@ class MethodView(View, metaclass=MethodViewType):
             meth = getattr(self, "get", None)
 
         assert meth is not None, f"Unimplemented method {request.method!r}"
-        return meth(*args, **kwargs)
+        return ensure_sync(meth)(*args, **kwargs)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -6,7 +6,8 @@ import pytest
 from flask import Blueprint
 from flask import Flask
 from flask import request
-from flask.views import View, MethodView
+from flask.views import MethodView
+from flask.views import View
 
 pytest.importorskip("asgiref")
 
@@ -61,7 +62,7 @@ def _async_app():
             return request.method
 
     app.add_url_rule("/async_view", view_func=AsyncView.as_view("async_view"))
-    
+
     class AsyncMethodView(MethodView):
         async def get(self):
             return "GET"
@@ -69,13 +70,17 @@ def _async_app():
         async def post(self):
             return "POST"
 
-    app.add_url_rule("/async_methodview", view_func=AsyncMethodView.as_view("async_methodview"))
+    app.add_url_rule(
+        "/async_methodview", view_func=AsyncMethodView.as_view("async_methodview")
+    )
 
     return app
 
 
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python >= 3.7")
-@pytest.mark.parametrize("path", ["/", "/home", "/bp/", "async_view", "async_methodview"])
+@pytest.mark.parametrize(
+    "path", ["/", "/home", "/bp/", "async_view", "async_methodview"]
+)
 def test_async_route(path, async_app):
     test_client = async_app.test_client()
     response = test_client.get(path)


### PR DESCRIPTION
## Changes

* Move `async_to_sync` and `ensure_sync` off of Flask class and into helpers.
  * This is open to discussion, but the necessity of referencing these functions from outside the context of the application may outweigh the ability to override them using the current implementation. More consideration is probably needed around how to make this behavior overridable while still being accessible from Views.
* Call `ensure_sync` on `dispatch_request` for `Views` and methods for `MethodViews`

## Issue

- fixes #4126

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
