### PR TITLE
Allow TypedDict as a ResponseValue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,8 @@ Unreleased
 
 -   Allow returning a list from a view function, to convert it to a
     JSON response like a dict is. :issue:`4672`
+-   When type checking, allow ``TypedDict`` to be returned from view
+    functions. :pr:`4695`
 
 
 Version 2.1.3

--- a/src/flask/typing.py
+++ b/src/flask/typing.py
@@ -11,7 +11,8 @@ ResponseValue = t.Union[
     str,
     bytes,
     t.List[t.Any],
-    t.Dict[str, t.Any],
+    # Only dict is actually accepted, but Mapping allows for TypedDict.
+    t.Mapping[str, t.Any],
     t.Iterator[str],
     t.Iterator[bytes],
 ]

--- a/tests/typing/typing_route.py
+++ b/tests/typing/typing_route.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import typing as t
 from http import HTTPStatus
 
+import typing_extensions as te
+
 from flask import Flask
 from flask import jsonify
 from flask import stream_template
@@ -36,6 +38,15 @@ def hello_json_dict() -> t.Dict[str, t.Any]:
 @app.route("/json/dict")
 def hello_json_list() -> t.List[t.Any]:
     return [{"message": "Hello"}, {"message": "World"}]
+
+
+class StatusJSON(te.TypedDict):
+    status: str
+
+
+@app.route("/typed-dict")
+def typed_dict() -> StatusJSON:
+    return {"status": "ok"}
 
 
 @app.route("/generator")


### PR DESCRIPTION
When using a `TypedDict` as the return type for a route, this is rejected by mypy with the following error:

```
class ExampleDict(TypedDict):
    status: str

@blueprint.route("/example")
def example() -> ExampleDict:
    return {"status": "ok"}

# error: Value of type variable "ft.RouteDecorator" of function cannot be "Callable[[str], ExampleDict]"  [type-var]
```

The problem first appeared in 2.1.3 due to #4579, which changed the route decorator's callable to `ViewCallable`, which requires the return type to be `ResponseValue`. `ResponseValue` is a union that already includes `dict[str, Any]`, however it does not include `TypedDict`, which would behave the same as `dict[str, Any]` at runtime.

This PR adds `TypedDict` to the `ResponseValue` union.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
