### PR TITLE
update some debug message behavior

### DIFF
--- a/src/flask/debughelpers.py
+++ b/src/flask/debughelpers.py
@@ -41,35 +41,33 @@ class DebugFilesKeyError(KeyError, AssertionError):
 
 
 class FormDataRoutingRedirect(AssertionError):
-    """This exception is raised by Flask in debug mode if it detects a
-    redirect caused by the routing system when the request method is not
-    GET, HEAD or OPTIONS.  Reasoning: form data will be dropped.
+    """This exception is raised in debug mode if a routing redirect
+    would cause the browser to drop the method or body. This happens
+    when method is not GET, HEAD or OPTIONS and the status code is not
+    307 or 308.
     """
 
     def __init__(self, request):
         exc = request.routing_exception
         buf = [
-            f"A request was sent to this URL ({request.url}) but a"
-            " redirect was issued automatically by the routing system"
-            f" to {exc.new_url!r}."
+            f"A request was sent to '{request.url}', but routing issued"
+            f" a redirect to the canonical URL '{exc.new_url}'."
         ]
 
-        # In case just a slash was appended we can be extra helpful
-        if f"{request.base_url}/" == exc.new_url.split("?")[0]:
+        if f"{request.base_url}/" == exc.new_url.partition("?")[0]:
             buf.append(
-                "  The URL was defined with a trailing slash so Flask"
-                " will automatically redirect to the URL with the"
-                " trailing slash if it was accessed without one."
+                " The URL was defined with a trailing slash. Flask"
+                " will redirect to the URL with a trailing slash if it"
+                " was accessed without one."
             )
 
         buf.append(
-            "  Make sure to directly send your"
-            f" {request.method}-request to this URL since we can't make"
-            " browsers or HTTP clients redirect with form data reliably"
-            " or without user interaction."
+            " Send requests to the canonical URL, or use 307 or 308 for"
+            " routing redirects. Otherwise, browsers will drop form"
+            " data.\n\n"
+            "This exception is only raised in debug mode."
         )
-        buf.append("\n\nNote: this exception is only raised in debug mode")
-        AssertionError.__init__(self, "".join(buf).encode("utf-8"))
+        super().__init__("".join(buf))
 
 
 def attach_enctype_error_multidict(request):

--- a/src/flask/wrappers.py
+++ b/src/flask/wrappers.py
@@ -9,7 +9,6 @@ from .globals import current_app
 from .helpers import _split_blueprint_path
 
 if t.TYPE_CHECKING:
-    import typing_extensions as te
     from werkzeug.routing import Rule
 
 
@@ -124,11 +123,14 @@ class Request(RequestBase):
 
             attach_enctype_error_multidict(self)
 
-    def on_json_loading_failed(self, e: Exception) -> "te.NoReturn":
-        if current_app and current_app.debug:
-            raise BadRequest(f"Failed to decode JSON object: {e}")
+    def on_json_loading_failed(self, e: ValueError) -> t.Any:
+        try:
+            return super().on_json_loading_failed(e)
+        except BadRequest as e:
+            if current_app and current_app.debug:
+                raise
 
-        raise BadRequest()
+            raise BadRequest() from e
 
 
 class Response(ResponseBase):

--- a/src/flask/wrappers.py
+++ b/src/flask/wrappers.py
@@ -110,7 +110,7 @@ class Request(RequestBase):
         return _split_blueprint_path(name)
 
     def _load_form_data(self) -> None:
-        RequestBase._load_form_data(self)
+        super()._load_form_data()
 
         # In debug mode we're replacing the files multidict with an ad-hoc
         # subclass that raises a different error for key errors.


### PR DESCRIPTION
* Don't intercept routing redirects if the code hasn't been changed from 308 (or 307). The message about not preserving the request method and body is not relevant for the modern status code. Also edited the message a bit, although it shouldn't be seen anymore.
* When `files` raises a `DebugFilesKeyError`, it looks like the original error rather than a chained exception.
* `on_json_loading_failed` tries to return the `super()` implementation first, then reraises any error in debug mode.

I originally started working on this due to https://github.com/pallets/werkzeug/pull/2355, because I thought it might be better to not suppress JSON errors outside debug mode. 400 errors indicate a problem with client data, so it seems ok to show what that problem was. I've stopped short of doing that for this release, but want to revisit suppressing information in 400 errors later.