### PR TITLE
Mark --cert option on run as is_eager

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 
 -   Fix type annotation for ``json.loads``, it accepts str or bytes.
     :issue:`4519`
+-   The ``--cert`` and ``--key`` options on ``flask run`` can be given
+    in either order. :issue:`4459`
 
 
 Version 2.1.1

--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -763,7 +763,10 @@ class SeparatedPathType(click.Path):
 @click.option("--host", "-h", default="127.0.0.1", help="The interface to bind to.")
 @click.option("--port", "-p", default=5000, help="The port to bind to.")
 @click.option(
-    "--cert", type=CertParamType(), help="Specify a certificate file to use HTTPS."
+    "--cert",
+    type=CertParamType(),
+    help="Specify a certificate file to use HTTPS.",
+    is_eager=True,
 )
 @click.option(
     "--key",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -553,7 +553,12 @@ def test_run_cert_path():
     with pytest.raises(click.BadParameter):
         run_command.make_context("run", ["--key", __file__])
 
+    # cert specified first
     ctx = run_command.make_context("run", ["--cert", __file__, "--key", __file__])
+    assert ctx.params["cert"] == (__file__, __file__)
+
+    # key specified first
+    ctx = run_command.make_context("run", ["--key", __file__, "--cert", __file__])
     assert ctx.params["cert"] == (__file__, __file__)
 
 


### PR DESCRIPTION
Added `is_eager=True` to the `--cert` option on the CLI `flask run` command so that it is evaluated before `--key`. This allows the two options to be specified in either order.

- fixes #4459

Checklist:

- [X] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [X] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [X] Run `pre-commit` hooks and fix any issues.
- [X] Run `pytest` and `tox`, no tests failed.
