### PR TITLE
Remove deprecated code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,13 @@ Unreleased
 
 -   Remove previously deprecated code. :pr:`4337`
 
-    -   The ``RequestContext.g`` proxy to ``AppContext.g`` is removed.
+    -   Old names for some ``send_file`` parameters have been removed.
+        ``download_name`` replaces ``attachment_filename``, ``max_age``
+        replaces ``cache_timeout``, and ``etag`` replaces ``add_etags``.
+        Additionally, ``path`` replaces ``filename`` in
+        ``send_from_directory``.
+    -   The ``RequestContext.g`` property returning ``AppContext.g`` is
+        removed.
 
 -   Add new customization points to the ``Flask`` app object for many
     previously global behaviors.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Version 2.2.0
 
 Unreleased
 
+-   Remove previously deprecated code. :pr:`4337`
+
+    -   The ``RequestContext.g`` proxy to ``AppContext.g`` is removed.
+
 -   Add new customization points to the ``Flask`` app object for many
     previously global behaviors.
 

--- a/src/flask/ctx.py
+++ b/src/flask/ctx.py
@@ -327,32 +327,6 @@ class RequestContext:
         # functions.
         self._after_request_functions: t.List[ft.AfterRequestCallable] = []
 
-    @property
-    def g(self) -> _AppCtxGlobals:
-        import warnings
-
-        warnings.warn(
-            "Accessing 'g' on the request context is deprecated and"
-            " will be removed in Flask 2.2. Access `g` directly or from"
-            "the application context instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return _app_ctx_stack.top.g
-
-    @g.setter
-    def g(self, value: _AppCtxGlobals) -> None:
-        import warnings
-
-        warnings.warn(
-            "Setting 'g' on the request context is deprecated and"
-            " will be removed in Flask 2.2. Set it on the application"
-            " context instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        _app_ctx_stack.top.g = value
-
     def copy(self) -> "RequestContext":
         """Creates a copy of this request context with the same request object.
         This can be used to move a request context to a different greenlet.


### PR DESCRIPTION
- Some argument to `send_file` and `send_from_directory` were renamed in Flask 2.0. The removal of the old names was deferred for an extra release. They have now been issuing a deprecation warning for over a year. `download_name` replaces `attachment_filename`, `max_age` replaces `cache_timeout`, `etag` replaces `add_etags`, and `path` replaces `filename`.
- `RequestContext.g` was a property returning `AppContext.g`. Since `g` is not part of the request context, the property is removed.