### PR TITLE
fix for #4982

### DIFF
--- a/examples/tutorial/flaskr/__init__.py
+++ b/examples/tutorial/flaskr/__init__.py
@@ -6,16 +6,19 @@ from flask import Flask
 def create_app(test_config=None):
     """Create and configure an instance of the Flask application."""
     app = Flask(__name__, instance_relative_config=True)
-    app.config.from_mapping(
-        # a default secret that should be overridden by instance config
-        SECRET_KEY="dev",
-        # store the database in the instance folder
-        DATABASE=os.path.join(app.instance_path, "flaskr.sqlite"),
-    )
 
     if test_config is None:
         # load the instance config, if it exists, when not testing
-        app.config.from_pyfile("config.py", silent=True)
+        if os.path.isfile("config.py"):
+            app.config.from_pyfile("config.py", silent=True)
+        else:
+            app.config.from_mapping(
+                # a default secret that should be overridden by instance config
+                SECRET_KEY="dev",
+                # store the database in the instance folder
+                DATABASE=os.path.join(app.instance_path, "flaskr.sqlite"),
+            )
+
     else:
         # load the test config if passed in
         app.config.update(test_config)


### PR DESCRIPTION
update to create_app - if using environment variables for SECRET_KEY testing is broken when it is outside like originally suggested

This moves the `app.config.from_mapping()` only into the section where it checks if `test_config` exists.

- fixes #4982

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
