### PR TITLE
drop Python 3.6

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,6 @@ jobs:
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
           - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
-          - {name: '3.6', python: '3.6', os: ubuntu-latest, tox: py36}
           - {name: 'PyPy', python: 'pypy-3.7', os: ubuntu-latest, tox: pypy37}
           - {name: Typing, python: '3.10', os: ubuntu-latest, tox: typing}
     steps:

--- a/docs/async-await.rst
+++ b/docs/async-await.rst
@@ -7,8 +7,7 @@ Using ``async`` and ``await``
 
 Routes, error handlers, before request, after request, and teardown
 functions can all be coroutine functions if Flask is installed with the
-``async`` extra (``pip install flask[async]``). It requires Python 3.7+
-where ``contextvars.ContextVar`` is available. This allows views to be
+``async`` extra (``pip install flask[async]``). This allows views to be
 defined with ``async def`` and use ``await``.
 
 .. code-block:: python
@@ -29,6 +28,12 @@ well as all the HTTP method handlers in views that inherit from the
     Python 3.8 has a bug related to asyncio on Windows. If you encounter
     something like ``ValueError: set_wakeup_fd only works in main thread``,
     please upgrade to Python 3.9.
+
+.. admonition:: Using ``async`` with greenlet
+
+    When using gevent or eventlet to serve an application or patch the
+    runtime, greenlet>=1.0 is required. When using PyPy, PyPy>=7.3.7 is
+    required.
 
 
 Performance

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -112,10 +112,9 @@ shell with the :func:`shell <cli.shell_command>` command. An application
 context will be active, and the app instance will be imported. ::
 
     $ flask shell
-    Python 3.6.2 (default, Jul 20 2017, 03:52:27)
-    [GCC 7.1.1 20170630] on linux
-    App: example
-    Instance: /home/user/Projects/hello/instance
+    Python 3.10.0 (default, Oct 27 2021, 06:59:51) [GCC 11.1.0] on linux
+    App: example [production]
+    Instance: /home/david/Projects/pallets/flask/instance
     >>>
 
 Use :meth:`~Flask.shell_context_processor` to add other automatic imports.

--- a/docs/extensiondev.rst
+++ b/docs/extensiondev.rst
@@ -322,9 +322,9 @@ ecosystem remain consistent and compatible.
     `Official Pallets Themes`_. A link to the documentation or project
     website must be in the PyPI metadata or the readme.
 7.  For maximum compatibility, the extension should support the same
-    versions of Python that Flask supports. 3.6+ is recommended as of
-    2020. Use ``python_requires=">= 3.6"`` in ``setup.py`` to indicate
-    supported versions.
+    versions of Python that Flask supports. 3.7+ is recommended as of
+    December 2021. Use ``python_requires=">= 3.7"`` in ``setup.py`` to
+    indicate supported versions.
 
 .. _PyPI: https://pypi.org/search/?c=Framework+%3A%3A+Flask
 .. _mailinglist: https://mail.python.org/mailman/listinfo/flask

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -49,6 +49,18 @@ use them if you install them.
 .. _watchdog: https://pythonhosted.org/watchdog/
 
 
+greenlet
+~~~~~~~~
+
+You may choose to use gevent or eventlet with your application. In this
+case, greenlet>=1.0 is required. When using PyPy, PyPy>=7.3.7 is
+required.
+
+These are not minimum supported versions, they only indicate the first
+versions that added necessary features. You should use the latest
+versions of each.
+
+
 Virtual environments
 --------------------
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,9 +6,7 @@ Python Version
 --------------
 
 We recommend using the latest version of Python. Flask supports Python
-3.6 and newer.
-
-``async`` support in Flask requires Python 3.7+ for ``contextvars.ContextVar``.
+3.7 and newer.
 
 
 Dependencies

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -38,7 +38,7 @@ filelock==3.3.2
     # via
     #   tox
     #   virtualenv
-greenlet==1.1.2
+greenlet==1.1.2 ; python_version < "3.11"
     # via -r requirements/tests.in
 identify==2.3.3
     # via pre-commit

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -1,5 +1,5 @@
 pytest
 asgiref
 blinker
-greenlet
+greenlet ; python_version < "3.11"
 python-dotenv

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -10,7 +10,7 @@ attrs==21.2.0
     # via pytest
 blinker==1.4
     # via -r requirements/tests.in
-greenlet==1.1.2
+greenlet==1.1.2 ; python_version < "3.11"
     # via -r requirements/tests.in
 iniconfig==1.1.1
     # via pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ classifiers =
 packages = find:
 package_dir = = src
 include_package_data = true
-python_requires = >= 3.6
+python_requires = >= 3.7
 # Dependencies are in setup.py for GitHub's dependency graph.
 
 [options.packages.find]
@@ -88,7 +88,7 @@ per-file-ignores =
 
 [mypy]
 files = src/flask
-python_version = 3.6
+python_version = 3.7
 allow_redefinition = True
 disallow_subclassing_any = True
 # disallow_untyped_calls = True

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -16,7 +16,6 @@ from werkzeug.exceptions import BadRequest
 from werkzeug.exceptions import BadRequestKeyError
 from werkzeug.exceptions import HTTPException
 from werkzeug.exceptions import InternalServerError
-from werkzeug.local import ContextVar
 from werkzeug.routing import BuildError
 from werkzeug.routing import Map
 from werkzeug.routing import MapAdapter
@@ -1620,13 +1619,6 @@ class Flask(Scaffold):
             raise RuntimeError(
                 "Install Flask with the 'async' extra in order to use async views."
             ) from None
-
-        # Check that Werkzeug isn't using its fallback ContextVar class.
-        if ContextVar.__module__ == "werkzeug.local":
-            raise RuntimeError(
-                "Async cannot be used with this combination of Python "
-                "and Greenlet versions."
-            )
 
         return asgiref_async_to_sync(func)
 

--- a/src/flask/json/__init__.py
+++ b/src/flask/json/__init__.py
@@ -1,3 +1,4 @@
+import dataclasses
 import decimal
 import io
 import json as _json
@@ -15,12 +16,6 @@ from ..globals import request
 if t.TYPE_CHECKING:
     from ..app import Flask
     from ..wrappers import Response
-
-try:
-    import dataclasses
-except ImportError:
-    # Python < 3.7
-    dataclasses = None  # type: ignore
 
 
 class JSONEncoder(_json.JSONEncoder):

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,5 +1,4 @@
 import asyncio
-import sys
 
 import pytest
 
@@ -79,7 +78,6 @@ def _async_app():
     return app
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python >= 3.7")
 @pytest.mark.parametrize("path", ["/", "/home", "/bp/", "/view", "/methodview"])
 def test_async_route(path, async_app):
     test_client = async_app.test_client()
@@ -89,7 +87,6 @@ def test_async_route(path, async_app):
     assert b"POST" in response.get_data()
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python >= 3.7")
 @pytest.mark.parametrize("path", ["/error", "/bp/error"])
 def test_async_error_handler(path, async_app):
     test_client = async_app.test_client()
@@ -97,7 +94,6 @@ def test_async_error_handler(path, async_app):
     assert response.status_code == 412
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python >= 3.7")
 def test_async_before_after_request():
     app_first_called = False
     app_before_called = False
@@ -154,10 +150,3 @@ def test_async_before_after_request():
     test_client.get("/bp/")
     assert bp_before_called
     assert bp_after_called
-
-
-@pytest.mark.skipif(sys.version_info >= (3, 7), reason="should only raise Python < 3.7")
-def test_async_runtime_error():
-    app = Flask(__name__)
-    with pytest.raises(RuntimeError):
-        app.async_to_sync(None)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,5 @@
 import gc
 import re
-import sys
 import time
 import uuid
 import weakref
@@ -1323,7 +1322,6 @@ def test_jsonify_mimetype(app, req_ctx):
     assert rv.mimetype == "application/vnd.api+json"
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python >= 3.7")
 def test_json_dump_dataclass(app, req_ctx):
     from dataclasses import make_dataclass
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py3{11,10,9,8,7,6},pypy37
+    py3{11,10,9,8,7},pypy3{8,7}
     py39-click7
     style
     typing


### PR DESCRIPTION
[Python 3.6 is end-of-life on December 2021.](https://www.python.org/dev/peps/pep-0494/#lifespan)

Greenlet doesn't compile on Python 3.11 yet, so it's excluded for tests.

Werkzeug removed compat code for `ContextVar`. When using greenlet (gevent or eventlet), greenlet>=1.0 is required, or PyPy>=7.3.7. Notes about this have been added to the installation, async, and deployment docs.