### PR TITLE
Remove the mention of Flask-Uploads in the uploading docs

### DIFF
--- a/docs/patterns/fileuploads.rst
+++ b/docs/patterns/fileuploads.rst
@@ -175,9 +175,8 @@ are JavaScript libraries like jQuery_ that have form plugins to ease the
 construction of progress bar.
 
 Because the common pattern for file uploads exists almost unchanged in all
-applications dealing with uploads, there is also a Flask extension called
-`Flask-Uploads`_ that implements a full fledged upload mechanism that
-allows controlling which file extensions are allowed to be uploaded.
+applications dealing with uploads, there are also some Flask extensions that
+implement a full fledged upload mechanism that allows controlling which
+file extensions are allowed to be uploaded.
 
 .. _jQuery: https://jquery.com/
-.. _Flask-Uploads: https://flask-uploads.readthedocs.io/en/latest/


### PR DESCRIPTION
The alternative of #4233, see that PR for more details.