### PR TITLE
Remove `zip_safe` from install.rst documentation

### DIFF
--- a/docs/tutorial/install.rst
+++ b/docs/tutorial/install.rst
@@ -41,7 +41,6 @@ to it.
         version='1.0.0',
         packages=find_packages(),
         include_package_data=True,
-        zip_safe=False,
         install_requires=[
             'flask',
         ],


### PR DESCRIPTION
`zip_safe` is obsolete per:
https://setuptools.pypa.io/en/latest/deprecated/zip_safe.html

In summary:
> It is very unlikely that the values of zip_safe will affect modern deployments that use pip for installing packages. Moreover, new users of setuptools should not attempt to create egg files using the deprecated build_egg command. Therefore, this flag is considered obsolete.

Checklist:

- [X] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [X] Run `pre-commit` hooks and fix any issues.
- [X] Run `pytest` and `tox`, no tests failed.
