### PR TITLE
Lint the code-block in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ A Simple Example
     def hello():
         return "Hello, World!"
 
-.. code-block:: text
+.. code-block:: python
 
     $ flask run
       * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)


### PR DESCRIPTION
Hi there,

Currently we have [```.. code-block:: text in line 46```](https://github.com/pallets/flask/blob/660994efc761efdfd49ca442b73f6712dc77b6cf/README.rst#L44).

But it would be better linted with ```.. code-block:: python```  ( In my opinion )

# Before Pic :
![1](https://user-images.githubusercontent.com/61817579/147540413-7a5a1ac8-34d1-488d-bddf-8b302736fccb.png)

# After Pic:
![2](https://user-images.githubusercontent.com/61817579/147540437-533d7f61-6417-4c4a-a114-0e6bb849afef.PNG)


### This pull request will essentially lint the README code-block a little better