### PR TITLE
use OIDC instead of token for publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,15 +58,15 @@ jobs:
     # files in the draft release.
     environment: 'publish'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
       # Try uploading to Test PyPI first, in case something fails.
       - uses: pypa/gh-action-pypi-publish@29930c9cf57955dc1b98162d0d8bc3ec80d9e75c
         with:
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
           packages_dir: artifact/
       - uses: pypa/gh-action-pypi-publish@29930c9cf57955dc1b98162d0d8bc3ec80d9e75c
         with:
-          password: ${{ secrets.PYPI_TOKEN }}
           packages_dir: artifact/


### PR DESCRIPTION
We're in PyPI's Trusted Publisher private beta, https://docs.pypi.org/trusted-publishers/. This repo's publish workflow acts as an OIDC provider through GitHub, which the project on PyPI is configured to trust. Instead of generating an API token and storing it as a secret, the two services can establish trust directly and temporarily.