### PR TITLE
Correct the actual unescaped character

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -468,7 +468,7 @@ Here is a basic introduction to how the :class:`~markupsafe.Markup` class works:
     >>> Markup.escape('<blink>hacker</blink>')
     Markup('&lt;blink&gt;hacker&lt;/blink&gt;')
     >>> Markup('<em>Marked up</em> &raquo; HTML').striptags()
-    'Marked up \xbb HTML'
+    'Marked up » HTML'
 
 .. versionchanged:: 0.5
 


### PR DESCRIPTION
`&raquo;` should be unescaped to `»` after `striptags`.

Ref: https://flask.palletsprojects.com/en/2.0.x/api/#flask.Markup.striptags