### PR TITLE
Update api.rst

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -248,7 +248,7 @@ HTML ``<script>`` tags.
 .. sourcecode:: html+jinja
 
     <script>
-        const names = {{ names|tosjon }};
+        const names = {{ names|tojson }};
         renderChart(names, {{ axis_data|tojson }});
     </script>
 


### PR DESCRIPTION
Corrected typo in "tojson" example, `const names = {{ names|tojson }};` was `const names = {{ names|tosjon }};`

- fixes #4906 

Checklist:
- only `api.rst` was changed, checklist not required.