### PR TITLE
Allow Response subclasses to set default_mimetype as None

### DIFF
--- a/src/flask/wrappers.py
+++ b/src/flask/wrappers.py
@@ -151,7 +151,7 @@ class Response(ResponseBase):
         Added :attr:`max_cookie_size`.
     """
 
-    default_mimetype = "text/html"
+    default_mimetype: t.Optional[str] = "text/html"
 
     json_module = json
 


### PR DESCRIPTION
This matches the type - see https://github.com/pallets/werkzeug/blob/92c6380248c7272ee668e1f8bbd80447027ccce2/src/werkzeug/sansio/response.py#L94.