### PR TITLE
update #loads param's type annotation

### DIFF
--- a/src/flask/json/__init__.py
+++ b/src/flask/json/__init__.py
@@ -153,13 +153,16 @@ def dump(
     _json.dump(obj, fp, **kwargs)
 
 
-def loads(s: str, app: t.Optional["Flask"] = None, **kwargs: t.Any) -> t.Any:
-    """Deserialize an object from a string of JSON.
+def loads(
+    s: t.Union[str, bytes, bytearray], app: t.Optional["Flask"] = None, **kwargs: t.Any
+) -> t.Any:
+    """Deserialize a string, bytes or bytearray instance containing
+    a JSON document to a Python object.
 
     Takes the same arguments as the built-in :func:`json.loads`, with
     some defaults from application configuration.
 
-    :param s: JSON string to deserialize.
+    :param s: String, bytes or bytearray instance to deserialize.
     :param app: Use this app's config instead of the active app context
         or defaults.
     :param kwargs: Extra arguments passed to :func:`json.loads`.


### PR DESCRIPTION
This PR is to improve the accuracy of the `loads` method's type annotation. [As of Python 3.6](https://docs.python.org/3/library/json.html#json.loads), it started supporting type `bytes` or `bytearray`.

- fixes [#4519](https://github.com/pallets/flask/issues/4519)

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
