### PR TITLE
deprecate `RequestContext.g`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ Unreleased
     -   ``add_etags`` is renamed to ``etag``.
     -   ``filename`` is renamed to ``path``.
 
+-   The ``RequestContext.g`` property is deprecated. Use ``g`` directly
+    or ``AppContext.g`` instead. :issue:`3898`
 -   ``copy_current_request_context`` can decorate async functions.
     :pr:`4303`
 

--- a/src/flask/ctx.py
+++ b/src/flask/ctx.py
@@ -332,11 +332,29 @@ class RequestContext:
         self._after_request_functions: t.List[AfterRequestCallable] = []
 
     @property
-    def g(self) -> AppContext:
+    def g(self) -> _AppCtxGlobals:
+        import warnings
+
+        warnings.warn(
+            "Accessing 'g' on the request context is deprecated and"
+            " will be removed in Flask 2.2. Access `g` directly or from"
+            "the application context instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return _app_ctx_stack.top.g
 
     @g.setter
-    def g(self, value: AppContext) -> None:
+    def g(self, value: _AppCtxGlobals) -> None:
+        import warnings
+
+        warnings.warn(
+            "Setting 'g' on the request context is deprecated and"
+            " will be removed in Flask 2.2. Set it on the application"
+            " context instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         _app_ctx_stack.top.g = value
 
     def copy(self) -> "RequestContext":


### PR DESCRIPTION
It was moved to `AppContext.g` a long time ago.