### PR TITLE
Adapted input parameters type restriction for json.loads function - fixes #4519 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 2.1.2
 
 Unreleased
 
+-   Fix type annotation for ``json.loads``, it accepts str or bytes.
+    :issue:`4519`
+
 
 Version 2.1.1
 -------------

--- a/src/flask/json/__init__.py
+++ b/src/flask/json/__init__.py
@@ -153,7 +153,11 @@ def dump(
     _json.dump(obj, fp, **kwargs)
 
 
-def loads(s: str, app: t.Optional["Flask"] = None, **kwargs: t.Any) -> t.Any:
+def loads(
+    s: t.Union[str, bytes],
+    app: t.Optional["Flask"] = None,
+    **kwargs: t.Any,
+) -> t.Any:
     """Deserialize an object from a string of JSON.
 
     Takes the same arguments as the built-in :func:`json.loads`, with


### PR DESCRIPTION
Adapted input parameters type restriction for
json.loads function. According to Python 3.6
changes, built-in :func:json.loads now accepts
bytes and bytes array as input.

- fixes #4519 

Checklist:

- [X] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [X] Add or update relevant docs, in the docs folder and in code.
- [X] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [X] Add `.. versionchanged::` entries in any relevant code docs.
- [X] Run `pre-commit` hooks and fix any issues.
- [X] Run `pytest` and `tox`, no tests failed.