### PR TITLE
Fix misrendered docstring

### DIFF
--- a/src/flask/config.py
+++ b/src/flask/config.py
@@ -275,8 +275,9 @@ class Config(dict):
     def from_mapping(
         self, mapping: t.Optional[t.Mapping[str, t.Any]] = None, **kwargs: t.Any
     ) -> bool:
-        """Updates the config like :meth:`update` ignoring items with non-upper
-        keys.
+        """Updates the config like :meth:`update` ignoring items with
+        non-upper keys.
+
         :return: Always returns ``True``.
 
         .. versionadded:: 0.11


### PR DESCRIPTION
The API reference for [flask.Config.from_mapping](https://flask.palletsprojects.com/en/2.2.x/api/#flask.Config.from_mapping) needs a newline to separate the summary from the return description.  I also wrapped the docstring at 72 characters as suggested in CONTRIBUTING.rst.

