### PR TITLE
remove use of `LocalStack`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,15 @@ Unreleased
     -   The ``RequestContext.g`` property returning ``AppContext.g`` is
         removed.
 
+-   The app and request contexts are managed using Python context vars
+    directly rather than Werkzeug's ``LocalStack``. This should result
+    in better performance and memory use. :pr:`4672`
+
+    -   Extension maintainers, be aware that ``_app_ctx_stack.top``
+        and ``_request_ctx_stack.top`` are deprecated. Store data on
+        ``g`` instead using a unique prefix, like
+        ``g._extension_name_attr``.
+
 -   Add new customization points to the ``Flask`` app object for many
     previously global behaviors.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -311,56 +311,28 @@ Useful Internals
 .. autoclass:: flask.ctx.RequestContext
    :members:
 
-.. data:: _request_ctx_stack
+.. data:: flask.globals.request_ctx
 
-    The internal :class:`~werkzeug.local.LocalStack` that holds
-    :class:`~flask.ctx.RequestContext` instances. Typically, the
-    :data:`request` and :data:`session` proxies should be accessed
-    instead of the stack. It may be useful to access the stack in
-    extension code.
+    The current :class:`~flask.ctx.RequestContext`. If a request context
+    is not active, accessing attributes on this proxy will raise a
+    ``RuntimeError``.
 
-    The following attributes are always present on each layer of the
-    stack:
-
-    `app`
-      the active Flask application.
-
-    `url_adapter`
-      the URL adapter that was used to match the request.
-
-    `request`
-      the current request object.
-
-    `session`
-      the active session object.
-
-    `g`
-      an object with all the attributes of the :data:`flask.g` object.
-
-    `flashes`
-      an internal cache for the flashed messages.
-
-    Example usage::
-
-        from flask import _request_ctx_stack
-
-        def get_session():
-            ctx = _request_ctx_stack.top
-            if ctx is not None:
-                return ctx.session
+    This is an internal object that is essential to how Flask handles
+    requests. Accessing this should not be needed in most cases. Most
+    likely you want :data:`request` and :data:`session` instead.
 
 .. autoclass:: flask.ctx.AppContext
    :members:
 
-.. data:: _app_ctx_stack
+.. data:: flask.globals.app_ctx
 
-    The internal :class:`~werkzeug.local.LocalStack` that holds
-    :class:`~flask.ctx.AppContext` instances. Typically, the
-    :data:`current_app` and :data:`g` proxies should be accessed instead
-    of the stack. Extensions can access the contexts on the stack as a
-    namespace to store data.
+    The current :class:`~flask.ctx.AppContext`. If an app context is not
+    active, accessing attributes on this proxy will raise a
+    ``RuntimeError``.
 
-    .. versionadded:: 0.9
+    This is an internal object that is essential to how Flask handles
+    requests. Accessing this should not be needed in most cases. Most
+    likely you want :data:`current_app` and :data:`g` instead.
 
 .. autoclass:: flask.blueprints.BlueprintSetupState
    :members:

--- a/docs/appcontext.rst
+++ b/docs/appcontext.rst
@@ -136,14 +136,6 @@ local from ``get_db()``::
 Accessing ``db`` will call ``get_db`` internally, in the same way that
 :data:`current_app` works.
 
-----
-
-If you're writing an extension, :data:`g` should be reserved for user
-code. You may store internal data on the context itself, but be sure to
-use a sufficiently unique name. The current context is accessed with
-:data:`_app_ctx_stack.top <_app_ctx_stack>`. For more information see
-:doc:`/extensiondev`.
-
 
 Events and Signals
 ------------------

--- a/docs/extensiondev.rst
+++ b/docs/extensiondev.rst
@@ -187,12 +187,6 @@ when the application context ends. If it should only be valid during a
 request, or would not be used in the CLI outside a reqeust, use
 :meth:`~flask.Flask.teardown_request`.
 
-An older technique for storing context data was to store it on
-``_app_ctx_stack.top`` or ``_request_ctx_stack.top``. However, this just
-moves the same namespace collision problem elsewhere (although less
-likely) and modifies objects that are very internal to Flask's
-operations. Prefer storing data under a unique name in ``g``.
-
 
 Views and Models
 ----------------

--- a/docs/patterns/sqlite3.rst
+++ b/docs/patterns/sqlite3.rst
@@ -30,10 +30,6 @@ or create an application context itself.  At that point the ``get_db``
 function can be used to get the current database connection.  Whenever the
 context is destroyed the database connection will be terminated.
 
-Note: if you use Flask 0.9 or older you need to use
-``flask._app_ctx_stack.top`` instead of ``g`` as the :data:`flask.g`
-object was bound to the request and not application context.
-
 Example::
 
     @app.route('/')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name="Flask",
     install_requires=[
-        "Werkzeug >= 2.0",
+        "Werkzeug >= 2.2.0a1",
         "Jinja2 >= 3.0",
         "itsdangerous >= 2.0",
         "click >= 8.0",

--- a/src/flask/__init__.py
+++ b/src/flask/__init__.py
@@ -11,8 +11,6 @@ from .ctx import after_this_request as after_this_request
 from .ctx import copy_current_request_context as copy_current_request_context
 from .ctx import has_app_context as has_app_context
 from .ctx import has_request_context as has_request_context
-from .globals import _app_ctx_stack as _app_ctx_stack
-from .globals import _request_ctx_stack as _request_ctx_stack
 from .globals import current_app as current_app
 from .globals import g as g
 from .globals import request as request
@@ -45,3 +43,29 @@ from .templating import stream_template as stream_template
 from .templating import stream_template_string as stream_template_string
 
 __version__ = "2.2.0.dev0"
+
+
+def __getattr__(name):
+    if name == "_app_ctx_stack":
+        import warnings
+        from .globals import __app_ctx_stack
+
+        warnings.warn(
+            "'_app_ctx_stack' is deprecated and will be removed in Flask 2.3.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return __app_ctx_stack
+
+    if name == "_request_ctx_stack":
+        import warnings
+        from .globals import __request_ctx_stack
+
+        warnings.warn(
+            "'_request_ctx_stack' is deprecated and will be removed in Flask 2.3.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return __request_ctx_stack
+
+    raise AttributeError(name)

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1284,29 +1284,30 @@ class Flask(Scaffold):
 
     @setupmethod
     def teardown_appcontext(self, f: T_teardown) -> T_teardown:
-        """Registers a function to be called when the application context
-        ends.  These functions are typically also called when the request
-        context is popped.
+        """Registers a function to be called when the application
+        context is popped. The application context is typically popped
+        after the request context for each request, at the end of CLI
+        commands, or after a manually pushed context ends.
 
-        Example::
+        .. code-block:: python
 
-            ctx = app.app_context()
-            ctx.push()
-            ...
-            ctx.pop()
+            with app.app_context():
+                ...
 
-        When ``ctx.pop()`` is executed in the above example, the teardown
-        functions are called just before the app context moves from the
-        stack of active contexts.  This becomes relevant if you are using
-        such constructs in tests.
+        When the ``with`` block exits (or ``ctx.pop()`` is called), the
+        teardown functions are called just before the app context is
+        made inactive. Since a request context typically also manages an
+        application context it would also be called when you pop a
+        request context.
 
-        Since a request context typically also manages an application
-        context it would also be called when you pop a request context.
+        When a teardown function was called because of an unhandled
+        exception it will be passed an error object. If an
+        :meth:`errorhandler` is registered, it will handle the exception
+        and the teardown will not receive it.
 
-        When a teardown function was called because of an unhandled exception
-        it will be passed an error object. If an :meth:`errorhandler` is
-        registered, it will handle the exception and the teardown will not
-        receive it.
+        Teardown functions must avoid raising exceptions. If they
+        execute code that might fail they must surround that code with a
+        ``try``/``except`` block and log any errors.
 
         The return values of teardown functions are ignored.
 

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -38,10 +38,11 @@ from .config import ConfigAttribute
 from .ctx import _AppCtxGlobals
 from .ctx import AppContext
 from .ctx import RequestContext
-from .globals import _app_ctx_stack
-from .globals import _request_ctx_stack
+from .globals import _cv_app
+from .globals import _cv_req
 from .globals import g
 from .globals import request
+from .globals import request_ctx
 from .globals import session
 from .helpers import _split_blueprint_path
 from .helpers import get_debug_flag
@@ -1554,10 +1555,10 @@ class Flask(Scaffold):
            This no longer does the exception handling, this code was
            moved to the new :meth:`full_dispatch_request`.
         """
-        req = _request_ctx_stack.top.request
+        req = request_ctx.request
         if req.routing_exception is not None:
             self.raise_routing_exception(req)
-        rule = req.url_rule
+        rule: Rule = req.url_rule  # type: ignore[assignment]
         # if we provide automatic options for this URL and the
         # request came with the OPTIONS method, reply automatically
         if (
@@ -1566,7 +1567,8 @@ class Flask(Scaffold):
         ):
             return self.make_default_options_response()
         # otherwise dispatch to the handler for that endpoint
-        return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
+        view_args: t.Dict[str, t.Any] = req.view_args  # type: ignore[assignment]
+        return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
 
     def full_dispatch_request(self) -> Response:
         """Dispatches the request and on top of that performs request
@@ -1631,8 +1633,8 @@ class Flask(Scaffold):
 
         .. versionadded:: 0.7
         """
-        adapter = _request_ctx_stack.top.url_adapter
-        methods = adapter.allowed_methods()
+        adapter = request_ctx.url_adapter
+        methods = adapter.allowed_methods()  # type: ignore[union-attr]
         rv = self.response_class()
         rv.allow.update(methods)
         return rv
@@ -1740,7 +1742,7 @@ class Flask(Scaffold):
         .. versionadded:: 2.2
             Moved from ``flask.url_for``, which calls this method.
         """
-        req_ctx = _request_ctx_stack.top
+        req_ctx = _cv_req.get(None)
 
         if req_ctx is not None:
             url_adapter = req_ctx.url_adapter
@@ -1759,7 +1761,7 @@ class Flask(Scaffold):
             if _external is None:
                 _external = _scheme is not None
         else:
-            app_ctx = _app_ctx_stack.top
+            app_ctx = _cv_app.get(None)
 
             # If called by helpers.url_for, an app context is active,
             # use its url_adapter. Otherwise, app.url_for was called
@@ -1790,7 +1792,7 @@ class Flask(Scaffold):
         self.inject_url_defaults(endpoint, values)
 
         try:
-            rv = url_adapter.build(
+            rv = url_adapter.build(  # type: ignore[union-attr]
                 endpoint,
                 values,
                 method=_method,
@@ -2099,7 +2101,7 @@ class Flask(Scaffold):
         :return: a new response object or the same, has to be an
                  instance of :attr:`response_class`.
         """
-        ctx = _request_ctx_stack.top
+        ctx = request_ctx._get_current_object()  # type: ignore[attr-defined]
 
         for func in ctx._after_request_functions:
             response = self.ensure_sync(func)(response)
@@ -2305,8 +2307,8 @@ class Flask(Scaffold):
             return response(environ, start_response)
         finally:
             if "werkzeug.debug.preserve_context" in environ:
-                environ["werkzeug.debug.preserve_context"](_app_ctx_stack.top)
-                environ["werkzeug.debug.preserve_context"](_request_ctx_stack.top)
+                environ["werkzeug.debug.preserve_context"](_cv_app.get())
+                environ["werkzeug.debug.preserve_context"](_cv_req.get())
 
             if error is not None and self.should_ignore_error(error):
                 error = None

--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -1051,13 +1051,11 @@ def shell_command() -> None:
     without having to manually configure the application.
     """
     import code
-    from .globals import _app_ctx_stack
 
-    app = _app_ctx_stack.top.app
     banner = (
         f"Python {sys.version} on {sys.platform}\n"
-        f"App: {app.import_name} [{app.env}]\n"
-        f"Instance: {app.instance_path}"
+        f"App: {current_app.import_name} [{current_app.env}]\n"
+        f"Instance: {current_app.instance_path}"
     )
     ctx: dict = {}
 
@@ -1068,7 +1066,7 @@ def shell_command() -> None:
         with open(startup) as f:
             eval(compile(f.read(), startup, "exec"), ctx)
 
-    ctx.update(app.make_shell_context())
+    ctx.update(current_app.make_shell_context())
 
     # Site, customize, or startup script can set a hook to call when
     # entering interactive mode. The default one sets up readline with

--- a/src/flask/ctx.py
+++ b/src/flask/ctx.py
@@ -227,12 +227,10 @@ def has_app_context() -> bool:
 
 
 class AppContext:
-    """The application context binds an application object implicitly
-    to the current thread or greenlet, similar to how the
-    :class:`RequestContext` binds request information.  The application
-    context is also implicitly created if a request context is created
-    but the application is not on top of the individual application
-    context.
+    """The app context contains application-specific information. An app
+    context is created and pushed at the beginning of each request if
+    one is not already active. An app context is also pushed when
+    running CLI commands.
     """
 
     def __init__(self, app: "Flask") -> None:
@@ -278,10 +276,10 @@ class AppContext:
 
 
 class RequestContext:
-    """The request context contains all request relevant information.  It is
-    created at the beginning of the request and pushed to the
-    `_request_ctx_stack` and removed at the end of it.  It will create the
-    URL adapter and request object for the WSGI environment provided.
+    """The request context contains per-request information. The Flask
+    app creates and pushes it at the beginning of the request, then pops
+    it at the end of the request. It will create the URL adapter and
+    request object for the WSGI environment provided.
 
     Do not attempt to use this class directly, instead use
     :meth:`~flask.Flask.test_request_context` and

--- a/src/flask/debughelpers.py
+++ b/src/flask/debughelpers.py
@@ -2,7 +2,7 @@ import typing as t
 
 from .app import Flask
 from .blueprints import Blueprint
-from .globals import _request_ctx_stack
+from .globals import request_ctx
 
 
 class UnexpectedUnicodeError(AssertionError, UnicodeError):
@@ -116,9 +116,8 @@ def explain_template_loading_attempts(app: Flask, template, attempts) -> None:
     info = [f"Locating template {template!r}:"]
     total_found = 0
     blueprint = None
-    reqctx = _request_ctx_stack.top
-    if reqctx is not None and reqctx.request.blueprint is not None:
-        blueprint = reqctx.request.blueprint
+    if request_ctx and request_ctx.request.blueprint is not None:
+        blueprint = request_ctx.request.blueprint
 
     for idx, (loader, srcobj, triple) in enumerate(attempts):
         if isinstance(srcobj, Flask):

--- a/src/flask/globals.py
+++ b/src/flask/globals.py
@@ -1,7 +1,7 @@
 import typing as t
 from contextvars import ContextVar
 
-from werkzeug.local import LocalStack
+from werkzeug.local import LocalProxy
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from .app import Flask
@@ -11,6 +11,39 @@ if t.TYPE_CHECKING:  # pragma: no cover
     from .sessions import SessionMixin
     from .wrappers import Request
 
+
+class _FakeStack:
+    def __init__(self, name: str, cv: ContextVar[t.Any]) -> None:
+        self.name = name
+        self.cv = cv
+
+    def _warn(self):
+        import warnings
+
+        warnings.warn(
+            f"'_{self.name}_ctx_stack' is deprecated and will be"
+            " removed in Flask 2.3. Use 'g' to store data, or"
+            f" '{self.name}_ctx' to access the current context.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+
+    def push(self, obj: t.Any) -> None:
+        self._warn()
+        self.cv.set(obj)
+
+    def pop(self) -> t.Any:
+        self._warn()
+        ctx = self.cv.get(None)
+        self.cv.set(None)
+        return ctx
+
+    @property
+    def top(self) -> t.Optional[t.Any]:
+        self._warn()
+        return self.cv.get(None)
+
+
 _no_app_msg = """\
 Working outside of application context.
 
@@ -18,16 +51,16 @@ This typically means that you attempted to use functionality that needed
 the current application. To solve this, set up an application context
 with app.app_context(). See the documentation for more information.\
 """
-_cv_app: ContextVar[t.List["AppContext"]] = ContextVar("flask.app_ctx")
-_app_ctx_stack: LocalStack["AppContext"] = LocalStack(_cv_app)
-app_ctx: "AppContext" = _app_ctx_stack(  # type: ignore[assignment]
-    unbound_message=_no_app_msg
+_cv_app: ContextVar["AppContext"] = ContextVar("flask.app_ctx")
+__app_ctx_stack = _FakeStack("app", _cv_app)
+app_ctx: "AppContext" = LocalProxy(  # type: ignore[assignment]
+    _cv_app, unbound_message=_no_app_msg
 )
-current_app: "Flask" = _app_ctx_stack(  # type: ignore[assignment]
-    "app", unbound_message=_no_app_msg
+current_app: "Flask" = LocalProxy(  # type: ignore[assignment]
+    _cv_app, "app", unbound_message=_no_app_msg
 )
-g: "_AppCtxGlobals" = _app_ctx_stack(  # type: ignore[assignment]
-    "g", unbound_message=_no_app_msg
+g: "_AppCtxGlobals" = LocalProxy(  # type: ignore[assignment]
+    _cv_app, "g", unbound_message=_no_app_msg
 )
 
 _no_req_msg = """\
@@ -37,14 +70,38 @@ This typically means that you attempted to use functionality that needed
 an active HTTP request. Consult the documentation on testing for
 information about how to avoid this problem.\
 """
-_cv_req: ContextVar[t.List["RequestContext"]] = ContextVar("flask.request_ctx")
-_request_ctx_stack: LocalStack["RequestContext"] = LocalStack(_cv_req)
-request_ctx: "RequestContext" = _request_ctx_stack(  # type: ignore[assignment]
-    unbound_message=_no_req_msg
+_cv_req: ContextVar["RequestContext"] = ContextVar("flask.request_ctx")
+__request_ctx_stack = _FakeStack("request", _cv_req)
+request_ctx: "RequestContext" = LocalProxy(  # type: ignore[assignment]
+    _cv_req, unbound_message=_no_req_msg
 )
-request: "Request" = _request_ctx_stack(  # type: ignore[assignment]
-    "request", unbound_message=_no_req_msg
+request: "Request" = LocalProxy(  # type: ignore[assignment]
+    _cv_req, "request", unbound_message=_no_req_msg
 )
-session: "SessionMixin" = _request_ctx_stack(  # type: ignore[assignment]
-    "session", unbound_message=_no_req_msg
+session: "SessionMixin" = LocalProxy(  # type: ignore[assignment]
+    _cv_req, "session", unbound_message=_no_req_msg
 )
+
+
+def __getattr__(name: str) -> t.Any:
+    if name == "_app_ctx_stack":
+        import warnings
+
+        warnings.warn(
+            "'_app_ctx_stack' is deprecated and will be remoevd in Flask 2.3.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return __app_ctx_stack
+
+    if name == "_request_ctx_stack":
+        import warnings
+
+        warnings.warn(
+            "'_request_ctx_stack' is deprecated and will be remoevd in Flask 2.3.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return __request_ctx_stack
+
+    raise AttributeError(name)

--- a/src/flask/globals.py
+++ b/src/flask/globals.py
@@ -1,59 +1,50 @@
 import typing as t
-from functools import partial
+from contextvars import ContextVar
 
-from werkzeug.local import LocalProxy
 from werkzeug.local import LocalStack
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from .app import Flask
     from .ctx import _AppCtxGlobals
+    from .ctx import AppContext
+    from .ctx import RequestContext
     from .sessions import SessionMixin
     from .wrappers import Request
 
-_request_ctx_err_msg = """\
-Working outside of request context.
-
-This typically means that you attempted to use functionality that needed
-an active HTTP request.  Consult the documentation on testing for
-information about how to avoid this problem.\
-"""
-_app_ctx_err_msg = """\
+_no_app_msg = """\
 Working outside of application context.
 
 This typically means that you attempted to use functionality that needed
-to interface with the current application object in some way. To solve
-this, set up an application context with app.app_context().  See the
-documentation for more information.\
+the current application. To solve this, set up an application context
+with app.app_context(). See the documentation for more information.\
 """
-
-
-def _lookup_req_object(name):
-    top = _request_ctx_stack.top
-    if top is None:
-        raise RuntimeError(_request_ctx_err_msg)
-    return getattr(top, name)
-
-
-def _lookup_app_object(name):
-    top = _app_ctx_stack.top
-    if top is None:
-        raise RuntimeError(_app_ctx_err_msg)
-    return getattr(top, name)
-
-
-def _find_app():
-    top = _app_ctx_stack.top
-    if top is None:
-        raise RuntimeError(_app_ctx_err_msg)
-    return top.app
-
-
-# context locals
-_request_ctx_stack = LocalStack()
-_app_ctx_stack = LocalStack()
-current_app: "Flask" = LocalProxy(_find_app)  # type: ignore
-request: "Request" = LocalProxy(partial(_lookup_req_object, "request"))  # type: ignore
-session: "SessionMixin" = LocalProxy(  # type: ignore
-    partial(_lookup_req_object, "session")
+_cv_app: ContextVar[t.List["AppContext"]] = ContextVar("flask.app_ctx")
+_app_ctx_stack: LocalStack["AppContext"] = LocalStack(_cv_app)
+app_ctx: "AppContext" = _app_ctx_stack(  # type: ignore[assignment]
+    unbound_message=_no_app_msg
 )
-g: "_AppCtxGlobals" = LocalProxy(partial(_lookup_app_object, "g"))  # type: ignore
+current_app: "Flask" = _app_ctx_stack(  # type: ignore[assignment]
+    "app", unbound_message=_no_app_msg
+)
+g: "_AppCtxGlobals" = _app_ctx_stack(  # type: ignore[assignment]
+    "g", unbound_message=_no_app_msg
+)
+
+_no_req_msg = """\
+Working outside of request context.
+
+This typically means that you attempted to use functionality that needed
+an active HTTP request. Consult the documentation on testing for
+information about how to avoid this problem.\
+"""
+_cv_req: ContextVar[t.List["RequestContext"]] = ContextVar("flask.request_ctx")
+_request_ctx_stack: LocalStack["RequestContext"] = LocalStack(_cv_req)
+request_ctx: "RequestContext" = _request_ctx_stack(  # type: ignore[assignment]
+    unbound_message=_no_req_msg
+)
+request: "Request" = _request_ctx_stack(  # type: ignore[assignment]
+    "request", unbound_message=_no_req_msg
+)
+session: "SessionMixin" = _request_ctx_stack(  # type: ignore[assignment]
+    "session", unbound_message=_no_req_msg
+)

--- a/src/flask/scaffold.py
+++ b/src/flask/scaffold.py
@@ -574,30 +574,27 @@ class Scaffold:
 
     @setupmethod
     def teardown_request(self, f: T_teardown) -> T_teardown:
-        """Register a function to be run at the end of each request,
-        regardless of whether there was an exception or not.  These functions
-        are executed when the request context is popped, even if not an
-        actual request was performed.
+        """Register a function to be called when the request context is
+        popped. Typically this happens at the end of each request, but
+        contexts may be pushed manually as well during testing.
 
-        Example::
+        .. code-block:: python
 
-            ctx = app.test_request_context()
-            ctx.push()
-            ...
-            ctx.pop()
+            with app.test_request_context():
+                ...
 
-        When ``ctx.pop()`` is executed in the above example, the teardown
-        functions are called just before the request context moves from the
-        stack of active contexts.  This becomes relevant if you are using
-        such constructs in tests.
+        When the ``with`` block exits (or ``ctx.pop()`` is called), the
+        teardown functions are called just before the request context is
+        made inactive.
 
-        Teardown functions must avoid raising exceptions. If
-        they execute code that might fail they
-        will have to surround the execution of that code with try/except
-        statements and log any errors.
+        When a teardown function was called because of an unhandled
+        exception it will be passed an error object. If an
+        :meth:`errorhandler` is registered, it will handle the exception
+        and the teardown will not receive it.
 
-        When a teardown function was called because of an exception it will
-        be passed an error object.
+        Teardown functions must avoid raising exceptions. If they
+        execute code that might fail they must surround that code with a
+        ``try``/``except`` block and log any errors.
 
         The return values of teardown functions are ignored.
         """

--- a/src/flask/templating.py
+++ b/src/flask/templating.py
@@ -5,8 +5,8 @@ from jinja2 import Environment as BaseEnvironment
 from jinja2 import Template
 from jinja2 import TemplateNotFound
 
-from .globals import _app_ctx_stack
-from .globals import _request_ctx_stack
+from .globals import _cv_app
+from .globals import _cv_req
 from .globals import current_app
 from .globals import request
 from .helpers import stream_with_context
@@ -22,9 +22,9 @@ def _default_template_ctx_processor() -> t.Dict[str, t.Any]:
     """Default template context processor.  Injects `request`,
     `session` and `g`.
     """
-    reqctx = _request_ctx_stack.top
-    appctx = _app_ctx_stack.top
-    rv = {}
+    appctx = _cv_app.get(None)
+    reqctx = _cv_req.get(None)
+    rv: t.Dict[str, t.Any] = {}
     if appctx is not None:
         rv["g"] = appctx.g
     if reqctx is not None:
@@ -124,7 +124,8 @@ class DispatchingJinjaLoader(BaseLoader):
         return list(result)
 
 
-def _render(template: Template, context: dict, app: "Flask") -> str:
+def _render(app: "Flask", template: Template, context: t.Dict[str, t.Any]) -> str:
+    app.update_template_context(context)
     before_render_template.send(app, template=template, context=context)
     rv = template.render(context)
     template_rendered.send(app, template=template, context=context)
@@ -135,36 +136,27 @@ def render_template(
     template_name_or_list: t.Union[str, Template, t.List[t.Union[str, Template]]],
     **context: t.Any
 ) -> str:
-    """Renders a template from the template folder with the given
-    context.
+    """Render a template by name with the given context.
 
-    :param template_name_or_list: the name of the template to be
-                                  rendered, or an iterable with template names
-                                  the first one existing will be rendered
-    :param context: the variables that should be available in the
-                    context of the template.
+    :param template_name_or_list: The name of the template to render. If
+        a list is given, the first name to exist will be rendered.
+    :param context: The variables to make available in the template.
     """
-    ctx = _app_ctx_stack.top
-    ctx.app.update_template_context(context)
-    return _render(
-        ctx.app.jinja_env.get_or_select_template(template_name_or_list),
-        context,
-        ctx.app,
-    )
+    app = current_app._get_current_object()  # type: ignore[attr-defined]
+    template = app.jinja_env.get_or_select_template(template_name_or_list)
+    return _render(app, template, context)
 
 
 def render_template_string(source: str, **context: t.Any) -> str:
-    """Renders a template from the given template source string
-    with the given context. Template variables will be autoescaped.
+    """Render a template from the given source string with the given
+    context.
 
-    :param source: the source code of the template to be
-                   rendered
-    :param context: the variables that should be available in the
-                    context of the template.
+    :param source: The source code of the template to render.
+    :param context: The variables to make available in the template.
     """
-    ctx = _app_ctx_stack.top
-    ctx.app.update_template_context(context)
-    return _render(ctx.app.jinja_env.from_string(source), context, ctx.app)
+    app = current_app._get_current_object()  # type: ignore[attr-defined]
+    template = app.jinja_env.from_string(source)
+    return _render(app, template, context)
 
 
 def _stream(

--- a/src/flask/testing.py
+++ b/src/flask/testing.py
@@ -94,11 +94,10 @@ class EnvironBuilder(werkzeug.test.EnvironBuilder):
 
 
 class FlaskClient(Client):
-    """Works like a regular Werkzeug test client but has some knowledge about
-    how Flask works to defer the cleanup of the request context stack to the
-    end of a ``with`` body when used in a ``with`` statement.  For general
-    information about how to use this class refer to
-    :class:`werkzeug.test.Client`.
+    """Works like a regular Werkzeug test client but has knowledge about
+    Flask's contexts to defer the cleanup of the request context until
+    the end of a ``with`` block. For general information about how to
+    use this class refer to :class:`werkzeug.test.Client`.
 
     .. versionchanged:: 0.12
        `app.test_client()` includes preset default environment, which can be

--- a/src/flask/testing.py
+++ b/src/flask/testing.py
@@ -163,7 +163,7 @@ class FlaskClient(Client):
             # behavior.  It's important to not use the push and pop
             # methods of the actual request context object since that would
             # mean that cleanup handlers are called
-            token = _cv_req.set(outer_reqctx)
+            token = _cv_req.set(outer_reqctx)  # type: ignore[arg-type]
             try:
                 yield sess
             finally:

--- a/src/flask/testing.py
+++ b/src/flask/testing.py
@@ -11,7 +11,7 @@ from werkzeug.urls import url_parse
 from werkzeug.wrappers import Request as BaseRequest
 
 from .cli import ScriptInfo
-from .globals import _request_ctx_stack
+from .globals import _cv_req
 from .json import dumps as json_dumps
 from .sessions import SessionMixin
 
@@ -147,7 +147,7 @@ class FlaskClient(Client):
         app = self.application
         environ_overrides = kwargs.setdefault("environ_overrides", {})
         self.cookie_jar.inject_wsgi(environ_overrides)
-        outer_reqctx = _request_ctx_stack.top
+        outer_reqctx = _cv_req.get(None)
         with app.test_request_context(*args, **kwargs) as c:
             session_interface = app.session_interface
             sess = session_interface.open_session(app, c.request)
@@ -163,11 +163,11 @@ class FlaskClient(Client):
             # behavior.  It's important to not use the push and pop
             # methods of the actual request context object since that would
             # mean that cleanup handlers are called
-            _request_ctx_stack.push(outer_reqctx)
+            token = _cv_req.set(outer_reqctx)
             try:
                 yield sess
             finally:
-                _request_ctx_stack.pop()
+                _cv_req.reset(token)
 
             resp = app.response_class()
             if not session_interface.is_null_session(sess):

--- a/tests/test_reqctx.py
+++ b/tests/test_reqctx.py
@@ -3,6 +3,7 @@ import warnings
 import pytest
 
 import flask
+from flask.globals import request_ctx
 from flask.sessions import SecureCookieSessionInterface
 from flask.sessions import SessionInterface
 
@@ -116,7 +117,7 @@ def test_context_binding(app):
         assert index() == "Hello World!"
     with app.test_request_context("/meh"):
         assert meh() == "http://localhost/meh"
-    assert flask._request_ctx_stack.top is None
+    assert not flask.request
 
 
 def test_context_test(app):
@@ -152,7 +153,7 @@ class TestGreenletContextCopying:
         @app.route("/")
         def index():
             flask.session["fizz"] = "buzz"
-            reqctx = flask._request_ctx_stack.top.copy()
+            reqctx = request_ctx.copy()
 
             def g():
                 assert not flask.request

--- a/tests/test_session_interface.py
+++ b/tests/test_session_interface.py
@@ -1,4 +1,5 @@
 import flask
+from flask.globals import request_ctx
 from flask.sessions import SessionInterface
 
 
@@ -13,7 +14,7 @@ def test_open_session_with_endpoint():
             pass
 
         def open_session(self, app, request):
-            flask._request_ctx_stack.top.match_request()
+            request_ctx.match_request()
             assert request.endpoint is not None
 
     app = flask.Flask(__name__)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -5,6 +5,7 @@ import werkzeug
 import flask
 from flask import appcontext_popped
 from flask.cli import ScriptInfo
+from flask.globals import _cv_req
 from flask.json import jsonify
 from flask.testing import EnvironBuilder
 from flask.testing import FlaskCliRunner
@@ -399,4 +400,4 @@ def test_client_pop_all_preserved(app, req_ctx, client):
     # close the response, releasing the context held by stream_with_context
     rv.close()
     # only req_ctx fixture should still be pushed
-    assert flask._request_ctx_stack.top is req_ctx
+    assert _cv_req.get(None) is req_ctx


### PR DESCRIPTION
While investigating `ContextVar` in https://github.com/pallets/werkzeug/pull/2436, I realized that there's no reason to use a `LocalStack` now to manage `RequestContext` and `AppContext`.

`LocalStack` incurs some performance and memory overhead on every `push` and `pop` because it uses a mutable list as the value of the `ContextVar`. Since we can never know if this context was copied by `asyncio` or asgiref into a child context, we always have to copy the list before mutating it, then set it again, otherwise mutations would be unsafe.

`RequestContext` and `AppContext` already have their own internal thread-unsafe state to track how many times they've been pushed, and implicit app contexts for request contexts.

Now, the contexts keep an internal stack of `contextvars.Token` objects, appending a new token when pushed. This allows resetting the context var to the previous value when the context is popped. Essentially, this makes the contexts singly-linked lists instead of stacks.

This does mean that `_app_ctx_stack.top` and `_request_ctx_stack.top` will no longer exist. Currently, there is a fake object that keeps the API around, since it's used by extensions to store state. However, importing them or accessing them will show deprecation warnings. Docs now encourage using `g` instead of the internal contexts for extension state. I added `app_ctx` and `request_ctx` objects that are proxies to the current objects, in case existing extensions want a less drastic change.

This bumps the minimum version of Werkzeug to 2.2 (currently 2.2.0a1) to take advantage of changes to its implementation of `LocalProxy`.