### PR TITLE
deprecate `got_first_request`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Unreleased
 
 -   Importing ``escape`` and ``Markup`` from ``flask`` is deprecated. Import them
     directly from ``markupsafe`` instead. :pr:`4996`
+-   The ``app.got_first_request`` property is deprecated. :pr:`4997`
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
     :pr:`4947`
 -   Ensure subdomains are applied with nested blueprints. :issue:`4834`

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Unreleased
     -   ``json_encoder`` and ``json_decoder`` attributes on app and blueprint, and the
         corresponding ``json.JSONEncoder`` and ``JSONDecoder`` classes, are removed.
     -   The ``json.htmlsafe_dumps`` and ``htmlsafe_dump`` functions are removed.
+    -   Calling setup methods on blueprints after registration is an error instead of a
+        warning. :pr:`4997`
 
 -   Importing ``escape`` and ``Markup`` from ``flask`` is deprecated. Import them
     directly from ``markupsafe`` instead. :pr:`4996`

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -8,7 +8,6 @@ import weakref
 from collections.abc import Iterator as _abc_Iterator
 from datetime import timedelta
 from itertools import chain
-from threading import Lock
 from types import TracebackType
 
 import click
@@ -496,7 +495,6 @@ class Flask(Scaffold):
         # tracks internally if the application already handled at least one
         # request.
         self._got_first_request = False
-        self._before_request_lock = Lock()
 
         # Add a static route using the provided static_url_path, static_host,
         # and static_folder if there is a configured static_folder.
@@ -592,8 +590,18 @@ class Flask(Scaffold):
         """This attribute is set to ``True`` if the application started
         handling the first request.
 
+        .. deprecated:: 2.3
+            Will be removed in Flask 2.4.
+
         .. versionadded:: 0.8
         """
+        import warnings
+
+        warnings.warn(
+            "'got_first_request' is deprecated and will be removed in Flask 2.4.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._got_first_request
 
     def make_config(self, instance_relative: bool = False) -> Config:

--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -207,19 +207,12 @@ class Blueprint(Scaffold):
 
     def _check_setup_finished(self, f_name: str) -> None:
         if self._got_registered_once:
-            import warnings
-
-            warnings.warn(
-                f"The setup method '{f_name}' can no longer be called on"
-                f" the blueprint '{self.name}'. It has already been"
-                " registered at least once, any changes will not be"
-                " applied consistently.\n"
-                "Make sure all imports, decorators, functions, etc."
-                " needed to set up the blueprint are done before"
-                " registering it.\n"
-                "This warning will become an exception in Flask 2.3.",
-                UserWarning,
-                stacklevel=3,
+            raise AssertionError(
+                f"The setup method '{f_name}' can no longer be called on the blueprint"
+                f" '{self.name}'. It has already been registered at least once, any"
+                " changes will not be applied consistently.\n"
+                "Make sure all imports, decorators, functions, etc. needed to set up"
+                " the blueprint are done before registering it."
             )
 
     @setupmethod

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1657,7 +1657,6 @@ def test_no_setup_after_first_request(app, client):
     def index():
         return "Awesome"
 
-    assert not app.got_first_request
     assert client.get("/").data == b"Awesome"
 
     with pytest.raises(AssertionError) as exc_info:


### PR DESCRIPTION
This property was missed when deprecating `before_first_request`.

Also make calling setup methods on registered blueprints an error instead of a warning, as was described in the previous warning.