### PR TITLE
New URL for the Quart project

### DIFF
--- a/docs/async-await.rst
+++ b/docs/async-await.rst
@@ -91,7 +91,7 @@ patch low-level Python functions to accomplish this, whereas ``async``/
 whether you should use Flask, Quart, or something else is ultimately up
 to understanding the specific needs of your project.
 
-.. _Quart: https://gitlab.com/pgjones/quart
+.. _Quart: https://github.com/pallets/quart
 .. _ASGI: https://asgi.readthedocs.io/en/latest/
 
 


### PR DESCRIPTION
The Quart project moved from Gitlab (https://gitlab.com/pgjones/quart) to Github (https://github.com/pallets/quart). There is a message at the top of the Gitlab page announcing the move.
