### PR TITLE
fix typo in quickstart

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -359,7 +359,7 @@ the application secure.  Because of that Flask configures the `Jinja2
 
 Templates can be used to generate any type of text file. For web applications, you'll
 primarily be generating HTML pages, but you can also generate markdown, plain text for
-emails, any anything else.
+emails, and anything else.
 
 For a reference to HTML, CSS, and other web APIs, use the `MDN Web Docs`_.
 


### PR DESCRIPTION
I yoinked the default pull request template because this is just a very small documentation change.