### PR TITLE
Fix error message for `after_this_request` when used outside request context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Unreleased
 -   ``app.json_encoder`` and ``json_decoder`` are only passed to
     ``dumps`` and ``loads`` if they have custom behavior. This improves
     performance, mainly on PyPy. :issue:`4349`
+-   Fix error message for ``after_this_request`` when it used outside
+    request context. :issue:`4333`
 
 
 Version 2.0.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Unreleased
 -   ``app.json_encoder`` and ``json_decoder`` are only passed to
     ``dumps`` and ``loads`` if they have custom behavior. This improves
     performance, mainly on PyPy. :issue:`4349`
--   Fix error message for ``after_this_request`` when it used outside
+-   Clearer error message when ``after_this_request`` is used outside a
     request context. :issue:`4333`
 
 

--- a/src/flask/ctx.py
+++ b/src/flask/ctx.py
@@ -130,7 +130,15 @@ def after_this_request(f: AfterRequestCallable) -> AfterRequestCallable:
 
     .. versionadded:: 0.9
     """
-    _request_ctx_stack.top._after_request_functions.append(f)
+    top = _request_ctx_stack.top
+    if top is None:
+        raise RuntimeError(
+            "This decorator can only be used at local scopes "
+            "when a request context is on the stack. For instance within "
+            "view functions."
+        )
+    top._after_request_functions.append(f)
+
     return f
 
 

--- a/src/flask/ctx.py
+++ b/src/flask/ctx.py
@@ -131,14 +131,14 @@ def after_this_request(f: AfterRequestCallable) -> AfterRequestCallable:
     .. versionadded:: 0.9
     """
     top = _request_ctx_stack.top
+
     if top is None:
         raise RuntimeError(
-            "This decorator can only be used at local scopes "
-            "when a request context is on the stack. For instance within "
-            "view functions."
+            "This decorator can only be used when a request context is"
+            " active, such as within a view function."
         )
-    top._after_request_functions.append(f)
 
+    top._after_request_functions.append(f)
     return f
 
 
@@ -167,12 +167,13 @@ def copy_current_request_context(f: t.Callable) -> t.Callable:
     .. versionadded:: 0.10
     """
     top = _request_ctx_stack.top
+
     if top is None:
         raise RuntimeError(
-            "This decorator can only be used at local scopes "
-            "when a request context is on the stack.  For instance within "
-            "view functions."
+            "This decorator can only be used when a request context is"
+            " active, such as within a view function."
         )
+
     reqctx = top.copy()
 
     def wrapper(*args, **kwargs):


### PR DESCRIPTION
- fixes #4333

Checklist:

- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
