### PR TITLE
no cookie domain by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,10 @@ Unreleased
     binary file instead. :issue:`4989`
 -   If a blueprint is created with an empty name it raises a ``ValueError``.
     :issue:`5010`
+-   ``SESSION_COOKIE_DOMAIN`` does not fall back to ``SERVER_NAME``. The default is not
+    to set the domain, which modern browsers interpret as an exact match rather than
+    a subdomain match. Warnings about ``localhost`` and IP addresses are also removed.
+    :issue:`5051`
 
 
 Version 2.2.4

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -134,11 +134,16 @@ The following configuration values are used internally by Flask:
 
 .. py:data:: SESSION_COOKIE_DOMAIN
 
-    The domain match rule that the session cookie will be valid for. If not
-    set, the cookie will be valid for all subdomains of :data:`SERVER_NAME`.
-    If ``False``, the cookie's domain will not be set.
+    The value of the ``Domain`` parameter on the session cookie. If not set, browsers
+    will only send the cookie to the exact domain it was set from. Otherwise, they
+    will send it to any subdomain of the given value as well.
+
+    Not setting this value is more restricted and secure than setting it.
 
     Default: ``None``
+
+    .. versionchanged:: 2.3
+        Not set by default, does not fall back to ``SERVER_NAME``.
 
 .. py:data:: SESSION_COOKIE_PATH
 
@@ -219,18 +224,13 @@ The following configuration values are used internally by Flask:
     Inform the application what host and port it is bound to. Required
     for subdomain route matching support.
 
-    If set, will be used for the session cookie domain if
-    :data:`SESSION_COOKIE_DOMAIN` is not set. Modern web browsers will
-    not allow setting cookies for domains without a dot. To use a domain
-    locally, add any names that should route to the app to your
-    ``hosts`` file. ::
-
-        127.0.0.1 localhost.dev
-
     If set, ``url_for`` can generate external URLs with only an application
     context instead of a request context.
 
     Default: ``None``
+
+    .. versionchanged:: 2.3
+        Does not affect ``SESSION_COOKIE_DOMAIN``.
 
 .. py:data:: APPLICATION_ROOT
 

--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -3,6 +3,7 @@ import pkgutil
 import socket
 import sys
 import typing as t
+import warnings
 from datetime import datetime
 from functools import lru_cache
 from functools import update_wrapper
@@ -662,7 +663,16 @@ def is_ip(value: str) -> bool:
 
     :return: True if string is an IP address
     :rtype: bool
+
+    .. deprecated:: 2.3
+        Will be removed in Flask 2.4.
     """
+    warnings.warn(
+        "The 'is_ip' function is deprecated and will be removed in Flask 2.4.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     for family in (socket.AF_INET, socket.AF_INET6):
         try:
             socket.inet_pton(family, value)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -251,36 +251,8 @@ def test_session(app, client):
     assert client.get("/get").data == b"42"
 
 
-def test_session_using_server_name(app, client):
-    app.config.update(SERVER_NAME="example.com")
-
-    @app.route("/")
-    def index():
-        flask.session["testing"] = 42
-        return "Hello World"
-
-    rv = client.get("/", "http://example.com/")
-    cookie = rv.headers["set-cookie"].lower()
-    # or condition for Werkzeug < 2.3
-    assert "domain=example.com" in cookie or "domain=.example.com" in cookie
-
-
-def test_session_using_server_name_and_port(app, client):
-    app.config.update(SERVER_NAME="example.com:8080")
-
-    @app.route("/")
-    def index():
-        flask.session["testing"] = 42
-        return "Hello World"
-
-    rv = client.get("/", "http://example.com:8080/")
-    cookie = rv.headers["set-cookie"].lower()
-    # or condition for Werkzeug < 2.3
-    assert "domain=example.com" in cookie or "domain=.example.com" in cookie
-
-
-def test_session_using_server_name_port_and_path(app, client):
-    app.config.update(SERVER_NAME="example.com:8080", APPLICATION_ROOT="/foo")
+def test_session_path(app, client):
+    app.config.update(APPLICATION_ROOT="/foo")
 
     @app.route("/")
     def index():
@@ -288,9 +260,7 @@ def test_session_using_server_name_port_and_path(app, client):
         return "Hello World"
 
     rv = client.get("/", "http://example.com:8080/foo")
-    assert "domain=example.com" in rv.headers["set-cookie"].lower()
     assert "path=/foo" in rv.headers["set-cookie"].lower()
-    assert "httponly" in rv.headers["set-cookie"].lower()
 
 
 def test_session_using_application_root(app, client):
@@ -380,34 +350,6 @@ def test_session_using_samesite_attribute(app, client):
     rv = client.get("/")
     cookie = rv.headers["set-cookie"].lower()
     assert "samesite=lax" in cookie
-
-
-def test_session_localhost_warning(recwarn, app, client):
-    app.config.update(SERVER_NAME="localhost:5000")
-
-    @app.route("/")
-    def index():
-        flask.session["testing"] = 42
-        return "testing"
-
-    rv = client.get("/", "http://localhost:5000/")
-    assert "domain" not in rv.headers["set-cookie"].lower()
-    w = recwarn.pop(UserWarning)
-    assert "'localhost' is not a valid cookie domain" in str(w.message)
-
-
-def test_session_ip_warning(recwarn, app, client):
-    app.config.update(SERVER_NAME="127.0.0.1:5000")
-
-    @app.route("/")
-    def index():
-        flask.session["testing"] = 42
-        return "testing"
-
-    rv = client.get("/", "http://127.0.0.1:5000/")
-    assert "domain=127.0.0.1" in rv.headers["set-cookie"].lower()
-    w = recwarn.pop(UserWarning)
-    assert "cookie domain is an IP" in str(w.message)
 
 
 def test_missing_session(app):


### PR DESCRIPTION
`SESSION_COOKIE_DOMAIN` is not set by default, and does not fall back to `SERVER_NAME`.

Browsers treat no domain parameter as "exact match". They ignore a leading dot, and treat any domain parameter as "subdomain match". They allow `localhost` and `127.0.0.1`. Note that `a.localhost` will be treated as if `localhost` were a TLD, which they _do not_ allow, you would need `b.a.localhost` and `c.a.localhost` to observe subdomain matching.

closes #5051 