### PR TITLE
Ignore style check for zip strict flag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -80,6 +80,8 @@ ignore =
     E722
     # bin op line break, invalid
     W503
+    # zip strict flag, requires Python 3.10
+    B905
 # up to 88 allowed by bugbear B950
 max-line-length = 80
 per-file-ignores =


### PR DESCRIPTION
An alternative of #4917.
