### PR TITLE
Fix URL "committing as you go"

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -171,7 +171,7 @@ Start coding
 
         $ git push --set-upstream fork your-branch-name
 
-.. _committing as you go: https://dont-be-afraid-to-commit.readthedocs.io/en/latest/git/commandlinegit.html#commit-your-changes
+.. _committing as you go: https://afraid-to-commit.readthedocs.io/en/latest/git/commandlinegit.html#commit-your-changes
 .. _create a pull request: https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request
 
 


### PR DESCRIPTION
This PR fixes URL ``committing as you go`` in ``CONTRIBUTING.rst``.
The old URL points to a non-existing page.

I am not sure whether the updated URL represents the same resource,
but it seems this way according to the way the URL looks.
