### PR TITLE
updating sentry links for error handling

### DIFF
--- a/docs/errorhandling.rst
+++ b/docs/errorhandling.rst
@@ -68,8 +68,7 @@ See also:
 
 -   Sentry also supports catching errors from a worker queue
     (RQ, Celery, etc.) in a similar fashion. See the `Python SDK docs
-    <https://docs.sentry.io/platforms/python/>`__ for more information.
--   `Getting started with Sentry <https://docs.sentry.io/quickstart/?platform=python>`__
+    <https://docs.sentry.io/platforms/#:~:text=Symfony-,Python,-AIOHTTP>`__ for more information.
 -   `Flask-specific documentation <https://docs.sentry.io/platforms/python/guides/flask/>`__
 
 


### PR DESCRIPTION
Minor docs fixes for Sentry links. Not sure full checklist applies, happy to open an issue

- update 1 link to direct to the python relevant integration 
- remove one which was not linking anywhere unique

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #<issue number>

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [NA] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [NA] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
