### PR TITLE
backport 2.2.x: set `Vary: Cookie` header consistently for session

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Version 2.2.5
 Unreleased
 
 -   Update for compatibility with Werkzeug 2.3.3.
+-   Set ``Vary: Cookie`` header when the session is accessed, modified, or refreshed.
 
 
 Version 2.2.4

--- a/src/flask/sessions.py
+++ b/src/flask/sessions.py
@@ -383,6 +383,10 @@ class SecureCookieSessionInterface(SessionInterface):
         samesite = self.get_cookie_samesite(app)
         httponly = self.get_cookie_httponly(app)
 
+        # Add a "Vary: Cookie" header if the session was accessed at all.
+        if session.accessed:
+            response.vary.add("Cookie")
+
         # If the session is modified to be empty, remove the cookie.
         # If the session is empty, return without setting the cookie.
         if not session:
@@ -395,12 +399,9 @@ class SecureCookieSessionInterface(SessionInterface):
                     samesite=samesite,
                     httponly=httponly,
                 )
+                response.vary.add("Cookie")
 
             return
-
-        # Add a "Vary: Cookie" header if the session was accessed at all.
-        if session.accessed:
-            response.vary.add("Cookie")
 
         if not self.should_set_cookie(app, session):
             return
@@ -417,3 +418,4 @@ class SecureCookieSessionInterface(SessionInterface):
             secure=secure,
             samesite=samesite,
         )
+        response.vary.add("Cookie")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -560,6 +560,11 @@ def test_session_vary_cookie(app, client):
     def setdefault():
         return flask.session.setdefault("test", "default")
 
+    @app.route("/clear")
+    def clear():
+        flask.session.clear()
+        return ""
+
     @app.route("/vary-cookie-header-set")
     def vary_cookie_header_set():
         response = flask.Response()
@@ -592,9 +597,27 @@ def test_session_vary_cookie(app, client):
     expect("/get")
     expect("/getitem")
     expect("/setdefault")
+    expect("/clear")
     expect("/vary-cookie-header-set")
     expect("/vary-header-set", "Accept-Encoding, Accept-Language, Cookie")
     expect("/no-vary-header", None)
+
+
+def test_session_refresh_vary(app, client):
+    @app.get("/login")
+    def login():
+        flask.session["user_id"] = 1
+        flask.session.permanent = True
+        return ""
+
+    @app.get("/ignored")
+    def ignored():
+        return ""
+
+    rv = client.get("/login")
+    assert rv.headers["Vary"] == "Cookie"
+    rv = client.get("/ignored")
+    assert rv.headers["Vary"] == "Cookie"
 
 
 def test_flashes(app, req_ctx):


### PR DESCRIPTION
Backport the fix for https://github.com/pallets/flask/security/advisories/GHSA-m2qf-hxjv-5gpq to 2.2.x.