### PR TITLE
require werkzeug >= 2.2.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@ Version 2.2.2
 
 Unreleased
 
+-   Update Werkzeug dependency to >= 2.2.2. This includes fixes related
+    to the new faster router, header parsing, and the development
+    server. :pr:`4754`
 -   Fix the default value for ``app.env`` to be ``"production"``. This
     attribute remains deprecated. :issue:`4740`
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name="Flask",
     install_requires=[
-        "Werkzeug >= 2.2.0",
+        "Werkzeug >= 2.2.2",
         "Jinja2 >= 3.0",
         "itsdangerous >= 2.0",
         "click >= 8.0",

--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -719,13 +719,6 @@ def show_server_banner(debug, app_import_path):
     if is_running_from_reloader():
         return
 
-    click.secho(
-        "WARNING: This is a development server. Do not use it in a production"
-        " deployment. Use a production WSGI server instead.",
-        fg="red",
-        bold=True,
-    )
-
     if app_import_path is not None:
         click.echo(f" * Serving Flask app '{app_import_path}'")
 


### PR DESCRIPTION
A few important fixes to the correctness of Werkzeug's new faster router were released, so since we're releasing a fix release for Flask we'll include Werkzeug as well.

This also removes the development server warnings, since Werkzeug always shows it now; it would show twice otherwise.