### PR TITLE
Fix argument in `register_api()` in docs/view.rst

### DIFF
--- a/docs/views.rst
+++ b/docs/views.rst
@@ -297,7 +297,7 @@ provide get (list) and post (create) methods.
             db.session.commit()
             return jsonify(item.to_json())
 
-    def register_api(app, model, url):
+    def register_api(app, model, name):
         item = ItemAPI.as_view(f"{name}-item", model)
         group = GroupAPI.as_view(f"{name}-group", model)
         app.add_url_rule(f"/{name}/<int:id>", view_func=item)


### PR DESCRIPTION
An example in `docs/views.rst` has incorrect argument name, which may be confusing.
The pull-request fixes the example.