### PR TITLE
Fix Blueprint.errorhandler restricts type of result function which avoids chaining

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,8 @@ Released 2021-10-04
 -   Fix the order of ``before_request`` and other callbacks that trigger
     before the view returns. They are called from the app down to the
     closest nested blueprint. :issue:`4229`
+-   Fix ``Blueprint.errorhandler`` restricts type of result function which
+    avoids chaining. :issue:`4297`
 
 
 Version 2.0.1

--- a/src/flask/scaffold.py
+++ b/src/flask/scaffold.py
@@ -80,7 +80,7 @@ class Scaffold:
     name: str
     _static_folder: t.Optional[str] = None
     _static_url_path: t.Optional[str] = None
-
+    T = t.TypeVar("T", t.Callable[..., t.Any], t.Any)
     #: JSON encoder class used by :func:`flask.json.dumps`. If a
     #: blueprint sets this, it will be used instead of the app's value.
     json_encoder: t.Optional[t.Type[JSONEncoder]] = None
@@ -646,12 +646,7 @@ class Scaffold:
         return f
 
     @setupmethod
-    def errorhandler(
-        self, code_or_exception: t.Union[t.Type[GenericException], int]
-    ) -> t.Callable[
-        ["ErrorHandlerCallable[GenericException]"],
-        "ErrorHandlerCallable[GenericException]",
-    ]:
+    def errorhandler(self, code_or_exception: t.Union[T, int]) -> T:
         """Register a function to handle errors by code or exception class.
 
         A decorator that is used to register a function given an

--- a/src/flask/scaffold.py
+++ b/src/flask/scaffold.py
@@ -646,7 +646,9 @@ class Scaffold:
         return f
 
     @setupmethod
-    def errorhandler(self, code_or_exception: t.Union[T, int]) -> T:
+    def errorhandler(
+        self, code_or_exception: t.Union[t.Type[GenericException], int]
+    ) -> T:
         """Register a function to handle errors by code or exception class.
 
         A decorator that is used to register a function given an


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixed #4297 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] I did tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
