### PR TITLE
deprecate before_first_request

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Unreleased
     registering the blueprint will show a warning. In the next version,
     this will become an error just like the application setup methods.
     :issue:`4571`
+-   ``before_first_request`` is deprecated. Run setup code when creating
+    the application instead. :issue:`4605`
 
 
 Version 2.1.3
@@ -1032,8 +1034,7 @@ Released 2011-09-29, codename Rakija
     earlier feedback when users forget to import view code ahead of
     time.
 -   Added the ability to register callbacks that are only triggered once
-    at the beginning of the first request.
-    (:meth:`Flask.before_first_request`)
+    at the beginning of the first request. (``before_first_request``)
 -   Malformed JSON data will now trigger a bad request HTTP exception
     instead of a value error which usually would result in a 500
     internal server error if not handled. This is a backwards

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -543,7 +543,20 @@ class Blueprint(Scaffold):
     ) -> ft.BeforeFirstRequestCallable:
         """Like :meth:`Flask.before_first_request`.  Such a function is
         executed before the first request to the application.
+
+        .. deprecated:: 2.2
+            Will be removed in Flask 2.3. Run setup code when creating
+            the application instead.
         """
+        import warnings
+
+        warnings.warn(
+            "'before_app_first_request' is deprecated and will be"
+            " removed in Flask 2.3. Use 'record_once' instead to run"
+            " setup code when registering the blueprint.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.record_once(lambda s: s.app.before_first_request_funcs.append(f))
         return f
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -107,10 +107,12 @@ def test_async_before_after_request():
     def index():
         return ""
 
-    @app.before_first_request
-    async def before_first():
-        nonlocal app_first_called
-        app_first_called = True
+    with pytest.deprecated_call():
+
+        @app.before_first_request
+        async def before_first():
+            nonlocal app_first_called
+            app_first_called = True
 
     @app.before_request
     async def before():

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1684,9 +1684,11 @@ def test_no_setup_after_first_request(app, client):
 def test_before_first_request_functions(app, client):
     got = []
 
-    @app.before_first_request
-    def foo():
-        got.append(42)
+    with pytest.deprecated_call():
+
+        @app.before_first_request
+        def foo():
+            got.append(42)
 
     client.get("/")
     assert got == [42]
@@ -1698,10 +1700,12 @@ def test_before_first_request_functions(app, client):
 def test_before_first_request_functions_concurrent(app, client):
     got = []
 
-    @app.before_first_request
-    def foo():
-        time.sleep(0.2)
-        got.append(42)
+    with pytest.deprecated_call():
+
+        @app.before_first_request
+        def foo():
+            time.sleep(0.2)
+            got.append(42)
 
     def get_and_assert():
         client.get("/")

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -722,9 +722,11 @@ def test_app_request_processing(app, client):
     bp = flask.Blueprint("bp", __name__)
     evts = []
 
-    @bp.before_app_first_request
-    def before_first_request():
-        evts.append("first")
+    with pytest.deprecated_call():
+
+        @bp.before_app_first_request
+        def before_first_request():
+            evts.append("first")
 
     @bp.before_app_request
     def before_app():


### PR DESCRIPTION
Add deprecation notices to `Flask.before_first_request`, `Blueprint.before_app_first_request`, and `Flask.before_first_request_funcs`. For now, inline `try_trigger_before_first_request_functions` to avoid a method call on every subsequent request.

closes #4605 