### PR TITLE
Use timezone aware datetime object on session

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,8 @@ Unreleased
 -   It is no longer required to decorate custom CLI commands on
     ``app.cli`` or ``blueprint.cli`` with ``@with_appcontext``, an app
     context will already be active at that point. :issue:`2410`
+-   ``SessionInterface.get_expiration_time`` uses a timezone-aware
+    value. :pr:`4645`
 
 
 Version 2.1.3

--- a/src/flask/sessions.py
+++ b/src/flask/sessions.py
@@ -3,6 +3,7 @@ import typing as t
 import warnings
 from collections.abc import MutableMapping
 from datetime import datetime
+from datetime import timezone
 
 from itsdangerous import BadSignature
 from itsdangerous import URLSafeTimedSerializer
@@ -277,7 +278,7 @@ class SessionInterface:
         lifetime configured on the application.
         """
         if session.permanent:
-            return datetime.utcnow() + app.permanent_session_lifetime
+            return datetime.now(timezone.utc) + app.permanent_session_lifetime
         return None
 
     def should_set_cookie(self, app: "Flask", session: SessionMixin) -> bool:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -5,6 +5,7 @@ import uuid
 import warnings
 import weakref
 from datetime import datetime
+from datetime import timezone
 from platform import python_implementation
 from threading import Thread
 
@@ -436,7 +437,7 @@ def test_session_expiration(app, client):
     assert "set-cookie" in rv.headers
     match = re.search(r"(?i)\bexpires=([^;]+)", rv.headers["set-cookie"])
     expires = parse_date(match.group())
-    expected = datetime.utcnow() + app.permanent_session_lifetime
+    expected = datetime.now(timezone.utc) + app.permanent_session_lifetime
     assert expires.year == expected.year
     assert expires.month == expected.month
     assert expires.day == expected.day
@@ -466,7 +467,7 @@ def test_session_stored_last(app, client):
 
 
 def test_session_special_types(app, client):
-    now = datetime.utcnow().replace(microsecond=0)
+    now = datetime.now(timezone.utc).replace(microsecond=0)
     the_uuid = uuid.uuid4()
 
     @app.route("/")


### PR DESCRIPTION
Naïve datetime objects are discouraged in https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow

> Warning Because naive datetime objects are treated by many datetime methods as local times, it is preferred to use aware datetimes to represent times in UTC. As such, the recommended way to create an object representing the current time in UTC is by calling datetime.now(timezone.utc).

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes N/A

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
