### PR TITLE
remove deprecated code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Unreleased
         instead.
     -   ``total_seconds`` is removed, use ``timedelta.total_seconds``
         instead.
+    -   The same blueprint cannot be registered with the same name. Use
+        ``name=`` when registering to specify a unique name.
 
 
 Version 2.0.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,15 @@ Unreleased
     -   The same blueprint cannot be registered with the same name. Use
         ``name=`` when registering to specify a unique name.
 
+-   Some parameters in ``send_file`` and ``send_from_directory`` were
+    renamed in 2.0. The deprecation period for the old names is extended
+    to 2.2. Be sure to test with deprecation warnings visible.
+
+    -   ``attachment_filename`` is renamed to ``download_name``.
+    -   ``cache_timeout`` is renamed to ``max_age``.
+    -   ``add_etags`` is renamed to ``etag``.
+    -   ``filename`` is renamed to ``path``.
+
 
 Version 2.0.2
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Unreleased
     -   The CLI does not pass ``script_info`` to app factory functions.
     -   ``config.from_json`` is replaced by
         ``config.from_file(name, load=json.load)``.
+    -   ``json`` functions no longer take an ``encoding`` parameter.
 
 
 Version 2.0.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Unreleased
 -   Remove previously deprecated code. :pr:`4337`
 
     -   The CLI does not pass ``script_info`` to app factory functions.
+    -   ``config.from_json`` is replaced by
+        ``config.from_file(name, load=json.load)``.
 
 
 Version 2.0.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Unreleased
     -   ``config.from_json`` is replaced by
         ``config.from_file(name, load=json.load)``.
     -   ``json`` functions no longer take an ``encoding`` parameter.
+    -   ``safe_join`` is removed, use ``werkzeug.utils.safe_join``
+        instead.
 
 
 Version 2.0.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@ Version 2.1.0
 
 Unreleased
 
--   Update Click dependency to >= 8.0.
+-   Drop support for Python 3.6. :pr:`4335`
+-   Update Click dependency to >= 8.0. :pr:`4008`
+-   Remove previously deprecated code. :pr:`4337`
+
+    -   The CLI does not pass ``script_info`` to app factory functions.
 
 
 Version 2.0.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Unreleased
     -   ``json`` functions no longer take an ``encoding`` parameter.
     -   ``safe_join`` is removed, use ``werkzeug.utils.safe_join``
         instead.
+    -   ``total_seconds`` is removed, use ``timedelta.total_seconds``
+        instead.
 
 
 Version 2.0.2

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -218,8 +218,6 @@ Useful Functions and Classes
 
 .. autofunction:: send_from_directory
 
-.. autofunction:: safe_join
-
 .. autofunction:: escape
 
 .. autoclass:: Markup

--- a/src/flask/__init__.py
+++ b/src/flask/__init__.py
@@ -23,7 +23,6 @@ from .helpers import flash as flash
 from .helpers import get_flashed_messages as get_flashed_messages
 from .helpers import get_template_attribute as get_template_attribute
 from .helpers import make_response as make_response
-from .helpers import safe_join as safe_join
 from .helpers import send_file as send_file
 from .helpers import send_from_directory as send_from_directory
 from .helpers import stream_with_context as stream_with_context

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -299,24 +299,14 @@ class Blueprint(Scaffold):
         name = f"{name_prefix}.{self_name}".lstrip(".")
 
         if name in app.blueprints:
+            bp_desc = "this" if app.blueprints[name] is self else "a different"
             existing_at = f" '{name}'" if self_name != name else ""
 
-            if app.blueprints[name] is not self:
-                raise ValueError(
-                    f"The name '{self_name}' is already registered for"
-                    f" a different blueprint{existing_at}. Use 'name='"
-                    " to provide a unique name."
-                )
-            else:
-                import warnings
-
-                warnings.warn(
-                    f"The name '{self_name}' is already registered for"
-                    f" this blueprint{existing_at}. Use 'name=' to"
-                    " provide a unique name. This will become an error"
-                    " in Flask 2.1.",
-                    stacklevel=4,
-                )
+            raise ValueError(
+                f"The name '{self_name}' is already registered for"
+                f" {bp_desc} blueprint{existing_at}. Use 'name=' to"
+                f" provide a unique name."
+            )
 
         first_bp_registration = not any(bp is self for bp in app.blueprints.values())
         first_name_registration = name not in app.blueprints

--- a/src/flask/config.py
+++ b/src/flask/config.py
@@ -176,6 +176,9 @@ class Config(dict):
 
         .. code-block:: python
 
+            import json
+            app.config.from_file("config.json", load=json.load)
+
             import toml
             app.config.from_file("config.toml", load=toml.load)
 
@@ -203,32 +206,6 @@ class Config(dict):
             raise
 
         return self.from_mapping(obj)
-
-    def from_json(self, filename: str, silent: bool = False) -> bool:
-        """Update the values in the config from a JSON file. The loaded
-        data is passed to the :meth:`from_mapping` method.
-
-        :param filename: The path to the JSON file. This can be an
-            absolute path or relative to the config root path.
-        :param silent: Ignore the file if it doesn't exist.
-        :return: ``True`` if the file was loaded successfully.
-
-        .. deprecated:: 2.0.0
-            Will be removed in Flask 2.1. Use :meth:`from_file` instead.
-            This was removed early in 2.0.0, was added back in 2.0.1.
-
-        .. versionadded:: 0.11
-        """
-        import warnings
-        from . import json
-
-        warnings.warn(
-            "'from_json' is deprecated and will be removed in Flask"
-            " 2.1. Use 'from_file(path, json.load)' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.from_file(filename, json.load, silent=silent)
 
     def from_mapping(
         self, mapping: t.Optional[t.Mapping[str, t.Any]] = None, **kwargs: t.Any

--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -452,7 +452,7 @@ def _prepare_send_file_kwargs(
         warnings.warn(
             "The 'attachment_filename' parameter has been renamed to"
             " 'download_name'. The old name will be removed in Flask"
-            " 2.1.",
+            " 2.2.",
             DeprecationWarning,
             stacklevel=3,
         )
@@ -461,7 +461,7 @@ def _prepare_send_file_kwargs(
     if cache_timeout is not None:
         warnings.warn(
             "The 'cache_timeout' parameter has been renamed to"
-            " 'max_age'. The old name will be removed in Flask 2.1.",
+            " 'max_age'. The old name will be removed in Flask 2.2.",
             DeprecationWarning,
             stacklevel=3,
         )
@@ -470,7 +470,7 @@ def _prepare_send_file_kwargs(
     if add_etags is not None:
         warnings.warn(
             "The 'add_etags' parameter has been renamed to 'etag'. The"
-            " old name will be removed in Flask 2.1.",
+            " old name will be removed in Flask 2.2.",
             DeprecationWarning,
             stacklevel=3,
         )
@@ -666,7 +666,7 @@ def send_from_directory(
     if filename is not None:
         warnings.warn(
             "The 'filename' parameter has been renamed to 'path'. The"
-            " old name will be removed in Flask 2.1.",
+            " old name will be removed in Flask 2.2.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -5,7 +5,6 @@ import sys
 import typing as t
 import warnings
 from datetime import datetime
-from datetime import timedelta
 from functools import lru_cache
 from functools import update_wrapper
 from threading import RLock
@@ -759,27 +758,6 @@ class locked_cached_property(werkzeug.utils.cached_property):
     def __delete__(self, obj: object) -> None:
         with self.lock:
             super().__delete__(obj)
-
-
-def total_seconds(td: timedelta) -> int:
-    """Returns the total seconds from a timedelta object.
-
-    :param timedelta td: the timedelta to be converted in seconds
-
-    :returns: number of seconds
-    :rtype: int
-
-    .. deprecated:: 2.0
-        Will be removed in Flask 2.1. Use
-        :meth:`timedelta.total_seconds` instead.
-    """
-    warnings.warn(
-        "'total_seconds' is deprecated and will be removed in Flask"
-        " 2.1. Use 'timedelta.total_seconds' instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return td.days * 60 * 60 * 24 + td.seconds
 
 
 def is_ip(value: str) -> bool:

--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -11,7 +11,6 @@ from functools import update_wrapper
 from threading import RLock
 
 import werkzeug.utils
-from werkzeug.exceptions import NotFound
 from werkzeug.routing import BuildError
 from werkzeug.urls import url_quote
 
@@ -625,29 +624,6 @@ def send_file(
             cache_timeout=cache_timeout,
         )
     )
-
-
-def safe_join(directory: str, *pathnames: str) -> str:
-    """Safely join zero or more untrusted path components to a base
-    directory to avoid escaping the base directory.
-
-    :param directory: The trusted base directory.
-    :param pathnames: The untrusted path components relative to the
-        base directory.
-    :return: A safe path, otherwise ``None``.
-    """
-    warnings.warn(
-        "'flask.helpers.safe_join' is deprecated and will be removed in"
-        " Flask 2.1. Use 'werkzeug.utils.safe_join' instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    path = werkzeug.utils.safe_join(directory, *pathnames)
-
-    if path is None:
-        raise NotFound()
-
-    return path
 
 
 def send_from_directory(

--- a/src/flask/json/__init__.py
+++ b/src/flask/json/__init__.py
@@ -1,10 +1,8 @@
 import dataclasses
 import decimal
-import io
 import json as _json
 import typing as t
 import uuid
-import warnings
 from datetime import date
 
 from jinja2.utils import htmlsafe_json_dumps as _jinja_htmlsafe_dumps
@@ -124,20 +122,7 @@ def dumps(obj: t.Any, app: t.Optional["Flask"] = None, **kwargs: t.Any) -> str:
         context for configuration.
     """
     _dump_arg_defaults(kwargs, app=app)
-    encoding = kwargs.pop("encoding", None)
-    rv = _json.dumps(obj, **kwargs)
-
-    if encoding is not None:
-        warnings.warn(
-            "'encoding' is deprecated and will be removed in Flask 2.1.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        if isinstance(rv, str):
-            return rv.encode(encoding)  # type: ignore
-
-    return rv
+    return _json.dumps(obj, **kwargs)
 
 
 def dump(
@@ -159,23 +144,6 @@ def dump(
         deprecated and will be removed in Flask 2.1.
     """
     _dump_arg_defaults(kwargs, app=app)
-    encoding = kwargs.pop("encoding", None)
-    show_warning = encoding is not None
-
-    try:
-        fp.write("")
-    except TypeError:
-        show_warning = True
-        fp = io.TextIOWrapper(fp, encoding or "utf-8")  # type: ignore
-
-    if show_warning:
-        warnings.warn(
-            "Writing to a binary file, and the 'encoding' argument, is"
-            " deprecated and will be removed in Flask 2.1.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
     _json.dump(obj, fp, **kwargs)
 
 
@@ -199,19 +167,6 @@ def loads(s: str, app: t.Optional["Flask"] = None, **kwargs: t.Any) -> t.Any:
         context for configuration.
     """
     _load_arg_defaults(kwargs, app=app)
-    encoding = kwargs.pop("encoding", None)
-
-    if encoding is not None:
-        warnings.warn(
-            "'encoding' is deprecated and will be removed in Flask 2.1."
-            " The data must be a string or UTF-8 bytes.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        if isinstance(s, bytes):
-            s = s.decode(encoding)
-
     return _json.loads(s, **kwargs)
 
 
@@ -231,20 +186,6 @@ def load(fp: t.IO[str], app: t.Optional["Flask"] = None, **kwargs: t.Any) -> t.A
         file must be text mode, or binary mode with UTF-8 bytes.
     """
     _load_arg_defaults(kwargs, app=app)
-    encoding = kwargs.pop("encoding", None)
-
-    if encoding is not None:
-        warnings.warn(
-            "'encoding' is deprecated and will be removed in Flask 2.1."
-            " The file must be text mode, or binary mode with UTF-8"
-            " bytes.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        if isinstance(fp.read(0), bytes):
-            fp = io.TextIOWrapper(fp, encoding)  # type: ignore
-
     return _json.load(fp, **kwargs)
 
 

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -954,8 +954,8 @@ def test_unique_blueprint_names(app, client) -> None:
 
     app.register_blueprint(bp)
 
-    with pytest.warns(UserWarning):
-        app.register_blueprint(bp)  # same bp, same name, warning
+    with pytest.raises(ValueError):
+        app.register_blueprint(bp)  # same bp, same name, error
 
     app.register_blueprint(bp, name="again")  # same bp, different name, ok
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,29 +49,27 @@ def test_cli_name(test_apps):
 
 
 def test_find_best_app(test_apps):
-    script_info = ScriptInfo()
-
     class Module:
         app = Flask("appname")
 
-    assert find_best_app(script_info, Module) == Module.app
+    assert find_best_app(Module) == Module.app
 
     class Module:
         application = Flask("appname")
 
-    assert find_best_app(script_info, Module) == Module.application
+    assert find_best_app(Module) == Module.application
 
     class Module:
         myapp = Flask("appname")
 
-    assert find_best_app(script_info, Module) == Module.myapp
+    assert find_best_app(Module) == Module.myapp
 
     class Module:
         @staticmethod
         def create_app():
             return Flask("appname")
 
-    app = find_best_app(script_info, Module)
+    app = find_best_app(Module)
     assert isinstance(app, Flask)
     assert app.name == "appname"
 
@@ -80,29 +78,7 @@ def test_find_best_app(test_apps):
         def create_app(**kwargs):
             return Flask("appname")
 
-    app = find_best_app(script_info, Module)
-    assert isinstance(app, Flask)
-    assert app.name == "appname"
-
-    class Module:
-        @staticmethod
-        def create_app(foo):
-            return Flask("appname")
-
-    with pytest.deprecated_call(match="Script info"):
-        app = find_best_app(script_info, Module)
-
-    assert isinstance(app, Flask)
-    assert app.name == "appname"
-
-    class Module:
-        @staticmethod
-        def create_app(foo=None, script_info=None):
-            return Flask("appname")
-
-    with pytest.deprecated_call(match="script_info"):
-        app = find_best_app(script_info, Module)
-
+    app = find_best_app(Module)
     assert isinstance(app, Flask)
     assert app.name == "appname"
 
@@ -111,7 +87,7 @@ def test_find_best_app(test_apps):
         def make_app():
             return Flask("appname")
 
-    app = find_best_app(script_info, Module)
+    app = find_best_app(Module)
     assert isinstance(app, Flask)
     assert app.name == "appname"
 
@@ -122,7 +98,7 @@ def test_find_best_app(test_apps):
         def create_app():
             return Flask("appname2")
 
-    assert find_best_app(script_info, Module) == Module.myapp
+    assert find_best_app(Module) == Module.myapp
 
     class Module:
         myapp = Flask("appname1")
@@ -131,32 +107,32 @@ def test_find_best_app(test_apps):
         def create_app():
             return Flask("appname2")
 
-    assert find_best_app(script_info, Module) == Module.myapp
+    assert find_best_app(Module) == Module.myapp
 
     class Module:
         pass
 
-    pytest.raises(NoAppException, find_best_app, script_info, Module)
+    pytest.raises(NoAppException, find_best_app, Module)
 
     class Module:
         myapp1 = Flask("appname1")
         myapp2 = Flask("appname2")
 
-    pytest.raises(NoAppException, find_best_app, script_info, Module)
+    pytest.raises(NoAppException, find_best_app, Module)
 
     class Module:
         @staticmethod
         def create_app(foo, bar):
             return Flask("appname2")
 
-    pytest.raises(NoAppException, find_best_app, script_info, Module)
+    pytest.raises(NoAppException, find_best_app, Module)
 
     class Module:
         @staticmethod
         def create_app():
             raise TypeError("bad bad factory!")
 
-    pytest.raises(TypeError, find_best_app, script_info, Module)
+    pytest.raises(TypeError, find_best_app, Module)
 
 
 @pytest.mark.parametrize(
@@ -220,8 +196,7 @@ def test_prepare_import(request, value, path, result):
     ),
 )
 def test_locate_app(test_apps, iname, aname, result):
-    info = ScriptInfo()
-    assert locate_app(info, iname, aname).name == result
+    assert locate_app(iname, aname).name == result
 
 
 @pytest.mark.parametrize(
@@ -243,20 +218,17 @@ def test_locate_app(test_apps, iname, aname, result):
     ),
 )
 def test_locate_app_raises(test_apps, iname, aname):
-    info = ScriptInfo()
-
     with pytest.raises(NoAppException):
-        locate_app(info, iname, aname)
+        locate_app(iname, aname)
 
 
 def test_locate_app_suppress_raise(test_apps):
-    info = ScriptInfo()
-    app = locate_app(info, "notanapp.py", None, raise_if_not_found=False)
+    app = locate_app("notanapp.py", None, raise_if_not_found=False)
     assert app is None
 
     # only direct import error is suppressed
     with pytest.raises(NoAppException):
-        locate_app(info, "cliapp.importerrorapp", None, raise_if_not_found=False)
+        locate_app("cliapp.importerrorapp", None, raise_if_not_found=False)
 
 
 def test_get_version(test_apps, capsys):


### PR DESCRIPTION
Removed:

* `script_info` is no longer passed as the first arg / matching kwarg to an app factory function. It is no longer passed as the first arg to many internal CLI functions.
* `config.from_json`, use `config.from_file(path, json.load)` instead.
* `json` functions no longer take an `encoding` parameter.
* `safe_join`, use `werkzeug.utils.safe_join` instead.
* `total_seconds`, use `timedelta.total_seconds` instead.
* The same blueprint can't be registered with the same name, every registration requires a unique, possibly nested, name.

Some parameters to `send_file` and `send_from_directory` were renamed to be more accurate to what they did when moving the implementations to Werkzeug. These old names were deprecated in Flask's wrappers. The deprecation period has been extended to 2.2. `attachment_filename` is renamed to `download_name`, `cache_timeout` is renamed to `max_age`, `add_etags` is renamed to `etag`, and `filename` is renamed to `path`.