### PR TITLE
#378 explictly set charset for jsonify()

### DIFF
--- a/src/flask/json/provider.py
+++ b/src/flask/json/provider.py
@@ -163,7 +163,7 @@ class DefaultJSONProvider(JSONProvider):
     or ``None`` in debug mode, it will use a non-compact representation.
     """
 
-    mimetype = "application/json"
+    mimetype = "application/json; charset=utf-8"
     """The mimetype set in :meth:`response`."""
 
     def dumps(self, obj: t.Any, **kwargs: t.Any) -> str:


### PR DESCRIPTION
https://webhint.io/docs/user-guide/hints/hint-content-type/ reference for best practice

Without this Microsoft Edge devtools post a warning

https://github.com/pallets/flask/issues/378 appears to be the first report (but was also possibly caused by bad payload).

- fixes #378 

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.

Opening as a place holder. I don't have time to setup a dev environment and create a new test for this.