### PR TITLE
Fix subdomain inheritance for nested blueprints.

### DIFF
--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -453,6 +453,15 @@ class Blueprint(Scaffold):
         for blueprint, bp_options in self._blueprints:
             bp_options = bp_options.copy()
             bp_url_prefix = bp_options.get("url_prefix")
+            bp_subdomain = bp_options.get("subdomain")
+
+            if bp_subdomain is None:
+                bp_subdomain = blueprint.subdomain
+
+            if state.subdomain is not None and bp_subdomain is None:
+                bp_options["subdomain"] = state.subdomain
+            elif bp_subdomain is not None:
+                bp_options["subdomain"] = bp_subdomain
 
             if bp_url_prefix is None:
                 bp_url_prefix = blueprint.url_prefix

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -950,6 +950,53 @@ def test_nesting_url_prefixes(
     assert response.status_code == 200
 
 
+def test_nesting_subdomains(app, client) -> None:
+    subdomain = "api"
+    parent = flask.Blueprint("parent", __name__)
+    child = flask.Blueprint("child", __name__)
+
+    @child.route("/child/")
+    def index():
+        return "child"
+
+    parent.register_blueprint(child)
+    app.register_blueprint(parent, subdomain=subdomain)
+
+    client.allow_subdomain_redirects = True
+
+    domain_name = "domain.tld"
+    app.config["SERVER_NAME"] = domain_name
+    response = client.get("/child/", base_url="http://api." + domain_name)
+
+    assert response.status_code == 200
+
+
+def test_child_overrides_parent_subdomain(app, client) -> None:
+    child_subdomain = "api"
+    parent_subdomain = "parent"
+    parent = flask.Blueprint("parent", __name__)
+    child = flask.Blueprint("child", __name__, subdomain=child_subdomain)
+
+    @child.route("/")
+    def index():
+        return "child"
+
+    parent.register_blueprint(child)
+    app.register_blueprint(parent, subdomain=parent_subdomain)
+
+    client.allow_subdomain_redirects = True
+
+    domain_name = "domain.tld"
+    app.config["SERVER_NAME"] = domain_name
+    response = client.get("/", base_url=f"http://{child_subdomain}.{domain_name}")
+
+    assert response.status_code == 200
+
+    response = client.get("/", base_url=f"http://{parent_subdomain}.{domain_name}")
+
+    assert response.status_code == 404
+
+
 def test_unique_blueprint_names(app, client) -> None:
     bp = flask.Blueprint("bp", __name__)
     bp2 = flask.Blueprint("bp", __name__)


### PR DESCRIPTION
When child blueprints are mounted onto parents, they don't inherit the subdomain set by the parent.

This PR ensures that routes in child blueprint will be available at the same subdomain set by the parent.

However, children can also specify their own subdomain if necessary.

- fixes #4834

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.