### PR TITLE
accurate type for `__exit__`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,8 @@ Unreleased
 -   Relax typing for ``errorhandler`` to allow the user to use more
     precise types and decorate the same function multiple times.
     :issue:`4095, 4295, 4297`
+-   Fix typing for ``__exit__`` methods for better compatibility with
+    ``ExitStack``. :issue:`4474`
 
 
 Version 2.0.3

--- a/src/flask/ctx.py
+++ b/src/flask/ctx.py
@@ -267,7 +267,10 @@ class AppContext:
         return self
 
     def __exit__(
-        self, exc_type: type, exc_value: BaseException, tb: TracebackType
+        self,
+        exc_type: t.Optional[type],
+        exc_value: t.Optional[BaseException],
+        tb: t.Optional[TracebackType],
     ) -> None:
         self.pop(exc_value)
 
@@ -491,7 +494,10 @@ class RequestContext:
         return self
 
     def __exit__(
-        self, exc_type: type, exc_value: BaseException, tb: TracebackType
+        self,
+        exc_type: t.Optional[type],
+        exc_value: t.Optional[BaseException],
+        tb: t.Optional[TracebackType],
     ) -> None:
         # do not pop the request stack if we are in debug mode and an
         # exception happened.  This will allow the debugger to still

--- a/src/flask/testing.py
+++ b/src/flask/testing.py
@@ -227,7 +227,10 @@ class FlaskClient(Client):
         return self
 
     def __exit__(
-        self, exc_type: type, exc_value: BaseException, tb: TracebackType
+        self,
+        exc_type: t.Optional[type],
+        exc_value: t.Optional[BaseException],
+        tb: t.Optional[TracebackType],
     ) -> None:
         self.preserve_context = False
 


### PR DESCRIPTION
Arguments to `__exit__` are optional.

fixes #4474 