### PR TITLE
Fix typo in docs/debugging.rst

### DIFF
--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -69,7 +69,7 @@ enables the debugger and reloader.
 
 ``FLASK_ENV`` can only be set as an environment variable. When running
 from Python code, passing ``debug=True`` enables debug mode, which is
-mostly equivalent. Debug mode can be controled separately from
+mostly equivalent. Debug mode can be controlled separately from
 ``FLASK_ENV`` with the ``FLASK_DEBUG`` environment variable as well.
 
 .. code-block:: python


### PR DESCRIPTION
`docs/debugging.rst:72: controled ==> controlled`

Checklist:

- [X] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [X] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [X] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
