### PR TITLE
Removed checks of useless keys by the property of sorted elements

### DIFF
--- a/src/flask/config.py
+++ b/src/flask/config.py
@@ -127,10 +127,16 @@ class Config(dict):
         prefix = f"{prefix}_"
         len_prefix = len(prefix)
 
+        variables = list()
+        is_found = False
         for key in sorted(os.environ):
-            if not key.startswith(prefix):
-                continue
+            if key.startswith(prefix):
+                is_found = True
+                variables.append(key)
+            elif is_found:
+                break
 
+        for key in variables:
             value = os.environ[key]
 
             try:


### PR DESCRIPTION
The function "from_prefixed_env" finds all words with the concrete prefix (by default "FLASK_"). The description of the function has the important condition: all keys are loaded in **sorted** order. Sorted order guarantees that all keys with needed prefix are consecutive (trivial statement). So, the function can use this property to reduce the number of operations.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
