### PR TITLE
Deleted types in `__exit__` methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Unreleased
     :issue:`4096`
 -   The CLI loader handles ``**kwargs`` in a ``create_app`` function.
     :issue:`4170`
+-   Removed type-hints in ``__exit__`` methods. :pr:`4250`
 
 
 Version 2.0.1

--- a/src/flask/ctx.py
+++ b/src/flask/ctx.py
@@ -1,7 +1,6 @@
 import sys
 import typing as t
 from functools import update_wrapper
-from types import TracebackType
 
 from werkzeug.exceptions import HTTPException
 
@@ -257,9 +256,7 @@ class AppContext:
         self.push()
         return self
 
-    def __exit__(
-        self, exc_type: type, exc_value: BaseException, tb: TracebackType
-    ) -> None:
+    def __exit__(self, exc_type, exc_value, tb) -> None:
         self.pop(exc_value)
 
 
@@ -463,9 +460,7 @@ class RequestContext:
         self.push()
         return self
 
-    def __exit__(
-        self, exc_type: type, exc_value: BaseException, tb: TracebackType
-    ) -> None:
+    def __exit__(self, exc_type, exc_value, tb) -> None:
         # do not pop the request stack if we are in debug mode and an
         # exception happened.  This will allow the debugger to still
         # access the request object in the interactive shell.  Furthermore

--- a/src/flask/testing.py
+++ b/src/flask/testing.py
@@ -1,7 +1,6 @@
 import typing as t
 from contextlib import contextmanager
 from copy import copy
-from types import TracebackType
 
 import werkzeug.test
 from click.testing import CliRunner
@@ -226,9 +225,7 @@ class FlaskClient(Client):
         self.preserve_context = True
         return self
 
-    def __exit__(
-        self, exc_type: type, exc_value: BaseException, tb: TracebackType
-    ) -> None:
+    def __exit__(self, exc_type, exc_value, tb) -> None:
         self.preserve_context = False
 
         # Normally the request context is preserved until the next


### PR DESCRIPTION
I deleted type-hints in `__exit__` methods, but i get error: `error: unused 'type: ignore' comment`. This is need to be fixed?

Checklist:

- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
