### PR TITLE
add a `reset_blueprint` method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Unreleased
 Version 2.2.3
 -------------
 
-Unreleased
+-   Added reset_blueprint method to prevent error and warning when using test-scoped app fixtures :issue:`#4786`
 
 
 Version 2.2.2

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -472,6 +472,8 @@ class Blueprint(Scaffold):
     def reset_blueprint(self):
         """Resets this blueprint. Clears registered child blueprints and
         set _got_registered_once flag to False
+
+        .. versionchanged:: 2.2.3
         """
         self._blueprints = []
         self._got_registered_once = False

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -469,6 +469,13 @@ class Blueprint(Scaffold):
             bp_options["name_prefix"] = name
             blueprint.register(app, bp_options)
 
+    def reset_blueprint(self):
+        """Resets this blueprint. Clears registered child blueprints and
+        set _got_registered_once flag to False
+        """
+        self._blueprints = []
+        self._got_registered_once = False
+
     @setupmethod
     def add_url_rule(
         self,

--- a/tests/test_nested_blueprints.py
+++ b/tests/test_nested_blueprints.py
@@ -1,0 +1,30 @@
+import pytest
+
+from flask import Blueprint
+from flask import Flask
+
+parent = Blueprint("parent", __name__)
+child = Blueprint("child", __name__)
+
+
+def create_app():
+    app = Flask(__name__)
+    parent.register_blueprint(child, url_prefix="/child")
+    app.register_blueprint(parent, url_prefix="/parent")
+
+    return app
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    yield app
+    parent.reset_blueprint()
+
+
+def test_1(app):
+    pass
+
+
+def test_2(app):
+    pass


### PR DESCRIPTION
Added `reset_blueprint` method to the `Blueprint` class. This method re-init the `_blueprints` list as an empty list and sets the `_got_registered_once` flag to False

- fixes #4786

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
