### PR TITLE
clean up `pytest.raises` tests

### DIFF
--- a/tests/test_appctx.py
+++ b/tests/test_appctx.py
@@ -120,7 +120,7 @@ def test_app_tearing_down_with_unhandled_exception(app, client):
     def index():
         raise Exception("dummy")
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="dummy"):
         with app.app_context():
             client.get("/")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -305,9 +305,9 @@ def test_lazy_load_error(monkeypatch):
 
     lazy = DispatchingApp(bad_load, use_eager_loading=False)
 
-    with pytest.raises(BadExc):
-        # reduce flakiness by waiting for the internal loading lock
-        with lazy._lock:
+    # reduce flakiness by waiting for the internal loading lock
+    with lazy._lock:
+        with pytest.raises(BadExc):
             lazy._flush_bg_loading_exception()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -133,9 +133,11 @@ def test_config_from_class():
 def test_config_from_envvar(monkeypatch):
     monkeypatch.setattr("os.environ", {})
     app = flask.Flask(__name__)
+
     with pytest.raises(RuntimeError) as e:
         app.config.from_envvar("FOO_SETTINGS")
-        assert "'FOO_SETTINGS' is not set" in str(e.value)
+
+    assert "'FOO_SETTINGS' is not set" in str(e.value)
     assert not app.config.from_envvar("FOO_SETTINGS", silent=True)
 
     monkeypatch.setattr(
@@ -147,8 +149,8 @@ def test_config_from_envvar(monkeypatch):
 
 def test_config_from_envvar_missing(monkeypatch):
     monkeypatch.setattr("os.environ", {"FOO_SETTINGS": "missing.cfg"})
+    app = flask.Flask(__name__)
     with pytest.raises(IOError) as e:
-        app = flask.Flask(__name__)
         app.config.from_envvar("FOO_SETTINGS")
     msg = str(e.value)
     assert msg.startswith(


### PR DESCRIPTION
Move as much code as possible outside the `pytest.raises` block. `asserts` will only run outside the block (it exits early), and other code might raise similar exceptions to the code being tested.

closes #4553 