### PR TITLE
Add no_auto_head option in app route decorator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,10 @@ Unreleased
     or ``AppContext.g`` instead. :issue:`3898`
 -   ``copy_current_request_context`` can decorate async functions.
     :pr:`4303`
+-   ``no_auto_head`` keyword argument added to ```app.route``` decorator
+    to optionally prevent Werkzeug from automatically adding a HEAD method
+    to a route that only has a GET method specified, allowing the user to
+    implement their own logic to handle HEAD requests. :pr:`4407`
 
 
 Version 2.0.3

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -697,7 +697,7 @@ instead of the `view_func` parameter.
                 of methods this rule should be limited to (``GET``, ``POST``
                 etc.).  By default a rule just listens for ``GET`` (and
                 implicitly ``HEAD``, although this can be disabled with the
-                keyword argument ```no_auto_head=True```).  Starting with
+                keyword argument ``no_auto_head=True``).  Starting with
                 Flask 0.6, ``OPTIONS`` is implicitly added and handled by
                 the standard request handling.  They have to be specified
                 as keyword arguments.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -696,9 +696,11 @@ instead of the `view_func` parameter.
                 Werkzeug is handling of method options.  methods is a list
                 of methods this rule should be limited to (``GET``, ``POST``
                 etc.).  By default a rule just listens for ``GET`` (and
-                implicitly ``HEAD``).  Starting with Flask 0.6, ``OPTIONS`` is
-                implicitly added and handled by the standard request
-                handling.  They have to be specified as keyword arguments.
+                implicitly ``HEAD``, although this can be disabled with the
+                keyword argument ```no_auto_head=True```).  Starting with
+                Flask 0.6, ``OPTIONS`` is implicitly added and handled by
+                the standard request handling.  They have to be specified
+                as keyword arguments.
 =============== ==========================================================
 
 

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1088,7 +1088,7 @@ class Flask(Scaffold):
         # own handling for HEAD.
         only_get = methods == {"GET", "OPTIONS"}
 
-        if only_get and no_auto_head is not None:
+        if only_get and no_auto_head is True:
             rule.methods.discard("HEAD")  # type: ignore
 
         self.url_map.add(rule)

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1083,9 +1083,10 @@ class Flask(Scaffold):
         rule = self.url_rule_class(rule, methods=methods, **options)
         rule.provide_automatic_options = provide_automatic_options  # type: ignore
 
-        # If GET is only specified method, Werkzeug automatically adds HEAD method.
-        # This option will disable that feature to allow the user to write their
-        # own handling for HEAD.
+        # When GET is only specified method, Werkzeug automatically adds HEAD method.
+        # If GET is the only user-specified method and the ``no_auto_head`` option
+        # is to True, this will disable that feature to allow the user to write their
+        # own handling for HEAD requests.
         only_get = methods == {"GET", "OPTIONS"}
 
         if only_get and no_auto_head is True:

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1089,7 +1089,7 @@ class Flask(Scaffold):
         only_get = methods == {"GET", "OPTIONS"}
 
         if only_get and no_auto_head is not None:
-            rule.methods.discard("HEAD")
+            rule.methods.discard("HEAD")  # type: ignore
 
         self.url_map.add(rule)
         if view_func is not None:

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1046,6 +1046,7 @@ class Flask(Scaffold):
             endpoint = _endpoint_from_view_func(view_func)  # type: ignore
         options["endpoint"] = endpoint
         methods = options.pop("methods", None)
+        no_auto_head = options.pop("no_auto_head", None)
 
         # if the methods are not given and the view_func object knows its
         # methods we can use that instead.  If neither exists, we go with
@@ -1081,6 +1082,14 @@ class Flask(Scaffold):
 
         rule = self.url_rule_class(rule, methods=methods, **options)
         rule.provide_automatic_options = provide_automatic_options  # type: ignore
+
+        # If GET is only specified method, Werkzeug automatically adds HEAD method.
+        # This option will disable that feature to allow the user to write their
+        # own handling for HEAD.
+        only_get = methods == {"GET", "OPTIONS"}
+
+        if only_get and no_auto_head is not None:
+            rule.methods.discard("HEAD")
 
         self.url_map.add(rule)
         if view_func is not None:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -2024,3 +2024,16 @@ def test_app_freed_on_zero_refcount():
         assert weak() is None
     finally:
         gc.enable()
+
+
+def test_no_auto_head_option(app, client):
+    @app.route("/", methods=["GET"], no_auto_head=True)
+    def index():
+        return "Hello world", 200
+
+    @app.route("/", methods=["HEAD"])
+    def index_head():
+        return "", 200, {"test-header": "test-value"}
+
+    assert client.get("/").data == b"Hello world"
+    assert "test-header" in client.head("/").headers

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -2035,5 +2035,10 @@ def test_no_auto_head_option(app, client):
     def index_head():
         return "", 200, {"test-header": "test-value"}
 
-    assert client.get("/").data == b"Hello world"
-    assert "test-header" in client.head("/").headers
+    rv = client.get("/")
+    assert rv.data == b"Hello world"
+    assert "test-header" not in rv.headers
+
+    rv = client.head("/")
+    assert rv.data == b""
+    assert "test-header" in rv.headers


### PR DESCRIPTION
Fixes #4395 

Adds ```no_auto_head``` as an optional keyword argument to the app route decorator to optionally prevent Werkzeug from automatically adding a HEAD method to a route that only has a GET method specified. This flexibility will allow the user to implement their own logic to handle HEAD requests separately, thus addressing the issue described in #4395.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
