### PR TITLE
Don't error when MethodView is a Metaclass base (fixes #4369)

### DIFF
--- a/src/flask/views.py
+++ b/src/flask/views.py
@@ -108,7 +108,7 @@ class MethodViewType(type):
     defines.
     """
 
-    def __init__(cls, name, bases, d):
+    def __init__(cls, name, bases, d, **kwargs):
         super().__init__(name, bases, d)
 
         if "methods" not in d:


### PR DESCRIPTION
`MethodViewType`'s init method lacks `**kwargs` so is unable to be used as a Metaclass base when supplying `**kwds` in the three argument form of [`type`](https://docs.python.org/3/library/functions.html#type).

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #4369

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
