### PR TITLE
overriding FlaskClient.open works with redirects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,8 @@ Unreleased
     :pr:`4303`
 -   The CLI uses ``importlib.metadata`` instead of ``setuptools`` to
     load command entry points. :issue:`4419`
+-   Overriding ``FlaskClient.open`` will not cause an error on redirect.
+    :issue:`3396`
 
 
 Version 2.0.3

--- a/src/flask/testing.py
+++ b/src/flask/testing.py
@@ -172,6 +172,22 @@ class FlaskClient(Client):
             headers = resp.get_wsgi_headers(c.request.environ)
             self.cookie_jar.extract_wsgi(c.request.environ, headers)
 
+    def _copy_environ(self, other):
+        return {
+            **self.environ_base,
+            **other,
+            "flask._preserve_context": self.preserve_context,
+        }
+
+    def _request_from_builder_args(self, args, kwargs):
+        kwargs["environ_base"] = self._copy_environ(kwargs.get("environ_base", {}))
+        builder = EnvironBuilder(self.application, *args, **kwargs)
+
+        try:
+            return builder.get_request()
+        finally:
+            builder.close()
+
     def open(
         self,
         *args: t.Any,
@@ -179,39 +195,24 @@ class FlaskClient(Client):
         follow_redirects: bool = False,
         **kwargs: t.Any,
     ) -> "TestResponse":
-        # Same logic as super.open, but apply environ_base and preserve_context.
-        request = None
-
-        def copy_environ(other):
-            return {
-                **self.environ_base,
-                **other,
-                "flask._preserve_context": self.preserve_context,
-            }
-
-        if not kwargs and len(args) == 1:
-            arg = args[0]
-
-            if isinstance(arg, werkzeug.test.EnvironBuilder):
-                builder = copy(arg)
-                builder.environ_base = copy_environ(builder.environ_base or {})
+        if args and isinstance(
+            args[0], (werkzeug.test.EnvironBuilder, dict, BaseRequest)
+        ):
+            if isinstance(args[0], werkzeug.test.EnvironBuilder):
+                builder = copy(args[0])
+                builder.environ_base = self._copy_environ(builder.environ_base or {})
                 request = builder.get_request()
-            elif isinstance(arg, dict):
+            elif isinstance(args[0], dict):
                 request = EnvironBuilder.from_environ(
-                    arg, app=self.application, environ_base=copy_environ({})
+                    args[0], app=self.application, environ_base=self._copy_environ({})
                 ).get_request()
-            elif isinstance(arg, BaseRequest):
-                request = copy(arg)
-                request.environ = copy_environ(request.environ)
-
-        if request is None:
-            kwargs["environ_base"] = copy_environ(kwargs.get("environ_base", {}))
-            builder = EnvironBuilder(self.application, *args, **kwargs)
-
-            try:
-                request = builder.get_request()
-            finally:
-                builder.close()
+            else:
+                # isinstance(args[0], BaseRequest)
+                request = copy(args[0])
+                request.environ = self._copy_environ(request.environ)
+        else:
+            # request is None
+            request = self._request_from_builder_args(args, kwargs)
 
         return super().open(
             request,


### PR DESCRIPTION
If the first argument to `open` is an existing request/environ/builder, other args and kwargs are ignored instead of raising an error. An existing request already preserves headers, etc., as that's how redirects work, so the other args shouldn't need to be included to build the redirect request.

closes #3396 

I'd like to work on the design of this API more in the future. I don't like that there can be four different things passed as the first argument. It might be better to have a way to re-init or otherwise merge a base env with an existing request. I'd like to see how much can be moved back to the Werkzeug base class.