### PR TITLE
Fix the command for checking port on macOS in server docs

### DIFF
--- a/docs/server.rst
+++ b/docs/server.rst
@@ -80,27 +80,34 @@ messages:
 Either identify and stop the other program, or use
 ``flask run --port 5001`` to pick a different port.
 
-You can use ``netstat`` to identify what process id is using a port,
-then use other operating system tools stop that process. The following
-example shows that process id 6847 is using port 5000.
+You can use ``netstat`` or ``lsof`` to identify what process id is using
+a port, then use other operating system tools stop that process. The
+following example shows that process id 6847 is using port 5000.
 
 .. tabs::
 
-    .. group-tab:: Linux/Mac
+    .. tab:: ``netstat`` (Linux)
 
         .. code-block:: text
 
             $ netstat -nlp | grep 5000
             tcp 0 0 127.0.0.1:5000 0.0.0.0:* LISTEN 6847/python
 
-    .. group-tab:: Windows
+    .. tab:: ``lsof`` (macOS / Linux)
+
+        .. code-block:: text
+
+            $ lsof -P -i :5000
+            Python 6847 IPv4 TCP localhost:5000 (LISTEN)
+
+    .. tab:: ``netstat`` (Windows)
 
         .. code-block:: text
 
             > netstat -ano | findstr 5000
             TCP 127.0.0.1:5000 0.0.0.0:0 LISTENING 6847
 
-MacOS Monterey and later automatically starts a service that uses port
+macOS Monterey and later automatically starts a service that uses port
 5000. To disable the service, go to System Preferences, Sharing, and
 disable "AirPlay Receiver".
 


### PR DESCRIPTION
The original `netstat` command is not working on macOS, I change it to `lsof` for a better output.

Continues #4343