### PR TITLE
Small grammatical suggestion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -236,7 +236,7 @@ Released 2021-05-21
     the endpoint name. :issue:`4041`
 -   Combine URL prefixes when nesting blueprints that were created with
     a ``url_prefix`` value. :issue:`4037`
--   Roll back a change to the order that URL matching was done. The
+-   Revert a change to the order that URL matching was done. The
     URL is again matched after the session is loaded, so the session is
     available in custom URL converters. :issue:`4053`
 -   Re-add deprecated ``Config.from_json``, which was accidentally


### PR DESCRIPTION
It is a small suggestion, in other places in the documentation `Revert` is used to mean that a change was undone, this suggestion is intended to keep the same line of terms.