### PR TITLE
Update quickstart to reflect get() and post() decorator syntax

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -390,6 +390,24 @@ of the :meth:`~flask.Flask.route` decorator to handle different HTTP methods.
         else:
             return show_the_login_form()
 
+The example above keeps all methods for the route within one function,
+which can be useful if each part uses some common data.
+
+You can also separate views for different methods into different
+functions. Flask provides a shortcut for decorating such routes with
+:meth:`~flask.Flask.get`, :meth:`~flask.Flask.post`, etc. for each
+common HTTP method.
+
+.. code-block:: python
+
+    @app.get('/login')
+    def login_get():
+        return show_the_login_form()
+
+    @app.post('/login')
+    def login_post():
+        return do_the_login()
+
 If ``GET`` is present, Flask automatically adds support for the ``HEAD`` method
 and handles ``HEAD`` requests according to the `HTTP RFC`_. Likewise,
 ``OPTIONS`` is automatically implemented for you.


### PR DESCRIPTION
Added a short paragraph and example to the http-methods section to explain that http methods can be referenced directly by using the `get()` and `post()` decorators as well as the `route(methods=['GET', 'POST])` decorator.

I believe this will be helpful for those new to Flask as it is simpler syntax and doesn't require referencing the `request` object which hasn't yet been introduced by this point in the quickstart.