### PR TITLE
Allow loading of environment variables into the config

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,10 @@ Unreleased
 -   From Werkzeug, for redirect responses the ``Location`` header URL
     will remain relative, and exclude the scheme and domain, by default.
     :pr:`4496`
+-   Add ``Config.from_prefixed_env()`` to load config values from
+    environment variables that start with ``FLASK_`` or another prefix.
+    This parses values as JSON by default, and allows setting keys in
+    nested dicts. :pr:`4479`
 
 
 Version 2.0.3

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -594,9 +594,12 @@ exist on the parent dict will be initialized to an empty dict.
 
     app.config["MYAPI"]["credentials"]["username"]  # Is "user123"
 
-For even more config loading features, including merging, try a
-dedicated library such as Dynaconf_, which includes integration with
-Flask.
+On Windows, environment variable keys are always uppercase, therefore
+the above example would end up as ``MYAPI__CREDENTIALS__USERNAME``.
+
+For even more config loading features, including merging and
+case-insensitive Windows support, try a dedicated library such as
+Dynaconf_, which includes integration with Flask.
 
 .. _Dynaconf: https://www.dynaconf.com/
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -521,7 +521,8 @@ configuration values directly from the environment. Flask can be
 instructed to load all environment variables starting with a specific
 prefix into the config using :meth:`~flask.Config.from_prefixed_env`.
 
-Environment variables can be set in the shell before starting the server:
+Environment variables can be set in the shell before starting the
+server:
 
 .. tabs::
 
@@ -561,30 +562,43 @@ Environment variables can be set in the shell before starting the server:
          > flask run
           * Running on http://127.0.0.1:5000/
 
-The variables can then be loaded and accessed via the config with a
-key equal to the environment variable name without the prefix i.e.
+The variables can then be loaded and accessed via the config with a key
+equal to the environment variable name without the prefix i.e.
 
 .. code-block:: python
 
     app.config.from_prefixed_env()
     app.config["SECRET_KEY"]  # Is "5f352379324c22463451387a0aec5d2f"
 
-The prefix is ``FLASK_`` by default, however it is an configurable via
-the ``prefix`` argument of :meth:`~flask.Config.from_prefixed_env`.
+The prefix is ``FLASK_`` by default. This is configurable via the
+``prefix`` argument of :meth:`~flask.Config.from_prefixed_env`.
 
-Whilst the value of any environment variable is a string, it will be
-parsed before being placed into the flask config. By default the
-parsing is done by json.loads, however this is configurable via the
-``loads`` argument of :meth:`~flask.Config.from_prefixed_env`.
+Values will be parsed to attempt to convert them to a more specific type
+than strings. By default :func:`json.loads` is used, so any valid JSON
+value is possible, including lists and dicts. This is configurable via
+the ``loads`` argument of :meth:`~flask.Config.from_prefixed_env`.
 
-Notice that any value besides an empty string will be interpreted as a boolean
-``True`` value in Python, which requires care if an environment explicitly sets
-values intended to be ``False``.
+When adding a boolean value with the default JSON parsing, only "true"
+and "false", lowercase, are valid values. Keep in mind that any
+non-empty string is considered ``True`` by Python.
 
-Make sure to load the configuration very early on, so that extensions have the
-ability to access the configuration when starting up.  There are other methods
-on the config object as well to load from individual files.  For a complete
-reference, read the :class:`~flask.Config` class documentation.
+It is possible to set keys in nested dictionaries by separating the
+keys with double underscore (``__``). Any intermediate keys that don't
+exist on the parent dict will be initialized to an empty dict.
+
+.. code-block:: text
+
+    $ export FLASK_MYAPI__credentials__username=user123
+
+.. code-block:: python
+
+    app.config["MYAPI"]["credentials"]["username"]  # Is "user123"
+
+For even more config loading features, including merging, try a
+dedicated library such as Dynaconf_, which includes integration with
+Flask.
+
+.. _Dynaconf: https://www.dynaconf.com/
 
 
 Configuration Best Practices
@@ -603,6 +617,10 @@ that experience:
 2.  Do not write code that needs the configuration at import time.  If you
     limit yourself to request-only accesses to the configuration you can
     reconfigure the object later on as needed.
+
+3.  Make sure to load the configuration very early on, so that
+    extensions can access the configuration when calling ``init_app``.
+
 
 .. _config-dev-prod:
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -515,9 +515,11 @@ Or from a JSON file:
 Configuring from Environment Variables
 --------------------------------------
 
-In addition to pointing to configuration files using environment variables, you
-may find it useful (or necessary) to control your configuration values directly
-from the environment.
+In addition to pointing to configuration files using environment
+variables, you may find it useful (or necessary) to control your
+configuration values directly from the environment. Flask can be
+instructed to load all environment variables starting with a specific
+prefix into the config using :meth:`~flask.Config.from_prefixed_env`.
 
 Environment variables can be set in the shell before starting the server:
 
@@ -527,8 +529,8 @@ Environment variables can be set in the shell before starting the server:
 
       .. code-block:: text
 
-         $ export SECRET_KEY="5f352379324c22463451387a0aec5d2f"
-         $ export MAIL_ENABLED=false
+         $ export FLASK_SECRET_KEY="5f352379324c22463451387a0aec5d2f"
+         $ export FLASK_MAIL_ENABLED=false
          $ flask run
           * Running on http://127.0.0.1:5000/
 
@@ -536,8 +538,8 @@ Environment variables can be set in the shell before starting the server:
 
       .. code-block:: text
 
-         $ set -x SECRET_KEY "5f352379324c22463451387a0aec5d2f"
-         $ set -x MAIL_ENABLED false
+         $ set -x FLASK_SECRET_KEY "5f352379324c22463451387a0aec5d2f"
+         $ set -x FLASK_MAIL_ENABLED false
          $ flask run
           * Running on http://127.0.0.1:5000/
 
@@ -545,8 +547,8 @@ Environment variables can be set in the shell before starting the server:
 
       .. code-block:: text
 
-         > set SECRET_KEY="5f352379324c22463451387a0aec5d2f"
-         > set MAIL_ENABLED=false
+         > set FLASK_SECRET_KEY="5f352379324c22463451387a0aec5d2f"
+         > set FLASK_MAIL_ENABLED=false
          > flask run
           * Running on http://127.0.0.1:5000/
 
@@ -554,27 +556,26 @@ Environment variables can be set in the shell before starting the server:
 
       .. code-block:: text
 
-         > $env:SECRET_KEY = "5f352379324c22463451387a0aec5d2f"
-         > $env:MAIL_ENABLED = "false"
+         > $env:FLASK_SECRET_KEY = "5f352379324c22463451387a0aec5d2f"
+         > $env:FLASK_MAIL_ENABLED = "false"
          > flask run
           * Running on http://127.0.0.1:5000/
 
-While this approach is straightforward to use, it is important to remember that
-environment variables are strings -- they are not automatically deserialized
-into Python types.
+The variables can then be loaded and accessed via the config with a
+key equal to the environment variable name without the prefix i.e.
 
-Here is an example of a configuration file that uses environment variables::
+.. code-block:: python
 
-    import os
+    app.config.from_prefixed_env()
+    app.config["SECRET_KEY"]  # Is "5f352379324c22463451387a0aec5d2f"
 
-    _mail_enabled = os.environ.get("MAIL_ENABLED", default="true")
-    MAIL_ENABLED = _mail_enabled.lower() in {"1", "t", "true"}
+The prefix is ``FLASK_`` by default, however it is an configurable via
+the ``prefix`` argument of :meth:`~flask.Config.from_prefixed_env`.
 
-    SECRET_KEY = os.environ.get("SECRET_KEY")
-
-    if not SECRET_KEY:
-        raise ValueError("No SECRET_KEY set for Flask application")
-
+Whilst the value of any environment variable is a string, it will be
+parsed before being placed into the flask config. By default the
+parsing is done by json.loads, however this is configurable via the
+``loads`` argument of :meth:`~flask.Config.from_prefixed_env`.
 
 Notice that any value besides an empty string will be interpreted as a boolean
 ``True`` value in Python, which requires care if an environment explicitly sets

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,6 +38,30 @@ def test_config_from_file():
     common_object_test(app)
 
 
+def test_config_from_prefixed_env(monkeypatch):
+    app = flask.Flask(__name__)
+    monkeypatch.setenv("FLASK_A", "A value")
+    monkeypatch.setenv("FLASK_B", "true")
+    monkeypatch.setenv("FLASK_C", "1")
+    monkeypatch.setenv("FLASK_D", "1.2")
+    monkeypatch.setenv("NOT_FLASK_A", "Another value")
+    app.config.from_prefixed_env()
+    assert app.config["A"] == "A value"
+    assert app.config["B"] is True
+    assert app.config["C"] == 1
+    assert app.config["D"] == 1.2
+    assert "Another value" not in app.config.items()
+
+
+def test_config_from_custom_prefixed_env(monkeypatch):
+    app = flask.Flask(__name__)
+    monkeypatch.setenv("FLASK_A", "A value")
+    monkeypatch.setenv("NOT_FLASK_A", "Another value")
+    app.config.from_prefixed_env("NOT_FLASK_")
+    assert app.config["A"] == "Another value"
+    assert "A value" not in app.config.items()
+
+
 def test_config_from_mapping():
     app = flask.Flask(__name__)
     app.config.from_mapping({"SECRET_KEY": "config", "TEST_KEY": "foo"})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -79,12 +79,24 @@ def test_from_prefixed_env_nested(monkeypatch):
     app.config["EXIST"] = {"ok": "value", "flag": True, "inner": {"ik": 1}}
     app.config.from_prefixed_env()
 
-    assert app.config["EXIST"] == {
-        "ok": "other",
-        "flag": True,
-        "inner": {"ik": 2},
-        "new": {"more": {"k": False}},
-    }
+    if os.name != "nt":
+        assert app.config["EXIST"] == {
+            "ok": "other",
+            "flag": True,
+            "inner": {"ik": 2},
+            "new": {"more": {"k": False}},
+        }
+    else:
+        # Windows env var keys are always uppercase.
+        assert app.config["EXIST"] == {
+            "ok": "value",
+            "OK": "other",
+            "flag": True,
+            "inner": {"ik": 1},
+            "INNER": {"IK": 2},
+            "NEW": {"MORE": {"k": False}},
+        }
+
     assert app.config["NEW"] == {"K": "v"}
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,28 +38,54 @@ def test_config_from_file():
     common_object_test(app)
 
 
-def test_config_from_prefixed_env(monkeypatch):
+def test_from_prefixed_env(monkeypatch):
+    monkeypatch.setenv("FLASK_STRING", "value")
+    monkeypatch.setenv("FLASK_BOOL", "true")
+    monkeypatch.setenv("FLASK_INT", "1")
+    monkeypatch.setenv("FLASK_FLOAT", "1.2")
+    monkeypatch.setenv("FLASK_LIST", "[1, 2]")
+    monkeypatch.setenv("FLASK_DICT", '{"k": "v"}')
+    monkeypatch.setenv("NOT_FLASK_OTHER", "other")
+
     app = flask.Flask(__name__)
-    monkeypatch.setenv("FLASK_A", "A value")
-    monkeypatch.setenv("FLASK_B", "true")
-    monkeypatch.setenv("FLASK_C", "1")
-    monkeypatch.setenv("FLASK_D", "1.2")
-    monkeypatch.setenv("NOT_FLASK_A", "Another value")
     app.config.from_prefixed_env()
-    assert app.config["A"] == "A value"
-    assert app.config["B"] is True
-    assert app.config["C"] == 1
-    assert app.config["D"] == 1.2
-    assert "Another value" not in app.config.items()
+
+    assert app.config["STRING"] == "value"
+    assert app.config["BOOL"] is True
+    assert app.config["INT"] == 1
+    assert app.config["FLOAT"] == 1.2
+    assert app.config["LIST"] == [1, 2]
+    assert app.config["DICT"] == {"k": "v"}
+    assert "OTHER" not in app.config
 
 
-def test_config_from_custom_prefixed_env(monkeypatch):
+def test_from_prefixed_env_custom_prefix(monkeypatch):
+    monkeypatch.setenv("FLASK_A", "a")
+    monkeypatch.setenv("NOT_FLASK_A", "b")
+
     app = flask.Flask(__name__)
-    monkeypatch.setenv("FLASK_A", "A value")
-    monkeypatch.setenv("NOT_FLASK_A", "Another value")
-    app.config.from_prefixed_env("NOT_FLASK_")
-    assert app.config["A"] == "Another value"
-    assert "A value" not in app.config.items()
+    app.config.from_prefixed_env("NOT_FLASK")
+
+    assert app.config["A"] == "b"
+
+
+def test_from_prefixed_env_nested(monkeypatch):
+    monkeypatch.setenv("FLASK_EXIST__ok", "other")
+    monkeypatch.setenv("FLASK_EXIST__inner__ik", "2")
+    monkeypatch.setenv("FLASK_EXIST__new__more", '{"k": false}')
+    monkeypatch.setenv("FLASK_NEW__K", "v")
+
+    app = flask.Flask(__name__)
+    app.config["EXIST"] = {"ok": "value", "flag": True, "inner": {"ik": 1}}
+    app.config.from_prefixed_env()
+
+    assert app.config["EXIST"] == {
+        "ok": "other",
+        "flag": True,
+        "inner": {"ik": 2},
+        "new": {"more": {"k": False}},
+    }
+    assert app.config["NEW"] == {"K": "v"}
 
 
 def test_config_from_mapping():


### PR DESCRIPTION
This new method will pick out any environment variables with a certain
prefix and place them into the config named without the prefix. This
makes it easy to use environment variables to configure the app as is
now more popular than when Flask started.

The prefix should ensure that the environment isn't polluted and the
config isn't polluted by environment variables.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
