### PR TITLE
Add link to additional packaging info

### DIFF
--- a/docs/tutorial/install.rst
+++ b/docs/tutorial/install.rst
@@ -67,10 +67,12 @@ This tells Python to copy everything in the ``static`` and ``templates``
 directories, and the ``schema.sql`` file, but to exclude all bytecode
 files.
 
-See the `official packaging guide`_ for another explanation of the files
+See the official `Packaging tutorial <packaging tutorial_>`_ and
+`detailed guide <packaging guide_>`_ for more explanation of the files
 and options used.
 
-.. _official packaging guide: https://packaging.python.org/tutorials/packaging-projects/
+.. _packaging tutorial: https://packaging.python.org/tutorials/packaging-projects/
+.. _packaging guide: https://packaging.python.org/guides/distributing-packages-using-setuptools/
 
 
 Install the Project


### PR DESCRIPTION
This PR adds a link to another relevant packaging guide in the "Make the Project Installable" tutorial section.

fixes #4594