### PR TITLE
added return type in from* methods

### DIFF
--- a/src/flask/config.py
+++ b/src/flask/config.py
@@ -107,7 +107,7 @@ class Config(dict):
                          root path.
         :param silent: set to ``True`` if you want silent failure for missing
                        files.
-
+        :return: bool.
         .. versionadded:: 0.7
            `silent` parameter.
         """
@@ -185,6 +185,7 @@ class Config(dict):
         :type load: ``Callable[[Reader], Mapping]`` where ``Reader``
             implements a ``read`` method.
         :param silent: Ignore the file if it doesn't exist.
+        :return: bool.
 
         .. versionadded:: 2.0
         """
@@ -209,7 +210,7 @@ class Config(dict):
         :param filename: The path to the JSON file. This can be an
             absolute path or relative to the config root path.
         :param silent: Ignore the file if it doesn't exist.
-
+        :return: bool.
         .. deprecated:: 2.0.0
             Will be removed in Flask 2.1. Use :meth:`from_file` instead.
             This was removed early in 2.0.0, was added back in 2.0.1.
@@ -232,7 +233,7 @@ class Config(dict):
     ) -> bool:
         """Updates the config like :meth:`update` ignoring items with non-upper
         keys.
-
+        :return: bool.
         .. versionadded:: 0.11
         """
         mappings: t.Dict[str, t.Any] = {}
@@ -271,7 +272,6 @@ class Config(dict):
                           dictionary should be lowercase
         :param trim_namespace: a flag indicating if the keys of the resulting
                           dictionary should not include the namespace
-
         .. versionadded:: 0.11
         """
         rv = {}


### PR DESCRIPTION
Added return types to all the `from_*`  methods in `src/flask/config.py` as described in the issue below.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #4082 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
