### PR TITLE
with_appcontext lasts for the lifetime of the click context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ Unreleased
 -   Add ``--env-file`` option to the ``flask`` CLI. This allows
     specifying a dotenv file to load in addition to ``.env`` and
     ``.flaskenv``. :issue:`3108`
+-   It is no longer required to decorate custom CLI commands on
+    ``app.cli`` or ``blueprint.cli`` with ``@with_appcontext``, an app
+    context will already be active at that point. :issue:`2410`
 
 
 Version 2.1.3

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -437,12 +437,14 @@ commands directly to the application's level:
 Application Context
 ~~~~~~~~~~~~~~~~~~~
 
-Commands added using the Flask app's :attr:`~Flask.cli`
-:meth:`~cli.AppGroup.command` decorator will be executed with an application
-context pushed, so your command and extensions have access to the app and its
-configuration. If you create a command using the Click :func:`~click.command`
-decorator instead of the Flask decorator, you can use
-:func:`~cli.with_appcontext` to get the same behavior. ::
+Commands added using the Flask app's :attr:`~Flask.cli` or
+:class:`~flask.cli.FlaskGroup` :meth:`~cli.AppGroup.command` decorator
+will be executed with an application context pushed, so your custom
+commands and parameters have access to the app and its configuration. The
+:func:`~cli.with_appcontext` decorator can be used to get the same
+behavior, but is not needed in most cases.
+
+.. code-block:: python
 
     import click
     from flask.cli import with_appcontext
@@ -453,12 +455,6 @@ decorator instead of the Flask decorator, you can use
         ...
 
     app.cli.add_command(do_work)
-
-If you're sure a command doesn't need the context, you can disable it::
-
-    @app.cli.command(with_appcontext=False)
-    def do_work():
-        ...
 
 
 Plugins

--- a/docs/tutorial/database.rst
+++ b/docs/tutorial/database.rst
@@ -40,7 +40,6 @@ response is sent.
 
     import click
     from flask import current_app, g
-    from flask.cli import with_appcontext
 
 
     def get_db():
@@ -128,7 +127,6 @@ Add the Python functions that will run these SQL commands to the
 
 
     @click.command('init-db')
-    @with_appcontext
     def init_db_command():
         """Clear the existing data and create new tables."""
         init_db()

--- a/examples/tutorial/flaskr/db.py
+++ b/examples/tutorial/flaskr/db.py
@@ -3,7 +3,6 @@ import sqlite3
 import click
 from flask import current_app
 from flask import g
-from flask.cli import with_appcontext
 
 
 def get_db():
@@ -39,7 +38,6 @@ def init_db():
 
 
 @click.command("init-db")
-@with_appcontext
 def init_db_command():
     """Clear existing data and create new tables."""
     init_db()


### PR DESCRIPTION
Commands registered under `app.cli` (and `blueprint.cli`) will always have an active app context. This makes it possible to access the app context in command *and parameter* callbacks without requiring the `@with_appcontext` decorator. The app context is pushed during `FlaskGroup.get_command` when the app is loaded to look up custom commands, because at that point the app is known and the command will definitely be part of `app.cli`.

Uses `click.Context.with_resource` to manage `app.app_context` for the lifetime of the Click context instead of only while executing the decorated function. This means that any callbacks under a group decorated with `@with_appcontext` will also have access to the same app context.

`@AppGroup.command` and `group` still have the `with_appcontext=True` keyword argument, since it's possible to register commands directly with `FlaskGroup.command`, or to register commands with other CLIs that might not push the context automatically like `FlaskGroup` does.

fixes #2410