### PR TITLE
Fix incorrect references to `query` in testing doc

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -92,7 +92,7 @@ The ``client`` has methods that match the common HTTP request methods,
 such as ``client.get()`` and ``client.post()``. They take many arguments
 for building the request; you can find the full documentation in
 :class:`~werkzeug.test.EnvironBuilder`. Typically you'll use ``path``,
-``query``, ``headers``, and ``data`` or ``json``.
+``query_string``, ``headers``, and ``data`` or ``json``.
 
 To make a request, call the method the request should use with the path
 to the route to test. A :class:`~werkzeug.test.TestResponse` is returned
@@ -108,9 +108,9 @@ provides ``response.text``, or use ``response.get_data(as_text=True)``.
         assert b"<h2>Hello, World!</h2>" in response.data
 
 
-Pass a dict ``query={"key": "value", ...}`` to set arguments in the
-query string (after the ``?`` in the URL). Pass a dict ``headers={}``
-to set request headers.
+Pass a dict ``query_string={"key": "value", ...}`` to set arguments in
+the query string (after the ``?`` in the URL). Pass a dict
+``headers={}`` to set request headers.
 
 To send a request body in a POST or PUT request, pass a value to
 ``data``. If raw bytes are passed, that exact body is used. Usually,


### PR DESCRIPTION
Resubmitted against the 2.1.x branch

The [EnvironBuilder doc](https://werkzeug.palletsprojects.com/en/2.1.x/test/#werkzeug.test.EnvironBuilder) shows that the correct name for the keyword argument is `query_string`, not `query`. Using `query` results in an error.

- fixes #4614 

Checklist:

- [ ] ~~Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.~~
- [x] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.

I have not contributed to this project before, so I'm not sure if it's essential to follow all of these Checklist items even in the case of a change only to the docs. LMK if I need to do more.
