### PR TITLE
Improve the description of flask run command

### DIFF
--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -890,8 +890,8 @@ def run_command(
     This server is for development purposes only. It does not provide
     the stability, security, or performance of production WSGI servers.
 
-    The reloader and debugger are enabled by default with the '--debug'
-    option.
+    The reloader and debugger are enabled by default with the 'flask --debug'
+    option (i.e. 'flask --debug run').
     """
     try:
         app = info.load_app()


### PR DESCRIPTION
Point out that the `--debug` option belongs to `flask` instead of `flask run`.

- fixes #4777

Maybe we could add a separate `--debug` to `flask run` since it's common to use `--debug` with `run` (see #4779).