### PR TITLE
find instance_path for namespace package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 -   Inline some optional imports that are only used for certain CLI
     commands. :pr:`4606`
 -   Relax type annotation for ``after_request`` functions. :issue:`4600`
+-   ``instance_path`` for namespace packages uses the path closest to
+    the imported submodule. :issue:`4600`
 
 
 Version 2.1.2

--- a/src/flask/scaffold.py
+++ b/src/flask/scaffold.py
@@ -780,30 +780,46 @@ def _matching_loader_thinks_module_is_package(loader, mod_name):
     )
 
 
-def _find_package_path(root_mod_name):
+def _find_package_path(import_name):
     """Find the path that contains the package or module."""
-    try:
-        spec = importlib.util.find_spec(root_mod_name)
+    root_mod_name, _, _ = import_name.partition(".")
 
-        if spec is None:
+    try:
+        root_spec = importlib.util.find_spec(root_mod_name)
+
+        if root_spec is None:
             raise ValueError("not found")
     # ImportError: the machinery told us it does not exist
     # ValueError:
     #    - the module name was invalid
     #    - the module name is __main__
-    #    - *we* raised `ValueError` due to `spec` being `None`
+    #    - *we* raised `ValueError` due to `root_spec` being `None`
     except (ImportError, ValueError):
         pass  # handled below
     else:
         # namespace package
-        if spec.origin in {"namespace", None}:
-            return os.path.dirname(next(iter(spec.submodule_search_locations)))
+        if root_spec.origin in {"namespace", None}:
+            package_spec = importlib.util.find_spec(import_name)
+            if package_spec is not None and package_spec.submodule_search_locations:
+                # Pick the path in the namespace that contains the submodule.
+                package_path = os.path.commonpath(
+                    package_spec.submodule_search_locations
+                )
+                search_locations = (
+                    location
+                    for location in root_spec.submodule_search_locations
+                    if package_path.startswith(location)
+                )
+            else:
+                # Pick the first path.
+                search_locations = iter(root_spec.submodule_search_locations)
+            return os.path.dirname(next(search_locations))
         # a package (with __init__.py)
-        elif spec.submodule_search_locations:
-            return os.path.dirname(os.path.dirname(spec.origin))
+        elif root_spec.submodule_search_locations:
+            return os.path.dirname(os.path.dirname(root_spec.origin))
         # just a normal module
         else:
-            return os.path.dirname(spec.origin)
+            return os.path.dirname(root_spec.origin)
 
     # we were unable to find the `package_path` using PEP 451 loaders
     loader = pkgutil.get_loader(root_mod_name)
@@ -845,8 +861,7 @@ def find_package(import_name: str):
     for import. If the package is not installed, it's assumed that the
     package was imported from the current working directory.
     """
-    root_mod_name, _, _ = import_name.partition(".")
-    package_path = _find_package_path(root_mod_name)
+    package_path = _find_package_path(import_name)
     py_prefix = os.path.abspath(sys.prefix)
 
     # installed to the system

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -1,4 +1,3 @@
-import os
 import sys
 
 import pytest
@@ -13,17 +12,6 @@ def test_explicit_instance_paths(modules_tmpdir):
 
     app = flask.Flask(__name__, instance_path=str(modules_tmpdir))
     assert app.instance_path == str(modules_tmpdir)
-
-
-def test_main_module_paths(modules_tmpdir, purge_module):
-    app = modules_tmpdir.join("main_app.py")
-    app.write('import flask\n\napp = flask.Flask("__main__")')
-    purge_module("main_app")
-
-    from main_app import app
-
-    here = os.path.abspath(os.getcwd())
-    assert app.instance_path == os.path.join(here, "instance")
 
 
 def test_uninstalled_module_paths(modules_tmpdir, purge_module):

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -15,7 +15,6 @@ def test_explicit_instance_paths(modules_tmpdir):
     assert app.instance_path == str(modules_tmpdir)
 
 
-@pytest.mark.xfail(reason="weird interaction with tox")
 def test_main_module_paths(modules_tmpdir, purge_module):
     app = modules_tmpdir.join("main_app.py")
     app.write('import flask\n\napp = flask.Flask("__main__")')
@@ -27,7 +26,6 @@ def test_main_module_paths(modules_tmpdir, purge_module):
     assert app.instance_path == os.path.join(here, "instance")
 
 
-@pytest.mark.xfail(reason="weird interaction with tox")
 def test_uninstalled_module_paths(modules_tmpdir, purge_module):
     app = modules_tmpdir.join("config_module_app.py").write(
         "import os\n"
@@ -42,7 +40,6 @@ def test_uninstalled_module_paths(modules_tmpdir, purge_module):
     assert app.instance_path == str(modules_tmpdir.join("instance"))
 
 
-@pytest.mark.xfail(reason="weird interaction with tox")
 def test_uninstalled_package_paths(modules_tmpdir, purge_module):
     app = modules_tmpdir.mkdir("config_package_app")
     init = app.join("__init__.py")

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -59,6 +59,25 @@ def test_uninstalled_package_paths(modules_tmpdir, purge_module):
     assert app.instance_path == str(modules_tmpdir.join("instance"))
 
 
+def test_uninstalled_namespace_paths(tmpdir, monkeypatch, purge_module):
+    def create_namespace(package):
+        project = tmpdir.join(f"project-{package}")
+        monkeypatch.syspath_prepend(str(project))
+        project.join("namespace").join(package).join("__init__.py").write(
+            "import flask\napp = flask.Flask(__name__)\n", ensure=True
+        )
+        return project
+
+    _ = create_namespace("package1")
+    project2 = create_namespace("package2")
+    purge_module("namespace.package2")
+    purge_module("namespace")
+
+    from namespace.package2 import app
+
+    assert app.instance_path == str(project2.join("instance"))
+
+
 def test_installed_module_paths(
     modules_tmpdir, modules_tmpdir_prefix, purge_module, site_packages, limit_loader
 ):

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
 skip_missing_interpreters = true
 
 [testenv]
+envtmpdir = {toxworkdir}/tmp/{envname}
 deps =
     -r requirements/tests.txt
     min: -r requirements/tests-pallets-min.txt


### PR DESCRIPTION
Fix `Flask.auto_find_instance_path()` so that it handles correctly namespace packages residing in several different locations, e.g. from several projects installed in development mode.

Return not the first submodule search location but the one most close to Flask app import name.

- fixes #4602 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
