### PR TITLE
Add 'aborter' and 'aborter_class' attrs to 'Flask' object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Version 2.2.0
 
 Unreleased
 
+-   Add ``aborter_class`` and ``aborter`` attributes to the Flask app
+    object. ``flask.abort`` will call ``app.aborter``. This makes it
+    possible for an app to override how aborts work, including custom
+    status codes. :issue:`4567`
 -   Add an ``app.redirect`` method, which ``flask.redirect`` will call.
     This makes it possible for an app to override how redirects work.
     :issue:`4569`

--- a/src/flask/__init__.py
+++ b/src/flask/__init__.py
@@ -1,6 +1,5 @@
 from markupsafe import escape
 from markupsafe import Markup
-from werkzeug.exceptions import abort as abort
 
 from . import json as json
 from .app import Flask as Flask
@@ -18,6 +17,7 @@ from .globals import current_app as current_app
 from .globals import g as g
 from .globals import request as request
 from .globals import session as session
+from .helpers import abort as abort
 from .helpers import flash as flash
 from .helpers import get_flashed_messages as get_flashed_messages
 from .helpers import get_template_attribute as get_template_attribute

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -12,6 +12,7 @@ from types import TracebackType
 
 from werkzeug.datastructures import Headers
 from werkzeug.datastructures import ImmutableDict
+from werkzeug.exceptions import Aborter
 from werkzeug.exceptions import BadRequest
 from werkzeug.exceptions import BadRequestKeyError
 from werkzeug.exceptions import HTTPException
@@ -200,6 +201,16 @@ class Flask(Scaffold):
     #: The class that is used for response objects.  See
     #: :class:`~flask.Response` for more information.
     response_class = Response
+
+    #: The class of the object assigned to :attr:`aborter`, created by
+    #: :meth:`create_aborter`. That object is called by
+    #: :func:`flask.abort` to raise HTTP errors, and can be
+    #: called directly as well.
+    #:
+    #: Defaults to :class:`werkzeug.exceptions.Aborter`.
+    #:
+    #: .. versionadded:: 2.2
+    aborter_class = Aborter
 
     #: The class that is used for the Jinja environment.
     #:
@@ -421,6 +432,13 @@ class Flask(Scaffold):
         #: to load a config from files.
         self.config = self.make_config(instance_relative_config)
 
+        #: An instance of :attr:`aborter_class` created by
+        #: :meth:`make_aborter`. This is called by :func:`flask.abort`
+        #: to raise HTTP errors, and can be called directly as well.
+        #:
+        #: .. versionadded:: 2.2
+        self.aborter = self.make_aborter()
+
         #: A list of functions that are called when :meth:`url_for` raises a
         #: :exc:`~werkzeug.routing.BuildError`.  Each function registered here
         #: is called with `error`, `endpoint` and `values`.  If a function
@@ -627,6 +645,18 @@ class Flask(Scaffold):
         defaults["ENV"] = get_env()
         defaults["DEBUG"] = get_debug_flag()
         return self.config_class(root_path, defaults)
+
+    def make_aborter(self) -> Aborter:
+        """Create the object to assign to :attr:`aborter`. That object
+        is called by :func:`flask.abort` to raise HTTP errors, and can
+        be called directly as well.
+
+        By default, this creates an instance of :attr:`aborter_class`,
+        which defaults to :class:`werkzeug.exceptions.Aborter`.
+
+        .. versionadded:: 2.2
+        """
+        return self.aborter_class()
 
     def auto_find_instance_path(self) -> str:
         """Tries to locate the instance path if it was not provided to the


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->
* Add an `aborter_class` attribute on the `Flask` object, similar to the `config_class`
* Upon `__init__`, create an `aborter` instance of the `aborter_class`
* Rather than exposing the `werkzeug.exceptions.abort` function in `flask` directly, add an `abort` function in `flask.helpers` that calls the `aborter` instance on the `current_app`. This is equivalent to what the `werkzeug.exceptions.abort` function is doing.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #4567

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
