### PR TITLE
Tutorial Jinja fix

### DIFF
--- a/docs/tutorial/blog.rst
+++ b/docs/tutorial/blog.rst
@@ -106,7 +106,7 @@ available in the result.
               <h1>{{ post['title'] }}</h1>
               <div class="about">by {{ post['username'] }} on {{ post['created'].strftime('%Y-%m-%d') }}</div>
             </div>
-            {% if g.user['id'] == post['author_id'] %}
+            {% if g.user['id']|int() == post['author_id']|int() %}
               <a class="action" href="{{ url_for('blog.update', id=post['id']) }}">Edit</a>
             {% endif %}
           </header>
@@ -120,12 +120,15 @@ available in the result.
 
 When a user is logged in, the ``header`` block adds a link to the
 ``create`` view. When the user is the author of a post, they'll see an
-"Edit" link to the ``update`` view for that post. ``loop.last`` is a
+"Edit" link to the ``update`` view for that post. The ``|int()`` invocations
+are `Jinja filters`_ that are used to cast both operands of the comparison
+operation (``==``) to integers prior to evaluating the comparison. ``loop.last`` is a
 special variable available inside `Jinja for loops`_. It's used to
 display a line after each post except the last one, to visually separate
 them.
 
 .. _Jinja for loops: https://jinja.palletsprojects.com/templates/#for
+.. _Jinja filters: https://jinja.palletsprojects.com/en/3.1.x/templates/#filters
 
 
 Create


### PR DESCRIPTION
Fixes a comparison within one of the tutorial's Jinja2 templates.

The Jinja2 template previously compared the user id of the currently logged in user with the `author_id` of each blog post in order to determine if the logged in user had edit permissions on that blog post. However, one of `g.user['id']` and `post['author_id']` was a string and the other was an integer. This caused the equality comparison to fail in every case.

Now, a Jinja filter is used to cast each of the operands to the same type prior to the equality comparison being evaluated. 

This ensures that the "Edit" link/button now shows up when appropriate.

- fixes #4587 

This PR only touches the docs, so removing the checklist as indicated by the comment.
