### PR TITLE
try to address flakiness of lazy loading test

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -334,7 +334,9 @@ def test_lazy_load_error(monkeypatch):
     lazy = DispatchingApp(bad_load, use_eager_loading=False)
 
     with pytest.raises(BadExc):
-        lazy._flush_bg_loading_exception()
+        # reduce flakiness by waiting for the internal loading lock
+        with lazy._lock:
+            lazy._flush_bg_loading_exception()
 
 
 def test_with_appcontext(runner):


### PR DESCRIPTION
This test checks if loading an app in the background will catch and re-raise an exception. It occasionally fails on pypy3. Possibly, the background loading thread does not finish before the assert line, and so there is no exception yet. Try to address this by waiting for the lock before asserting. This could still fail if the thread starts *very* slowly.

closes #4292 