### PR TITLE
rewrite testing docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -168,9 +168,9 @@ thing, like it does for :class:`request` and :class:`session`.
     :attr:`Flask.app_ctx_globals_class`, which defaults to
     :class:`ctx._AppCtxGlobals`.
 
-    This is a good place to store resources during a request. During
-    testing, you can use the :ref:`faking-resources` pattern to
-    pre-configure such resources.
+    This is a good place to store resources during a request. For
+    example, a ``before_request`` function could load a user object from
+    a session id, then set ``g.user`` to be used in the view function.
 
     This is a proxy. See :ref:`notes-on-proxies` for more information.
 


### PR DESCRIPTION
Instead of showing tests for the tutorial application, since that's already described in detail during the tutorial, show off the different concepts used to test requests, CLI commands, and functions that use the context.

closes #3545