### PR TITLE
docs/debugging.rst typo fix

### DIFF
--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -69,7 +69,7 @@ enables the debugger and reloader.
 
 ``FLASK_ENV`` can only be set as an environment variable. When running
 from Python code, passing ``debug=True`` enables debug mode, which is
-mostly equivalent. Debug mode can be controled separately from
+mostly equivalent. Debug mode can be controlled separately from
 ``FLASK_ENV`` with the ``FLASK_DEBUG`` environment variable as well.
 
 .. code-block:: python


### PR DESCRIPTION
fixed docs/debugging.rst typo: `controled -> controlled`