### PR TITLE
Fix werkzeug updating and causing an issue with EnvironBuilder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name="Flask",
     install_requires=[
-        "Werkzeug >= 2.0",
+        "Werkzeug >= 2.0, <2.1",
         "Jinja2 >= 3.0",
         "itsdangerous >= 2.0",
         "click >= 7.1.2",


### PR DESCRIPTION
EnvironBuilder no longer accepts `as_tuple` in 2.1.0 but since we have `>= 2.0` in `install_requires`, it updates without us noticing it and builds can fail suddenly.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
