### PR TITLE
Allow to return list as JSON

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,9 @@ Unreleased
         ``with client`` block. It will be cleaned up when
         ``response.get_data()`` or ``response.close()`` is called.
 
+-   Allow returning a list from a view function, to convert it to a
+    JSON response like a dict is. :issue:`4672`
+
 
 Version 2.1.3
 -------------

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1924,15 +1924,17 @@ class Flask(Scaffold):
                     raise TypeError(
                         f"{e}\nThe view function did not return a valid"
                         " response. The return type must be a string,"
-                        " dict, list, tuple, Response instance, or WSGI"
-                        f" callable, but it was a {type(rv).__name__}."
+                        " dict, list, tuple with headers or status,"
+                        " Response instance, or WSGI callable, but it"
+                        f" was a {type(rv).__name__}."
                     ).with_traceback(sys.exc_info()[2]) from None
             else:
                 raise TypeError(
                     "The view function did not return a valid"
                     " response. The return type must be a string,"
-                    " dict, list, tuple, Response instance, or WSGI"
-                    f" callable, but it was a {type(rv).__name__}."
+                    " dict, list, tuple with headers or status,"
+                    " Response instance, or WSGI callable, but it was a"
+                    f" {type(rv).__name__}."
                 )
 
         rv = t.cast(Response, rv)

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1830,6 +1830,9 @@ class Flask(Scaffold):
             ``dict``
                 A dictionary that will be jsonify'd before being returned.
 
+            ``list``
+                A list that will be jsonify'd before being returned.
+
             ``generator`` or ``iterator``
                 A generator that returns ``str`` or ``bytes`` to be
                 streamed as the response.
@@ -1855,6 +1858,7 @@ class Flask(Scaffold):
 
         .. versionchanged:: 2.2
             A generator will be converted to a streaming response.
+            A list will be converted to a JSON response.
 
         .. versionchanged:: 1.1
             A dict will be converted to a JSON response.
@@ -1907,7 +1911,7 @@ class Flask(Scaffold):
                     headers=headers,  # type: ignore[arg-type]
                 )
                 status = headers = None
-            elif isinstance(rv, dict):
+            elif isinstance(rv, (dict, list)):
                 rv = jsonify(rv)
             elif isinstance(rv, BaseResponse) or callable(rv):
                 # evaluate a WSGI callable, or coerce a different response
@@ -1920,14 +1924,14 @@ class Flask(Scaffold):
                     raise TypeError(
                         f"{e}\nThe view function did not return a valid"
                         " response. The return type must be a string,"
-                        " dict, tuple, Response instance, or WSGI"
+                        " dict, list, tuple, Response instance, or WSGI"
                         f" callable, but it was a {type(rv).__name__}."
                     ).with_traceback(sys.exc_info()[2]) from None
             else:
                 raise TypeError(
                     "The view function did not return a valid"
                     " response. The return type must be a string,"
-                    " dict, tuple, Response instance, or WSGI"
+                    " dict, list, tuple, Response instance, or WSGI"
                     f" callable, but it was a {type(rv).__name__}."
                 )
 

--- a/src/flask/typing.py
+++ b/src/flask/typing.py
@@ -7,7 +7,13 @@ if t.TYPE_CHECKING:  # pragma: no cover
 
 # The possible types that are directly convertible or are a Response object.
 ResponseValue = t.Union[
-    "Response", str, bytes, list, t.Dict[str, t.Any], t.Iterator[str], t.Iterator[bytes]
+    "Response",
+    str,
+    bytes,
+    t.List[t.Any],
+    t.Dict[str, t.Any],
+    t.Iterator[str],
+    t.Iterator[bytes],
 ]
 
 # the possible types for an individual HTTP header

--- a/src/flask/typing.py
+++ b/src/flask/typing.py
@@ -7,7 +7,7 @@ if t.TYPE_CHECKING:  # pragma: no cover
 
 # The possible types that are directly convertible or are a Response object.
 ResponseValue = t.Union[
-    "Response", str, bytes, t.Dict[str, t.Any], t.Iterator[str], t.Iterator[bytes]
+    "Response", str, bytes, list, t.Dict[str, t.Any], t.Iterator[str], t.Iterator[bytes]
 ]
 
 # the possible types for an individual HTTP header

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1166,6 +1166,10 @@ def test_response_types(app, client):
     def from_dict():
         return {"foo": "bar"}, 201
 
+    @app.route("/list")
+    def from_list():
+        return ["foo", "bar"], 201
+
     assert client.get("/text").data == "Hällo Wörld".encode()
     assert client.get("/bytes").data == "Hällo Wörld".encode()
 
@@ -1203,6 +1207,10 @@ def test_response_types(app, client):
 
     rv = client.get("/dict")
     assert rv.json == {"foo": "bar"}
+    assert rv.status_code == 201
+
+    rv = client.get("/list")
+    assert rv.json == ["foo", "bar"]
     assert rv.status_code == 201
 
 

--- a/tests/typing/typing_route.py
+++ b/tests/typing/typing_route.py
@@ -25,7 +25,17 @@ def hello_bytes() -> bytes:
 
 @app.route("/json")
 def hello_json() -> Response:
-    return jsonify({"response": "Hello, World!"})
+    return jsonify("Hello, World!")
+
+
+@app.route("/json/dict")
+def hello_json_dict() -> t.Dict[str, t.Any]:
+    return {"response": "Hello, World!"}
+
+
+@app.route("/json/dict")
+def hello_json_list() -> t.List[t.Any]:
+    return [{"message": "Hello"}, {"message": "World"}]
 
 
 @app.route("/generator")


### PR DESCRIPTION
This adds support to serializing list return values to JSON, like what we did for the dictionary:

```python
@app.route('/')
def index():
    return ['this', 'will', 'become', 'JSON']
```

There are some discusses related to this feature in #3111, and the concern is the list return value looks too much like the tuple. Maybe we can rethink about this feature? I propose this because the following reasons:

- List as JSON response is a common use case for Web APIs. We support returning dict as JSON, but not list. This makes people feel inconsistent (#4533, #4659).
- With #2737, we only treat tuple as a valid shortcut for return values, so there will be no program conflicts to allow returning list (we also throw an error for list return value currently).
- In terms of semantics, there is no concept of "tuple" in JSON. Although list and tuple are both sequences in Python, there are differences in syntax and meaning. We can add docs to address the different meaning of list and tuple in return values.
- In terms of visuals, most people will not mix `[1, 2, 3]` and `(1, 2, 3)`, and people usually return tuple items without the bracket in the view function.

If this change is acceptable, I will update the docs and changelog.

Sorry for break the "zero status". :P

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
