### PR TITLE
Update send_from_directory docstring to mention relative root for `directory`

### DIFF
--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -649,7 +649,8 @@ def send_from_directory(
     If the final path does not point to an existing regular file,
     raises a 404 :exc:`~werkzeug.exceptions.NotFound` error.
 
-    :param directory: The directory that ``path`` must be located under.
+    :param directory: The directory that ``path`` must be located under,
+        relative to the current application's root path.
     :param path: The path to the file to send, relative to
         ``directory``.
     :param kwargs: Arguments to pass to :func:`send_file`.


### PR DESCRIPTION
send_from_directory's `directory` parameter is relative to the application root_path. This tripped me up, I saw "relative to the current working directory" for send_file's `path_or_file` parameter and expected the same. Add a note to the docs to make it clear.

