### PR TITLE
Add missing .dev to version

### DIFF
--- a/src/flask/__init__.py
+++ b/src/flask/__init__.py
@@ -42,7 +42,7 @@ from .templating import render_template_string as render_template_string
 from .templating import stream_template as stream_template
 from .templating import stream_template_string as stream_template_string
 
-__version__ = "2.2.3"
+__version__ = "2.2.3.dev"
 
 
 def __getattr__(name):


### PR DESCRIPTION
This issue was causing many dead github links on the docs, not just the one listed in the linked issue. 

In the file [/src/flask/__init__.py](https://github.com/pallets/flask/commit/212b72a1feeae69739fb50fc5ab11d1c025350bc#diff-5f8053fe4e0b6f1e107e49fef04a4f71a8b2a0c2c3f4f0d4dfb87482219c3b47), `__version__ = "2.2.3"` did not have `.dev` at the end. This caused the github links in the docs to link to files beginning with **/flask/tree/2.2.3/** which do not exist yet. The addition of `.dev` changes the github links to **2.2.2** in the docs.

- fixes #4791

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
