### PR TITLE
remove deprecated as_tuple parameter from test_client

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ Unreleased
         instead.
     -   The same blueprint cannot be registered with the same name. Use
         ``name=`` when registering to specify a unique name.
+    -   The test client's ``as_tuple`` parameter is removed. Use
+        ``response.request.environ`` instead. :pr:`4417`
 
 -   Some parameters in ``send_file`` and ``send_from_directory`` were
     renamed in 2.0. The deprecation period for the old names is extended

--- a/src/flask/testing.py
+++ b/src/flask/testing.py
@@ -179,8 +179,6 @@ class FlaskClient(Client):
         follow_redirects: bool = False,
         **kwargs: t.Any,
     ) -> "TestResponse":
-        as_tuple = kwargs.pop("as_tuple", None)
-
         # Same logic as super.open, but apply environ_base and preserve_context.
         request = None
 
@@ -215,28 +213,11 @@ class FlaskClient(Client):
             finally:
                 builder.close()
 
-        if as_tuple is not None:
-            import warnings
-
-            warnings.warn(
-                "'as_tuple' is deprecated and will be removed in"
-                " Werkzeug 2.1 and Flask 2.1. Use"
-                " 'response.request.environ' instead.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-            return super().open(
-                request,
-                as_tuple=as_tuple,
-                buffered=buffered,
-                follow_redirects=follow_redirects,
-            )
-        else:
-            return super().open(
-                request,
-                buffered=buffered,
-                follow_redirects=follow_redirects,
-            )
+        return super().open(
+            request,
+            buffered=buffered,
+            follow_redirects=follow_redirects,
+        )
 
     def __enter__(self) -> "FlaskClient":
         if self.preserve_context:


### PR DESCRIPTION
This was deprecated in Werkzeug 2.0, and is no longer supported in Werkzeug 2.1 or Flask 2.1.