### PR TITLE
Document serialization of Decimal in JSONEncoder

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -242,6 +242,7 @@ for easier customization. By default it handles some extra data types:
 
 -   :class:`datetime.datetime` and :class:`datetime.date` are serialized
     to :rfc:`822` strings. This is the same as the HTTP date format.
+-   :class:`decimal.Decimal` is serialized to a string.
 -   :class:`uuid.UUID` is serialized to a string.
 -   :class:`dataclasses.dataclass` is passed to
     :func:`dataclasses.asdict`.

--- a/src/flask/json/__init__.py
+++ b/src/flask/json/__init__.py
@@ -23,6 +23,7 @@ class JSONEncoder(_json.JSONEncoder):
     -   :class:`datetime.datetime` and :class:`datetime.date` are
         serialized to :rfc:`822` strings. This is the same as the HTTP
         date format.
+    -   :class:`decimal.Decimal` is serialized to a string.
     -   :class:`uuid.UUID` is serialized to a string.
     -   :class:`dataclasses.dataclass` is passed to
         :func:`dataclasses.asdict`.


### PR DESCRIPTION
The Flask JSONEncoder serializes Decimal types to strings, but this behavior is missing from the docs. The docs are updated accordingly.