### PR TITLE
Fix command-line formatting

### DIFF
--- a/docs/patterns/packages.rst
+++ b/docs/patterns/packages.rst
@@ -66,6 +66,8 @@ To use the ``flask`` command and run your application you need to set
 the ``--app`` option that tells Flask where to find the application
 instance:
 
+.. code-block:: text
+
     $ flask --app yourapplication run
 
 What did we gain from this?  Now we can restructure the application a bit


### PR DESCRIPTION
Fix formatting for a bash command in ``docs/patterns/packages.rst``.