### PR TITLE
Update cherokee links in docs/deploying

### DIFF
--- a/docs/deploying/fastcgi.rst
+++ b/docs/deploying/fastcgi.rst
@@ -234,5 +234,5 @@ python path.  Common problems are:
 
 .. _nginx: https://nginx.org/
 .. _lighttpd: https://www.lighttpd.net/
-.. _cherokee: http://cherokee-project.com/
+.. _cherokee: https://cherokee-project.com/
 .. _flup: https://pypi.org/project/flup/

--- a/docs/deploying/uwsgi.rst
+++ b/docs/deploying/uwsgi.rst
@@ -67,5 +67,5 @@ to have it in the URL root its a bit simpler::
 
 .. _nginx: https://nginx.org/
 .. _lighttpd: https://www.lighttpd.net/
-.. _cherokee: http://cherokee-project.com/
+.. _cherokee: https://cherokee-project.com/
 .. _uwsgi: https://uwsgi-docs.readthedocs.io/en/latest/


### PR DESCRIPTION
Replace http:// with https:// in cherokee links in docs/deploying. (This is a recreated PR as an alternative to #4246 )

- fixes #4245