### PR TITLE
Preserve HttpOnly flag when deleting session cookie

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,8 @@ Unreleased
 -   When using lazy loading (the default with the debugger), the Click
     context from the ``flask run`` command remains available in the
     loader thread. :issue:`4460`
+-   Deleting the session cookie uses the ``httponly`` flag.
+    :issue:`4485`
 
 
 Version 2.0.3

--- a/src/flask/sessions.py
+++ b/src/flask/sessions.py
@@ -383,13 +383,19 @@ class SecureCookieSessionInterface(SessionInterface):
         path = self.get_cookie_path(app)
         secure = self.get_cookie_secure(app)
         samesite = self.get_cookie_samesite(app)
+        httponly = self.get_cookie_httponly(app)
 
         # If the session is modified to be empty, remove the cookie.
         # If the session is empty, return without setting the cookie.
         if not session:
             if session.modified:
                 response.delete_cookie(
-                    name, domain=domain, path=path, secure=secure, samesite=samesite
+                    name,
+                    domain=domain,
+                    path=path,
+                    secure=secure,
+                    samesite=samesite,
+                    httponly=httponly,
                 )
 
             return
@@ -401,7 +407,6 @@ class SecureCookieSessionInterface(SessionInterface):
         if not self.should_set_cookie(app, session):
             return
 
-        httponly = self.get_cookie_httponly(app)
         expires = self.get_expiration_time(app, session)
         val = self.get_signing_serializer(app).dumps(dict(session))  # type: ignore
         response.set_cookie(


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

When the session modified such that it ends up empty, the session cookie is deleted by sending an expired cookie. This 'deletion cookie' is missing the HttpOnly flag. 


- fixes #4485

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [n/a] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [n/a] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
