### PR TITLE
The documentation snippet in "Returning API Errors as JSON" returned unexpected status code #4524

### DIFF
--- a/docs/errorhandling.rst
+++ b/docs/errorhandling.rst
@@ -489,7 +489,7 @@ This is a simple example:
 
     @app.errorhandler(InvalidAPIUsage)
     def invalid_api_usage(e):
-        return jsonify(e.to_dict())
+        return jsonify(e.to_dict()), e.status_code
 
     # an API app route for getting user information
     # a correct request might be /api/user?user_id=420


### PR DESCRIPTION
before: code snippet would always return status code 200 (unexpected)
after: code snippet returns requested status code (expected)
