### PR TITLE
Add `exclude-patterns` option to `flask run` CLI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,9 @@ Unreleased
     load command entry points. :issue:`4419`
 -   Overriding ``FlaskClient.open`` will not cause an error on redirect.
     :issue:`3396`
+-   Add an ``--exclude-patterns`` option to the ``flask run`` CLI
+    command to specify patterns that will be ignored by the reloader.
+    :issue:`4188`
 
 
 Version 2.0.3

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -262,6 +262,15 @@ separated with ``:``, or ``;`` on Windows.
            * Detected change in '/path/to/file1', reloading
 
 
+Ignore files with the Reloader
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The reloader can also ignore files using :mod:`fnmatch` patterns with
+the ``--exclude-patterns`` option, or the ``FLASK_RUN_EXCLUDE_PATTERNS``
+environment variable. Multiple patterns are separated with ``:``, or
+``;`` on Windows.
+
+
 Debug Mode
 ----------
 

--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -796,9 +796,28 @@ class SeparatedPathType(click.Path):
         f" are separated by {os.path.pathsep!r}."
     ),
 )
+@click.option(
+    "--exclude-patterns",
+    default=None,
+    type=SeparatedPathType(),
+    help=(
+        "Files matching these fnmatch patterns will not trigger a reload"
+        " on change. Multiple patterns are separated by"
+        f" {os.path.pathsep!r}."
+    ),
+)
 @pass_script_info
 def run_command(
-    info, host, port, reload, debugger, eager_loading, with_threads, cert, extra_files
+    info,
+    host,
+    port,
+    reload,
+    debugger,
+    eager_loading,
+    with_threads,
+    cert,
+    extra_files,
+    exclude_patterns,
 ):
     """Run a local development server.
 
@@ -830,6 +849,7 @@ def run_command(
         threaded=with_threads,
         ssl_context=cert,
         extra_files=extra_files,
+        exclude_patterns=exclude_patterns,
     )
 
 


### PR DESCRIPTION
Pass `exclude_patterns` to Werkzeug's `run_simple` function.
This configures a list of patterns to ignore when running the reloader.

- fixes  #4188

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
