### PR TITLE
Fix bad link in templating docs

### DIFF
--- a/docs/templating.rst
+++ b/docs/templating.rst
@@ -37,7 +37,7 @@ by default:
 .. data:: config
    :noindex:
 
-   The current configuration object (:data:`flask.config`)
+   The current configuration object (:data:`flask.Flask.config`)
 
    .. versionadded:: 0.6
 


### PR DESCRIPTION
The standard context `config` should be the configuration object [`flask.Flask.config`](https://flask.palletsprojects.com/en/2.0.x/api/#flask.Flask.config), but not `flask.config`, the latter doesn't exist.