### PR TITLE
Remove extra backtick in docs

### DIFF
--- a/src/flask/scaffold.py
+++ b/src/flask/scaffold.py
@@ -123,7 +123,7 @@ class Scaffold:
         self.view_functions: t.Dict[str, t.Callable] = {}
 
         #: A data structure of registered error handlers, in the format
-        #: ``{scope: {code: {class: handler}}}```. The ``scope`` key is
+        #: ``{scope: {code: {class: handler}}}``. The ``scope`` key is
         #: the name of a blueprint the handlers are active for, or
         #: ``None`` for all requests. The ``code`` key is the HTTP
         #: status code for ``HTTPException``, or ``None`` for


### PR DESCRIPTION
Removes an extra backtick from the inline code