### PR TITLE
add `View.init_every_request` attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,9 @@ Unreleased
     :issue:`4571`
 -   ``before_first_request`` is deprecated. Run setup code when creating
     the application instead. :issue:`4605`
-
+-   Added the ``View.init_every_request`` class attribute. If a view
+    subclass sets this to ``False``, the view will not create a new
+    instance on every request. :issue:`2520`.
 
 Version 2.1.3
 -------------

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -240,3 +240,21 @@ def test_remove_method_from_parent(app, client):
     assert client.get("/").data == b"GET"
     assert client.post("/").status_code == 405
     assert sorted(View.methods) == ["GET"]
+
+
+def test_init_once(app, client):
+    n = 0
+
+    class CountInit(flask.views.View):
+        init_every_request = False
+
+        def __init__(self):
+            nonlocal n
+            n += 1
+
+        def dispatch_request(self):
+            return str(n)
+
+    app.add_url_rule("/", view_func=CountInit.as_view("index"))
+    assert client.get("/").data == b"1"
+    assert client.get("/").data == b"1"


### PR DESCRIPTION
If `ViewSubclass.init_every_request` is set to `False`, the generated view function will use a single instance of the view class instead of creating a new instance for each request.

Remove the `MethodViewType` metaclass and use `MethodView.__init_subclass__` instead.

Rewrite the docs about class-based views.

fixes #2520 