### PR TITLE
Support calling with_appcontext decorator with parenthesis

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -95,6 +95,8 @@ Unreleased
     functions. :pr:`4695`
 -   It is now possible to also call ``@with_appcontext`` decorator
     with parenthesis, to have additional parity with Quart.
+-   The ``@with_appcontext`` decorator decorator has type hints.
+
 
 Version 2.1.3
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,7 +93,8 @@ Unreleased
     JSON response like a dict is. :issue:`4672`
 -   When type checking, allow ``TypedDict`` to be returned from view
     functions. :pr:`4695`
-
+-   It is now possible to also call ``@with_appcontext`` decorator
+    with parenthesis, to have additional parity with Quart.
 
 Version 2.1.3
 -------------

--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -408,7 +408,7 @@ class ScriptInfo:
 pass_script_info = click.make_pass_decorator(ScriptInfo, ensure=True)
 
 
-def with_appcontext(f):
+def with_appcontext(f=None):
     """Wraps a callback so that it's guaranteed to be executed with the
     script's application context.
 
@@ -417,10 +417,17 @@ def with_appcontext(f):
     decorator is not required in that case.
 
     .. versionchanged:: 2.2
+        It is now also possible to call the decorator with parenthesis.
+
+    .. versionchanged:: 2.2
         The app context is active for subcommands as well as the
         decorated callback. The app context is always available to
         ``app.cli`` command and parameter callbacks.
     """
+
+    # Decorator was used with parenthesis
+    if f is None:
+        return with_appcontext
 
     @click.pass_context
     def decorator(__ctx, *args, **kwargs):

--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -408,7 +408,7 @@ class ScriptInfo:
 pass_script_info = click.make_pass_decorator(ScriptInfo, ensure=True)
 
 
-def with_appcontext(f=None):
+def with_appcontext(f: t.Optional[t.Callable] = None) -> t.Callable:
     """Wraps a callback so that it's guaranteed to be executed with the
     script's application context.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -341,6 +341,19 @@ def test_with_appcontext(runner):
     assert result.output == "testapp\n"
 
 
+def test_with_appcontext_parenthesis(runner):
+    @click.command()
+    @with_appcontext()
+    def testcmd():
+        click.echo(current_app.name)
+
+    obj = ScriptInfo(create_app=lambda: Flask("testapp"))
+
+    result = runner.invoke(testcmd, obj=obj)
+    assert result.exit_code == 0
+    assert result.output == "testapp\n"
+
+
 def test_appgroup_app_context(runner):
     @click.group(cls=AppGroup)
     def cli():


### PR DESCRIPTION
I've added type hints for the `with_appcontext` decorator. This fixes mypy error "Untyped decorator makes function untyped" for otherwise-typed function that uses this decorator. Although explicit `with_appcontext` is probably not needed in most cases as of #4647, I think it would still make sense if it's typed.

I also included a small change to allow calling `with_appcontext` with parenthesis, because the same [is possible](https://github.com/pallets/quart/blob/main/src/quart/cli.py#L271-L273) in Quart.

If possible, it would be nice if added type hints could be backported to 2.1, so I don't have to wait for 2.2 to fix mypy issues.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
