### PR TITLE
Fix after_this_request fails with a meaningless error when used outside request context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,8 @@ Released 2021-10-04
 -   Fix the order of ``before_request`` and other callbacks that trigger
     before the view returns. They are called from the app down to the
     closest nested blueprint. :issue:`4229`
+-   Fix ``after_this_request`` fails with a meaningless error when used
+    outside request context. :issue:`4333`
 
 
 Version 2.0.1

--- a/src/flask/ctx.py
+++ b/src/flask/ctx.py
@@ -130,7 +130,14 @@ def after_this_request(f: AfterRequestCallable) -> AfterRequestCallable:
 
     .. versionadded:: 0.9
     """
-    _request_ctx_stack.top._after_request_functions.append(f)
+    try:
+        _request_ctx_stack.top._after_request_functions.append(f)
+    except Exception:
+        print(
+            "This decorator can only be used at local scopes "
+            "when a request context is on the stack.  For instance within "
+            "view functions."
+        )
     return f
 
 


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixed #4333 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] I did tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
