### PR TITLE
Use latest patch of Werkzeug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "Werkzeug>=2.2.2",
+    "Werkzeug>=2.2.3",
     "Jinja2>=3.0",
     "itsdangerous>=2.0",
     "click>=8.0",


### PR DESCRIPTION
This is pulling a security fix for a vulnerability in Werkzeug 2.2.2
A patch has been release https://github.com/pallets/werkzeug/releases/tag/2.2.3

- fixes N/A (see security report)

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
