### PR TITLE
set importlib_metadata minimum version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 2.1.1
 
 Unreleased
 
+-   Set the minimum required version of importlib_metadata to 3.6.0,
+    which is required on Python < 3.10. :issue:`4502`
+
 
 Version 2.1.0
 -------------

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
         "Jinja2 >= 3.0",
         "itsdangerous >= 2.0",
         "click >= 8.0",
-        "importlib-metadata; python_version < '3.10'",
+        "importlib-metadata >= 3.6.0; python_version < '3.10'",
     ],
     extras_require={
         "async": ["asgiref >= 3.2"],


### PR DESCRIPTION
The `entry_points(group=...)` API was added in importlib_metadata 3.6.0. If a previous version was already installed, pip does not eagerly install newer versions. Set a minimum required version.

fixes #4502 