### PR TITLE
Allow pathlib.Path for template_folder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 2.2.3
 
 Unreleased
 
+-   Fix the type of ``template_folder`` to accept ``pathlib.Path``. :issue:`4892`
+
 
 Version 2.2.2
 -------------

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -558,7 +558,7 @@ class Flask(Scaffold):
         static_host: t.Optional[str] = None,
         host_matching: bool = False,
         subdomain_matching: bool = False,
-        template_folder: t.Optional[str] = "templates",
+        template_folder: t.Optional[t.Union[str, os.PathLike]] = "templates",
         instance_path: t.Optional[str] = None,
         instance_relative_config: bool = False,
         root_path: t.Optional[str] = None,

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -250,7 +250,7 @@ class Blueprint(Scaffold):
         import_name: str,
         static_folder: t.Optional[t.Union[str, os.PathLike]] = None,
         static_url_path: t.Optional[str] = None,
-        template_folder: t.Optional[str] = None,
+        template_folder: t.Optional[t.Union[str, os.PathLike]] = None,
         url_prefix: t.Optional[str] = None,
         subdomain: t.Optional[str] = None,
         url_defaults: t.Optional[dict] = None,

--- a/src/flask/scaffold.py
+++ b/src/flask/scaffold.py
@@ -93,7 +93,7 @@ class Scaffold:
         import_name: str,
         static_folder: t.Optional[t.Union[str, os.PathLike]] = None,
         static_url_path: t.Optional[str] = None,
-        template_folder: t.Optional[str] = None,
+        template_folder: t.Optional[t.Union[str, os.PathLike]] = None,
         root_path: t.Optional[str] = None,
     ):
         #: The name of the package or module that this object belongs


### PR DESCRIPTION
This PR allows ``template_folder`` argument to be a ``pathlib.Path`` object.

- fixes #4892

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.

I added a new test, which ensures that ``template_folder`` can be ``pathlib.Path`` object.
However, when I added this tests, it was already successful.
I noticed that there are no similar tests of this kind in regards to ``template_folder``.

I suppose that the issue referenced is related to typing only, because according to the successful test, one can use this out of the box, and there is no need to convert it into a str object.
``` python
app = Flask(
    __name__,
    template_folder=pathlib.Path("templates"),
)
```