### PR TITLE
Fix backstick not rendering.

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -47,7 +47,7 @@ Debug Mode
 
 The :data:`DEBUG` config value is special because it may behave inconsistently if
 changed after the app has begun setting up. In order to set debug mode reliably, use the
-``--debug`` option on the ``flask`` command.``flask run`` will use the interactive
+``--debug`` option on the ``flask`` command. ``flask run`` will use the interactive
 debugger and reloader by default in debug mode.
 
 .. code-block:: text


### PR DESCRIPTION
Added space before backtick to render command highlighting.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
