### PR TITLE
Clarify the docstring for `View.as_view`.

### DIFF
--- a/src/flask/views.py
+++ b/src/flask/views.py
@@ -92,8 +92,8 @@ class View:
         :attr:`init_every_request` to ``False``, the same instance will
         be used for every request.
 
-        The arguments passed to this method are forwarded to the view
-        class ``__init__`` method.
+        Except for ``name``, all other arguments passed to this method
+        are forwarded to the view class ``__init__`` method.
 
         .. versionchanged:: 2.2
             Added the ``init_every_request`` class attribute.


### PR DESCRIPTION
Clarify which arguments `as_view` forwards to `__init__`.