### PR TITLE
improving test_cli by adding test_enable_dotenv_from_env tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -562,6 +562,30 @@ def test_disable_dotenv_from_env(monkeypatch, runner):
     assert "FOO" not in os.environ
 
 
+@need_dotenv
+def test_enable_dotenv_from_env_zero(monkeypatch, runner):
+    monkeypatch.chdir(test_path)
+    monkeypatch.setitem(os.environ, "FLASK_SKIP_DOTENV", "0")
+    runner.invoke(FlaskGroup())
+    assert "FOO" in os.environ
+
+
+@need_dotenv
+def test_enable_dotenv_from_env_false(monkeypatch, runner):
+    monkeypatch.chdir(test_path)
+    monkeypatch.setitem(os.environ, "FLASK_SKIP_DOTENV", "FALSE")
+    runner.invoke(FlaskGroup())
+    assert "FOO" in os.environ
+
+
+@need_dotenv
+def test_enable_dotenv_from_env_no(monkeypatch, runner):
+    monkeypatch.chdir(test_path)
+    monkeypatch.setitem(os.environ, "FLASK_SKIP_DOTENV", "NO")
+    runner.invoke(FlaskGroup())
+    assert "FOO" in os.environ
+
+
 def test_run_cert_path():
     # no key
     with pytest.raises(click.BadParameter):


### PR DESCRIPTION
Improved `test_cli` with cases to enable dotenv from env (with the envvar `FLASK_SKIP_DOTENV`), which is currently untested.

We can enable dotenv from env with three values: "0", "false", or "no".
See: https://github.com/pallets/flask/blob/main/src/flask/helpers.py#L81


Thus, this PR creates three tests:

- test_enable_dotenv_from_env_zero
- test_enable_dotenv_from_env_false
- test_enable_dotenv_from_env_no

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
