### PR TITLE
lazy loading preserves click context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,9 @@ Unreleased
 -   Add an ``--exclude-patterns`` option to the ``flask run`` CLI
     command to specify patterns that will be ignored by the reloader.
     :issue:`4188`
+-   When using lazy loading (the default with the debugger), the Click
+    context from the ``flask run`` command remains available in the
+    loader thread. :issue:`4460`
 
 
 Version 2.0.3

--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -301,9 +301,17 @@ class DispatchingApp:
             self._load_in_background()
 
     def _load_in_background(self):
+        # Store the Click context and push it in the loader thread so
+        # script_info is still available.
+        ctx = click.get_current_context(silent=True)
+
         def _load_app():
             __traceback_hide__ = True  # noqa: F841
+
             with self._lock:
+                if ctx is not None:
+                    click.globals.push_context(ctx)
+
                 try:
                     self._load_unlocked()
                 except Exception as e:


### PR DESCRIPTION
When using lazy loading, which is the default when using the reloader, the app factory is called in a separate thread. Since the Click context is thread local, `click.get_current_context()` returns `None`. While the context shouldn't be relied on since it will never be available in production, this at least keeps it available consistently within the `flask` command.

closes #4460 