### PR TITLE
Appending missing parentheses

### DIFF
--- a/docs/deploying/eventlet.rst
+++ b/docs/deploying/eventlet.rst
@@ -54,7 +54,7 @@ its ``wsgi.server``, as well as your app or app factory.
     from hello import create_app
 
     app = create_app()
-    wsgi.server(eventlet.listen(("127.0.0.1", 8000), app)
+    wsgi.server(eventlet.listen(("127.0.0.1", 8000)), app)
 
 .. code-block:: text
 


### PR DESCRIPTION
When trying multiple different WSGIs, I noticed that Flasks example code for running `eventlet` did not run. I added the missing parentheses.

- fixes #5028

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
