### PR TITLE
update werkzeug to >=2.3.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,8 @@ Version 2.3.2
 
 Unreleased
 
--   Session cookie sets ``Vary: Cookie`` header when it is accessed, modified, cleared,
-    or refreshed.
+-   Set ``Vary: Cookie`` header when the session is accessed, modified, or refreshed.
+-   Update Werkzeug requirement to >=2.3.3 to apply recent bug fixes.
 
 
 Version 2.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "Werkzeug>=2.3.0",
+    "Werkzeug>=2.3.3",
     "Jinja2>=3.1.2",
     "itsdangerous>=2.1.2",
     "click>=8.1.3",

--- a/src/flask/testing.py
+++ b/src/flask/testing.py
@@ -138,21 +138,14 @@ class FlaskClient(Client):
         :meth:`~flask.Flask.test_request_context` which are directly
         passed through.
         """
-        # new cookie interface for Werkzeug >= 2.3
-        cookie_storage = self._cookies if hasattr(self, "_cookies") else self.cookie_jar
-
-        if cookie_storage is None:
+        if self._cookies is None:
             raise TypeError(
                 "Cookies are disabled. Create a client with 'use_cookies=True'."
             )
 
         app = self.application
         ctx = app.test_request_context(*args, **kwargs)
-
-        if hasattr(self, "_add_cookies_to_wsgi"):
-            self._add_cookies_to_wsgi(ctx.request.environ)
-        else:
-            self.cookie_jar.inject_wsgi(ctx.request.environ)  # type: ignore[union-attr]
+        self._add_cookies_to_wsgi(ctx.request.environ)
 
         with ctx:
             sess = app.session_interface.open_session(app, ctx.request)
@@ -169,14 +162,11 @@ class FlaskClient(Client):
         with ctx:
             app.session_interface.save_session(app, sess, resp)
 
-        if hasattr(self, "_update_cookies_from_response"):
-            self._update_cookies_from_response(
-                ctx.request.host.partition(":")[0], resp.headers.getlist("Set-Cookie")
-            )
-        else:
-            self.cookie_jar.extract_wsgi(  # type: ignore[union-attr]
-                ctx.request.environ, resp.headers
-            )
+        self._update_cookies_from_response(
+            ctx.request.host.partition(":")[0],
+            ctx.request.path,
+            resp.headers.getlist("Set-Cookie"),
+        )
 
     def _copy_environ(self, other):
         out = {**self.environ_base, **other}


### PR DESCRIPTION
Contains important bug fixes: https://werkzeug.palletsprojects.com/en/2.3.x/changes/#version-2-3-3 Also requires an update to Flask's test client to work with a fix to cookie path handling (and can remove compat code for this). Tests will fail since 2.3.3 isn't out yet, need both ready simultaneously.