### PR TITLE
new preserve context implementation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,18 @@ Unreleased
     them in a ``Response``. :pr:`4629`
 -   Add ``stream_template`` and ``stream_template_string`` functions to
     render a template as a stream of pieces. :pr:`4629`
+-   A new implementation of context preservation during debugging and
+    testing. :pr:`4666`
+
+    -   ``request``, ``g``, and other context-locals point to the
+        correct data when running code in the interactive debugger
+        console. :issue:`2836`
+    -   Teardown functions are always run at the end of the request,
+        even if the context is preserved. They are also run after the
+        preserved context is popped.
+    -   ``stream_with_context`` preserves context separately from a
+        ``with client`` block. It will be cleaned up when
+        ``response.get_data()`` or ``response.close()`` is called.
 
 
 Version 2.1.3

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -126,14 +126,6 @@ The following configuration values are used internally by Flask:
 
     Default: ``None``
 
-.. py:data:: PRESERVE_CONTEXT_ON_EXCEPTION
-
-    Don't pop the request context when an exception occurs. If not set, this
-    is true if ``DEBUG`` is true. This allows debuggers to introspect the
-    request data on errors, and should normally not need to be set directly.
-
-    Default: ``None``
-
 .. py:data:: TRAP_HTTP_EXCEPTIONS
 
     If there is no handler for an ``HTTPException``-type exception, re-raise it
@@ -391,6 +383,9 @@ The following configuration values are used internally by Flask:
     cookie's ``SameSite`` option.
 
     Added :data:`MAX_COOKIE_SIZE` to control a warning from Werkzeug.
+
+.. versionchanged:: 2.2
+    Removed ``PRESERVE_CONTEXT_ON_EXCEPTION``.
 
 
 Configuring from Python Files

--- a/docs/reqcontext.rst
+++ b/docs/reqcontext.rst
@@ -219,25 +219,6 @@ sent:
     :meth:`~Flask.teardown_request` functions are called.
 
 
-Context Preservation on Error
------------------------------
-
-At the end of a request, the request context is popped and all data
-associated with it is destroyed. If an error occurs during development,
-it is useful to delay destroying the data for debugging purposes.
-
-When the development server is running in development mode (the
-``--env`` option is set to ``'development'``), the error and data will
-be preserved and shown in the interactive debugger.
-
-This behavior can be controlled with the
-:data:`PRESERVE_CONTEXT_ON_EXCEPTION` config. As described above, it
-defaults to ``True`` in the development environment.
-
-Do not enable :data:`PRESERVE_CONTEXT_ON_EXCEPTION` in production, as it
-will cause your application to leak memory on exceptions.
-
-
 .. _notes-on-proxies:
 
 Notes On Proxies

--- a/src/flask/scaffold.py
+++ b/src/flask/scaffold.py
@@ -600,13 +600,6 @@ class Scaffold:
         be passed an error object.
 
         The return values of teardown functions are ignored.
-
-        .. admonition:: Debug Note
-
-           In debug mode Flask will not tear down a request on an exception
-           immediately.  Instead it will keep it alive so that the interactive
-           debugger can still access it.  This behavior can be controlled
-           by the ``PRESERVE_CONTEXT_ON_EXCEPTION`` configuration variable.
         """
         self.teardown_request_funcs.setdefault(None, []).append(f)
         return f


### PR DESCRIPTION
Uses the new mechanism introduced by https://github.com/pallets/werkzeug/pull/2439 to preserve the app and request context. If the `werkzeug.debug.preserve_context` key is in the environ, it is a callable. It is called to record context managers that should be entered again after the request ends. Rather than keeping the contexts on the stack for longer, this allows preserving the contexts independently of the context-local stack and subsequent requests.

Because `request`, `g`, etc. are context-local, they would never be available in the debugger when using the default threaded server. Now they will point to the correct data in the debugger. The same mechanism is used by the test client.

The contexts are now always popped at the end of the request, even if they are preserved. This means teardown functions will run to clean up resources. The previous implementation would pop the preserved context from the stack on the next, but that would never happen when using the threaded server because each request would be in a new thread with its own stack. I have a feeling this was causing issues especially with Flask-SQLAlchemy, where connections would never be released for requests caught by the debugger.

The contexts are restored after the request finishes in the test client, or when code is executed in the debugger. This means that signals will run each time, and teardown functions will run each time.

Only the contexts directly preserved by `werkzeug.debug.preserve_context` are popped. This reverts #3157, which caused every instance of the same context to be popped. This means that the context preserved with `stream_with_context` will not be popped when a `with client` block ends, it will only be popped once `response.data` is read (or `response.close()` is called).

closes #2836