### PR TITLE
Close p tag in templateinheritance docs

### DIFF
--- a/docs/patterns/templateinheritance.rst
+++ b/docs/patterns/templateinheritance.rst
@@ -59,6 +59,7 @@ A child template might look like this:
       <h1>Index</h1>
       <p class="important">
         Welcome on my awesome homepage.
+      </p>
     {% endblock %}
 
 The ``{% extends %}`` tag is the key here. It tells the template engine that


### PR DESCRIPTION
I noticed this when going through the docs.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->



<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

