### PR TITLE
docs in quickstart.rst in use wrong variable name.

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -626,7 +626,7 @@ Werkzeug provides for you::
     def upload_file():
         if request.method == 'POST':
             file = request.files['the_file']
-            file.save(f"/var/www/uploads/{secure_filename(f.filename)}")
+            file.save(f"/var/www/uploads/{secure_filename(file.filename)}")
         ...
 
 For some better examples, see :doc:`patterns/fileuploads`.


### PR DESCRIPTION
quickstart.rts in File upload section in request file parameter variable name is "file". but file save with file name in secure_filename() function in use "f".
