### PR TITLE
Only use a custom JSONDecoder if needed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Unreleased
 -   Fix type annotation for ``errorhandler`` decorator. :issue:`4295`
 -   Revert a change to the CLI that caused it to hide ``ImportError``
     tracebacks when importing the application. :issue:`4307`
+-   ``app.json_encoder`` and ``json_decoder`` are only passed to
+    ``dumps`` and ``loads`` if they have custom behavior. This improves
+    performance, mainly on PyPy. :issue:`4349`
 
 
 Version 2.0.2

--- a/src/flask/json/__init__.py
+++ b/src/flask/json/__init__.py
@@ -81,6 +81,11 @@ def _dump_arg_defaults(
         if bp is not None and bp.json_encoder is not None:
             cls = bp.json_encoder
 
+        # Only set a custom encoder if it has custom behavior. This is
+        # faster on PyPy.
+        if cls is not _json.JSONEncoder:
+            kwargs.setdefault("cls", cls)
+
         kwargs.setdefault("cls", cls)
         kwargs.setdefault("ensure_ascii", app.config["JSON_AS_ASCII"])
         kwargs.setdefault("sort_keys", app.config["JSON_SORT_KEYS"])
@@ -102,9 +107,10 @@ def _load_arg_defaults(
         if bp is not None and bp.json_decoder is not None:
             cls = bp.json_decoder
 
-        kwargs.setdefault("cls", cls)
-    else:
-        kwargs.setdefault("cls", JSONDecoder)
+        # Only set a custom decoder if it has custom behavior. This is
+        # faster on PyPy.
+        if cls not in {JSONDecoder, _json.JSONDecoder}:
+            kwargs.setdefault("cls", cls)
 
 
 def dumps(obj: t.Any, app: t.Optional["Flask"] = None, **kwargs: t.Any) -> str:


### PR DESCRIPTION
The default JSONDecoder adds no extra functionality to `json.loads`, but using a custom class takes you off of an optimized fast path in pypy (it adds some overhead in cpython, but I think it's minimal). This change sticks with the default loading behaviour unless the user has specifically opted in to customising it.

- fixes #4349

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.

Notes:
- I can update the above if the general outline of the fix is acceptable
- Testing performance is hard: but I can add a test to ensure the correct args are passed to `json.loads` in all cases.