### PR TITLE
DOC: Fix broken link to Flask-WTF

### DIFF
--- a/docs/patterns/wtforms.rst
+++ b/docs/patterns/wtforms.rst
@@ -19,7 +19,7 @@ forms.
    fun.  You can get it from `PyPI
    <https://pypi.org/project/Flask-WTF/>`_.
 
-.. _Flask-WTF: https://flask-wtf.readthedocs.io/en/stable/
+.. _Flask-WTF: https://flask-wtf.readthedocs.io/
 
 The Forms
 ---------


### PR DESCRIPTION
The link to Flask-WTF is broken in the current online documentation. Simple change of the URL is needed.

- fixes #4270
