### PR TITLE
Matching data types of Static_folder & template_folder

### DIFF
--- a/src/flask/scaffold.py
+++ b/src/flask/scaffold.py
@@ -255,8 +255,9 @@ class Scaffold:
     @static_folder.setter
     def static_folder(self, value: t.Optional[t.Union[str, os.PathLike]]) -> None:
         if value is not None:
-            value = os.fspath(value).rstrip(r"\/")
-
+            value = os.fspath(value).rstrip(r"\/")    
+            
+        # Static folder is a string
         self._static_folder = value
 
     @property
@@ -341,7 +342,7 @@ class Scaffold:
         .. versionadded:: 0.5
         """
         if self.template_folder is not None:
-            return FileSystemLoader(os.path.join(self.root_path, self.template_folder))
+            return str(FileSystemLoader(os.path.join(self.root_path, self.template_folder)))
         else:
             return None
 


### PR DESCRIPTION
template folder is an optional input for the flask object so to maintain similarity in inputs like Static_folder & template_folder, converted the output into string

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #<issue number>

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
