### PR TITLE
fix: remove obsolete `zip_safe`

### DIFF
--- a/docs/tutorial/install.rst
+++ b/docs/tutorial/install.rst
@@ -41,7 +41,6 @@ to it.
         version='1.0.0',
         packages=find_packages(),
         include_package_data=True,
-        zip_safe=False,
         install_requires=[
             'flask',
         ],


### PR DESCRIPTION
X-Ref: #4782

The only other `zip_safe` reference foundin the current codebase from doing a case insensitive search was:
https://github.com/pallets/flask/blob/main/tests/conftest.py#L159

Which is used here:
https://github.com/pallets/flask/blob/main/tests/test_instance_config.py#L116