### PR TITLE
Add support for a `FLASK_RUN_EXTRA_FILES` config variable.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Version 2.1.0
 Unreleased
 
 -   Update Click dependency to >= 8.0.
+-   Add support for a `FLASK_RUN_EXTRA_FILES` config variable.
 
 
 Version 2.0.2

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -232,6 +232,7 @@ separated with ``:``, or ``;`` on Windows.
 
 Alternatively, you can set the ``FLASK_RUN_EXTRA_FILES`` config
 variable, which takes a list of files::
+
   from flask import Flask
 
   app = Flask(__name__)

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -184,11 +184,15 @@ reloader.
 Watch Extra Files with the Reloader
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 2.1
+  Support for the ``FLASK_RUN_EXTRA_FILES`` config variable was added.
+
 When using development mode, the reloader will trigger whenever your
 Python code or imported modules change. The reloader can watch
 additional files with the ``--extra-files`` option, or the
 ``FLASK_RUN_EXTRA_FILES`` environment variable. Multiple paths are
 separated with ``:``, or ``;`` on Windows.
+
 
 .. tabs::
 
@@ -224,6 +228,15 @@ separated with ``:``, or ``;`` on Windows.
           > flask run
            * Running on http://127.0.0.1:8000/
            * Detected change in '/path/to/file1', reloading
+
+
+Alternatively, you can set the ``FLASK_RUN_EXTRA_FILES`` config
+variable, which takes a list of files::
+  from flask import Flask
+
+  app = Flask(__name__)
+  app.config['FLASK_RUN_EXTRA_FILES'] = ["file1", "dirA/file2", "dirB/"]
+
 
 
 Debug Mode

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -914,6 +914,7 @@ class Flask(Scaffold):
         options.setdefault("use_reloader", self.debug)
         options.setdefault("use_debugger", self.debug)
         options.setdefault("threaded", True)
+        options.setdefault("extra_files", self.config.get("FLASK_RUN_EXTRA_FILES"))
 
         cli.show_server_banner(self.env, self.debug, self.name, False)
 

--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -841,6 +841,11 @@ def run_command(
     if debugger is None:
         debugger = debug
 
+    # Override extra_files argument with config variable if specified
+    app = info.load_app()
+    if app.config.get("FLASK_RUN_EXTRA_FILES"):
+        extra_files = app.config.get("FLASK_RUN_EXTRA_FILES")
+
     show_server_banner(get_env(), debug, info.app_import_path, eager_loading)
     app = DispatchingApp(info.load_app, use_eager_loading=eager_loading)
 


### PR DESCRIPTION
This commit adds support for a `FLASK_RUN_EXTRA_FILES=[]` config variable to specify other files to watch. 

It amends the two methods of running the app (`flask run` & `app.run()`) to pass this config variable to the `extra_files` argument of the `run_server()` function. 

Open to other implementation suggestions.

- fixes #4222

## Testing
I'm not sure the right way to add this to the testing suite, and am grateful for any direction. That said, here's a minimal reproducible example to test. 

1) Create two files: `main.py` and `test.txt`
```python
# main.py
from flask import Flask

app = Flask(__name__)

#app.config['FLASK_RUN_EXTRA_FILES'] = ["test.txt"]

if __name__ == "__main__":
	app.run(debug=1)
```

```
# test.txt
test
```

2) Run the server with the config variable declaration commented out. Verify that the server does not reload when you change `test.txt`.

3) Stop the server.

4) Uncomment the config variable declaration in `main.py`.

5) Run the server and verify that the server now does reload when you change `test.txt`. 



<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
