### PR TITLE
`FlaskGroup` can be nested

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ Unreleased
 -   Added the ``View.init_every_request`` class attribute. If a view
     subclass sets this to ``False``, the view will not create a new
     instance on every request. :issue:`2520`.
+-   A ``flask.cli.FlaskGroup`` Click group can be nested as a
+    sub-command in a custom CLI. :issue:`3263`
+
 
 Version 2.1.3
 -------------

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -10,6 +10,7 @@ from itertools import chain
 from threading import Lock
 from types import TracebackType
 
+import click
 from werkzeug.datastructures import Headers
 from werkzeug.datastructures import ImmutableDict
 from werkzeug.exceptions import Aborter
@@ -23,6 +24,7 @@ from werkzeug.routing import MapAdapter
 from werkzeug.routing import RequestRedirect
 from werkzeug.routing import RoutingException
 from werkzeug.routing import Rule
+from werkzeug.serving import is_running_from_reloader
 from werkzeug.urls import url_quote
 from werkzeug.utils import redirect as _wz_redirect
 from werkzeug.wrappers import Response as BaseResponse
@@ -908,12 +910,18 @@ class Flask(Scaffold):
             The default port is now picked from the ``SERVER_NAME``
             variable.
         """
-        # Change this into a no-op if the server is invoked from the
-        # command line. Have a look at cli.py for more information.
+        # Ignore this call so that it doesn't start another server if
+        # the 'flask run' command is used.
         if os.environ.get("FLASK_RUN_FROM_CLI") == "true":
-            from .debughelpers import explain_ignored_app_run
+            if not is_running_from_reloader():
+                click.secho(
+                    " * Ignoring a call to 'app.run()', the server is"
+                    " already being run with the 'flask run' command.\n"
+                    "   Only call 'app.run()' in an 'if __name__ =="
+                    ' "__main__"\' guard.',
+                    fg="red",
+                )
 
-            explain_ignored_app_run()
             return
 
         if get_load_dotenv(load_dotenv):

--- a/src/flask/debughelpers.py
+++ b/src/flask/debughelpers.py
@@ -1,6 +1,4 @@
-import os
 import typing as t
-from warnings import warn
 
 from .app import Flask
 from .blueprints import Blueprint
@@ -159,16 +157,3 @@ def explain_template_loading_attempts(app: Flask, template, attempts) -> None:
         info.append("  See https://flask.palletsprojects.com/blueprints/#templates")
 
     app.logger.info("\n".join(info))
-
-
-def explain_ignored_app_run() -> None:
-    if os.environ.get("WERKZEUG_RUN_MAIN") != "true":
-        warn(
-            Warning(
-                "Silently ignoring app.run() because the application is"
-                " run from the flask command line executable. Consider"
-                ' putting app.run() behind an if __name__ == "__main__"'
-                " guard to silence this warning."
-            ),
-            stacklevel=3,
-        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -388,6 +388,19 @@ def test_flaskgroup_debug(runner, set_debug_flag):
     assert result.output == f"{not set_debug_flag}\n"
 
 
+def test_flaskgroup_nested(app, runner):
+    cli = click.Group("cli")
+    flask_group = FlaskGroup(name="flask", create_app=lambda: app)
+    cli.add_command(flask_group)
+
+    @flask_group.command()
+    def show():
+        click.echo(current_app.name)
+
+    result = runner.invoke(cli, ["flask", "show"])
+    assert result.output == "flask_test\n"
+
+
 def test_no_command_echo_loading_error():
     from flask.cli import cli
 


### PR DESCRIPTION
Move custom behavior out of `FlaskGroup.main` into `__init__` or `make_context instead. `main` isn't called when invoking subcommands, which would cause a `FlaskGroup` nested in a custom CLI to not get the passed in `create_app` function and other behavior. Now both the `flask.cli.cli`, as well as custom `FlaskGroup` instances, can be nested under a custom CLI.

fixes #3263 