### PR TITLE
rewrite extension development docs

### DIFF
--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -39,10 +39,10 @@ an extension called "Flask-Foo" might be used like this::
 Building Extensions
 -------------------
 
-While the `PyPI <pypi_>`_ contains many Flask extensions, you may
-not find an extension that fits your need. If this is the case, you can
-create your own. Read :doc:`/extensiondev` to develop your own Flask
-extension.
+While `PyPI <pypi_>`_ contains many Flask extensions, you may not find
+an extension that fits your need. If this is the case, you can create
+your own, and publish it for others to use as well. Read
+:doc:`extensiondev` to develop your own Flask extension.
 
 
 .. _pypi: https://pypi.org/search/?c=Framework+%3A%3A+Flask


### PR DESCRIPTION
Rewrite the extension development docs to focus on discussion of patterns rather than specific examples. I tried to identify the things that truly are common to extensions, because it's such a huge topic that basically covers all of project development.

I also added a section about accessing models, which are defined later, from views that are defined as part of the extension's code. That closes #289.