### PR TITLE
Fixed grammatically incorrect sentence in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@ complex applications. It began as a simple wrapper around `Werkzeug`_
 and `Jinja`_ and has become one of the most popular Python web
 application frameworks.
 
-Flask offers suggestions, but doesn't enforce any dependencies or
-project layout. It is up to the developer to choose the tools and
+Flask offers suggestions but doesn't enforce any dependencies or
+project layouts. It is up to the developer to choose the tools and
 libraries they want to use. There are many extensions provided by the
 community that make adding new functionality easy.
 


### PR DESCRIPTION
Fixed README grammar error (minor issue).

[Issue link](https://github.com/pallets/flask/issues/5047)

- fixes #<5047>

- Contributing checklist not needed because only docs were changed