### PR TITLE
relax `errorhandler` function arg type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,9 @@ Unreleased
     loader thread. :issue:`4460`
 -   Deleting the session cookie uses the ``httponly`` flag.
     :issue:`4485`
+-   Relax typing for ``errorhandler`` to allow the user to use more
+    precise types and decorate the same function multiple times.
+    :issue:`4095, 4295, 4297`
 
 
 Version 2.0.3

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1672,13 +1672,13 @@ class Flask(Scaffold):
 
             # a 3-tuple is unpacked directly
             if len_rv == 3:
-                rv, status, headers = rv
+                rv, status, headers = rv  # type: ignore[misc]
             # decide if a 2-tuple has status or headers
             elif len_rv == 2:
                 if isinstance(rv[1], (Headers, dict, tuple, list)):
                     rv, headers = rv
                 else:
-                    rv, status = rv
+                    rv, status = rv  # type: ignore[misc]
             # other sized tuples are not allowed
             else:
                 raise TypeError(
@@ -1701,7 +1701,11 @@ class Flask(Scaffold):
                 # let the response class set the status and headers instead of
                 # waiting to do it manually, so that the class can handle any
                 # special logic
-                rv = self.response_class(rv, status=status, headers=headers)
+                rv = self.response_class(
+                    rv,
+                    status=status,
+                    headers=headers,  # type: ignore[arg-type]
+                )
                 status = headers = None
             elif isinstance(rv, dict):
                 rv = jsonify(rv)
@@ -1729,13 +1733,13 @@ class Flask(Scaffold):
         # prefer the status if it was provided
         if status is not None:
             if isinstance(status, (str, bytes, bytearray)):
-                rv.status = status  # type: ignore
+                rv.status = status
             else:
                 rv.status_code = status
 
         # extend existing headers with provided headers
         if headers:
-            rv.headers.update(headers)
+            rv.headers.update(headers)  # type: ignore[arg-type]
 
         return rv
 

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1265,9 +1265,7 @@ class Flask(Scaffold):
         self.shell_context_processors.append(f)
         return f
 
-    def _find_error_handler(
-        self, e: Exception
-    ) -> t.Optional["ErrorHandlerCallable[Exception]"]:
+    def _find_error_handler(self, e: Exception) -> t.Optional["ErrorHandlerCallable"]:
         """Return a registered error handler for an exception in this order:
         blueprint handler for a specific code, app handler for a specific code,
         blueprint handler for an exception class, app handler for an exception

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -574,9 +574,7 @@ class Blueprint(Scaffold):
         handler is used for all requests, even if outside of the blueprint.
         """
 
-        def decorator(
-            f: "ErrorHandlerCallable[Exception]",
-        ) -> "ErrorHandlerCallable[Exception]":
+        def decorator(f: "ErrorHandlerCallable") -> "ErrorHandlerCallable":
             self.record_once(lambda s: s.app.errorhandler(code)(f))
             return f
 

--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -186,7 +186,7 @@ def make_response(*args: t.Any) -> "Response":
         return current_app.response_class()
     if len(args) == 1:
         args = args[0]
-    return current_app.make_response(args)
+    return current_app.make_response(args)  # type: ignore
 
 
 def url_for(endpoint: str, **values: t.Any) -> str:

--- a/src/flask/typing.py
+++ b/src/flask/typing.py
@@ -33,8 +33,6 @@ ResponseReturnValue = t.Union[
     "WSGIApplication",
 ]
 
-GenericException = t.TypeVar("GenericException", bound=Exception, contravariant=True)
-
 AppOrBlueprintKey = t.Optional[str]  # The App key is None, whereas blueprints are named
 AfterRequestCallable = t.Callable[["Response"], "Response"]
 BeforeFirstRequestCallable = t.Callable[[], None]
@@ -46,4 +44,10 @@ TemplateGlobalCallable = t.Callable[..., t.Any]
 TemplateTestCallable = t.Callable[..., bool]
 URLDefaultCallable = t.Callable[[str, dict], None]
 URLValuePreprocessorCallable = t.Callable[[t.Optional[str], t.Optional[dict]], None]
-ErrorHandlerCallable = t.Callable[[GenericException], ResponseReturnValue]
+# This should take Exception, but that either breaks typing the argument
+# with a specific exception, or decorating multiple times with different
+# exceptions (and using a union type on the argument).
+# https://github.com/pallets/flask/issues/4095
+# https://github.com/pallets/flask/issues/4295
+# https://github.com/pallets/flask/issues/4297
+ErrorHandlerCallable = t.Callable[[t.Any], ResponseReturnValue]

--- a/src/flask/typing.py
+++ b/src/flask/typing.py
@@ -4,14 +4,16 @@ import typing as t
 if t.TYPE_CHECKING:
     from _typeshed.wsgi import WSGIApplication  # noqa: F401
     from werkzeug.datastructures import Headers  # noqa: F401
-    from .wrappers import Response  # noqa: F401
+    from werkzeug.wrappers.response import Response  # noqa: F401
 
 # The possible types that are directly convertible or are a Response object.
 ResponseValue = t.Union[
     "Response",
-    t.AnyStr,
+    str,
+    bytes,
     t.Dict[str, t.Any],  # any jsonify-able dict
-    t.Generator[t.AnyStr, None, None],
+    t.Iterator[str],
+    t.Iterator[bytes],
 ]
 StatusCode = int
 


### PR DESCRIPTION
The `errorhandler` decorator should decorate a callable that takes a `BaseException` argument. However, it doesn't appear possible to type this correctly while accounting for different ways that the decorator is used.

#4095 reported that it wasn't possible to type the function argument to match the decorator argument, and fixed it by using a `contravariant` `TypeVar` to represent a generic `Exception`. #4295 reported that the fix broke for some cases that did match, and fixed it by removing the `Protocol` in favor of a basic `Callable` type. However, neither of these could actually ensure that the exception used in the decorator was the same used in the argument type.

#4297 reported that it wasn't possible to decorate a function multiple times to handle different exceptions. Going back to `BaseException` instead of `GenericException` fixed that, but broke the other two issues again. And it still wasn't possible to type correctly, since the argument was actually a union, not a single exception.

Given all this, I made the callable take `Any` instead. At the expense of not actually ensuring that the user gave the argument an `Exception` type, it allows them to decorate multiple times and to use a specific type or union of types on the function argument.

I also noticed that mypy's output of `ResponseValue` said `Any` instead of `AnyStr`, so I replaced it with `str, bytes`. It would be nice if this output was configurable, since `ResponseValue` is so complex it makes it unreadable.