### PR TITLE
Correct `waitress-serve` command

### DIFF
--- a/docs/deploying/waitress.rst
+++ b/docs/deploying/waitress.rst
@@ -45,10 +45,10 @@ pattern, use ``--call {module}:{factory}`` instead.
 .. code-block:: text
 
     # equivalent to 'from hello import app'
-    $ waitress-serve hello:app --host 127.0.0.1
+    $ waitress-serve --host 127.0.0.1 hello:app
 
     # equivalent to 'from hello import create_app; create_app()'
-    $ waitress-serve --call hello:create_app --host 127.0.0.1
+    $ waitress-serve --host 127.0.0.1 --call hello:create_app
 
     Serving on http://127.0.0.1:8080
 


### PR DESCRIPTION
Fix the `waitress-serve` command on the docs.
https://flask.palletsprojects.com/en/2.2.x/deploying/waitress/
`waitress-serve main:app --host 127.0.0.1` doesn't work due to options needing to come before specifying `main:app`

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #4771