### PR TITLE
Remove X-XSS-Protection suggestion

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -173,18 +173,6 @@ invisibly to clicks on your page's elements. This is also known as
 
 - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
 
-X-XSS-Protection
-~~~~~~~~~~~~~~~~
-
-The browser will try to prevent reflected XSS attacks by not loading the page
-if the request contains something that looks like JavaScript and the response
-contains the same data. ::
-
-    response.headers['X-XSS-Protection'] = '1; mode=block'
-
-- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
-
-
 .. _security-cookie:
 
 Set-Cookie options


### PR DESCRIPTION
According to [caniuse.com](https://caniuse.com/?search=X-XSS-Protection), this header is not supported by all major browsers except Safari and MDN includes this warning in their [documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection):

> Warning: Even though this feature can protect users of older web browsers that don't yet support CSP, in some cases, XSS protection can create XSS vulnerabilities in otherwise safe websites. See the section below for more information. 

This pull request addresses #4392 

