### PR TITLE
update tests

### DIFF
--- a/src/flask/scaffold.py
+++ b/src/flask/scaffold.py
@@ -865,7 +865,7 @@ def _find_package_path(import_name):
     if hasattr(loader, "get_filename"):
         filename = loader.get_filename(root_mod_name)
     elif hasattr(loader, "archive"):
-        # zipimporter's loader.archive points to the .egg or .zip file.
+        # zipimporter's loader.archive points to the .zip file.
         filename = loader.archive
     else:
         # At least one loader is missing both get_filename and archive:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,28 +128,27 @@ def limit_loader(request, monkeypatch):
 
 
 @pytest.fixture
-def modules_tmpdir(tmpdir, monkeypatch):
-    """A tmpdir added to sys.path."""
-    rv = tmpdir.mkdir("modules_tmpdir")
-    monkeypatch.syspath_prepend(str(rv))
+def modules_tmp_path(tmp_path, monkeypatch):
+    """A temporary directory added to sys.path."""
+    rv = tmp_path / "modules_tmp"
+    rv.mkdir()
+    monkeypatch.syspath_prepend(os.fspath(rv))
     return rv
 
 
 @pytest.fixture
-def modules_tmpdir_prefix(modules_tmpdir, monkeypatch):
-    monkeypatch.setattr(sys, "prefix", str(modules_tmpdir))
-    return modules_tmpdir
+def modules_tmp_path_prefix(modules_tmp_path, monkeypatch):
+    monkeypatch.setattr(sys, "prefix", os.fspath(modules_tmp_path))
+    return modules_tmp_path
 
 
 @pytest.fixture
-def site_packages(modules_tmpdir, monkeypatch):
+def site_packages(modules_tmp_path, monkeypatch):
     """Create a fake site-packages."""
-    rv = (
-        modules_tmpdir.mkdir("lib")
-        .mkdir(f"python{sys.version_info.major}.{sys.version_info.minor}")
-        .mkdir("site-packages")
-    )
-    monkeypatch.syspath_prepend(str(rv))
+    py_dir = f"python{sys.version_info.major}.{sys.version_info.minor}"
+    rv = modules_tmp_path / "lib" / py_dir / "site-packages"
+    rv.mkdir(parents=True)
+    monkeypatch.syspath_prepend(os.fspath(rv))
     return rv
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import os
 import pkgutil
 import sys
-import textwrap
 
 import pytest
 from _pytest import monkeypatch
@@ -152,42 +151,6 @@ def site_packages(modules_tmpdir, monkeypatch):
     )
     monkeypatch.syspath_prepend(str(rv))
     return rv
-
-
-@pytest.fixture
-def install_egg(modules_tmpdir, monkeypatch):
-    """Generate egg from package name inside base and put the egg into
-    sys.path."""
-
-    def inner(name, base=modules_tmpdir):
-        base.join(name).ensure_dir()
-        base.join(name).join("__init__.py").ensure()
-
-        egg_setup = base.join("setup.py")
-        egg_setup.write(
-            textwrap.dedent(
-                f"""
-                from setuptools import setup
-                setup(
-                    name="{name}",
-                    version="1.0",
-                    packages=["site_egg"],
-                    zip_safe=True,
-                )
-                """
-            )
-        )
-
-        import subprocess
-
-        subprocess.check_call(
-            [sys.executable, "setup.py", "bdist_egg"], cwd=str(modules_tmpdir)
-        )
-        (egg_path,) = modules_tmpdir.join("dist/").listdir()
-        monkeypatch.syspath_prepend(str(egg_path))
-        return egg_path
-
-    return inner
 
 
 @pytest.fixture

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,5 @@
 import json
 import os
-import textwrap
 
 import pytest
 
@@ -242,17 +241,10 @@ def test_get_namespace():
 
 
 @pytest.mark.parametrize("encoding", ["utf-8", "iso-8859-15", "latin-1"])
-def test_from_pyfile_weird_encoding(tmpdir, encoding):
-    f = tmpdir.join("my_config.py")
-    f.write_binary(
-        textwrap.dedent(
-            f"""
-            # -*- coding: {encoding} -*-
-            TEST_VALUE = "föö"
-            """
-        ).encode(encoding)
-    )
+def test_from_pyfile_weird_encoding(tmp_path, encoding):
+    f = tmp_path / "my_config.py"
+    f.write_text(f'# -*- coding: {encoding} -*-\nTEST_VALUE = "föö"\n', encoding)
     app = flask.Flask(__name__)
-    app.config.from_pyfile(str(f))
+    app.config.from_pyfile(os.fspath(f))
     value = app.config["TEST_VALUE"]
     assert value == "föö"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -218,8 +218,8 @@ class TestNoImports:
     imp modules in the Python standard library.
     """
 
-    def test_name_with_import_error(self, modules_tmpdir):
-        modules_tmpdir.join("importerror.py").write("raise NotImplementedError()")
+    def test_name_with_import_error(self, modules_tmp_path):
+        (modules_tmp_path / "importerror.py").write_text("raise NotImplementedError()")
         try:
             flask.Flask("importerror")
         except NotImplementedError:

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -1,19 +1,20 @@
+import os
+
 import pytest
 
 import flask
 
 
-def test_explicit_instance_paths(modules_tmpdir):
-    with pytest.raises(ValueError) as excinfo:
+def test_explicit_instance_paths(modules_tmp_path):
+    with pytest.raises(ValueError, match=".*must be absolute"):
         flask.Flask(__name__, instance_path="instance")
-    assert "must be absolute" in str(excinfo.value)
 
-    app = flask.Flask(__name__, instance_path=str(modules_tmpdir))
-    assert app.instance_path == str(modules_tmpdir)
+    app = flask.Flask(__name__, instance_path=os.fspath(modules_tmp_path))
+    assert app.instance_path == os.fspath(modules_tmp_path)
 
 
-def test_uninstalled_module_paths(modules_tmpdir, purge_module):
-    app = modules_tmpdir.join("config_module_app.py").write(
+def test_uninstalled_module_paths(modules_tmp_path, purge_module):
+    (modules_tmp_path / "config_module_app.py").write_text(
         "import os\n"
         "import flask\n"
         "here = os.path.abspath(os.path.dirname(__file__))\n"
@@ -23,13 +24,13 @@ def test_uninstalled_module_paths(modules_tmpdir, purge_module):
 
     from config_module_app import app
 
-    assert app.instance_path == str(modules_tmpdir.join("instance"))
+    assert app.instance_path == os.fspath(modules_tmp_path / "instance")
 
 
-def test_uninstalled_package_paths(modules_tmpdir, purge_module):
-    app = modules_tmpdir.mkdir("config_package_app")
-    init = app.join("__init__.py")
-    init.write(
+def test_uninstalled_package_paths(modules_tmp_path, purge_module):
+    app = modules_tmp_path / "config_package_app"
+    app.mkdir()
+    (app / "__init__.py").write_text(
         "import os\n"
         "import flask\n"
         "here = os.path.abspath(os.path.dirname(__file__))\n"
@@ -39,16 +40,16 @@ def test_uninstalled_package_paths(modules_tmpdir, purge_module):
 
     from config_package_app import app
 
-    assert app.instance_path == str(modules_tmpdir.join("instance"))
+    assert app.instance_path == os.fspath(modules_tmp_path / "instance")
 
 
-def test_uninstalled_namespace_paths(tmpdir, monkeypatch, purge_module):
+def test_uninstalled_namespace_paths(tmp_path, monkeypatch, purge_module):
     def create_namespace(package):
-        project = tmpdir.join(f"project-{package}")
-        monkeypatch.syspath_prepend(str(project))
-        project.join("namespace").join(package).join("__init__.py").write(
-            "import flask\napp = flask.Flask(__name__)\n", ensure=True
-        )
+        project = tmp_path / f"project-{package}"
+        monkeypatch.syspath_prepend(os.fspath(project))
+        ns = project / "namespace" / package
+        ns.mkdir(parents=True)
+        (ns / "__init__.py").write_text("import flask\napp = flask.Flask(__name__)\n")
         return project
 
     _ = create_namespace("package1")
@@ -58,50 +59,53 @@ def test_uninstalled_namespace_paths(tmpdir, monkeypatch, purge_module):
 
     from namespace.package2 import app
 
-    assert app.instance_path == str(project2.join("instance"))
+    assert app.instance_path == os.fspath(project2 / "instance")
 
 
 def test_installed_module_paths(
-    modules_tmpdir, modules_tmpdir_prefix, purge_module, site_packages, limit_loader
+    modules_tmp_path, modules_tmp_path_prefix, purge_module, site_packages, limit_loader
 ):
-    site_packages.join("site_app.py").write(
+    (site_packages / "site_app.py").write_text(
         "import flask\napp = flask.Flask(__name__)\n"
     )
     purge_module("site_app")
 
     from site_app import app
 
-    assert app.instance_path == modules_tmpdir.join("var").join("site_app-instance")
+    assert app.instance_path == os.fspath(
+        modules_tmp_path / "var" / "site_app-instance"
+    )
 
 
 def test_installed_package_paths(
-    limit_loader, modules_tmpdir, modules_tmpdir_prefix, purge_module, monkeypatch
+    limit_loader, modules_tmp_path, modules_tmp_path_prefix, purge_module, monkeypatch
 ):
-    installed_path = modules_tmpdir.mkdir("path")
+    installed_path = modules_tmp_path / "path"
+    installed_path.mkdir()
     monkeypatch.syspath_prepend(installed_path)
 
-    app = installed_path.mkdir("installed_package")
-    init = app.join("__init__.py")
-    init.write("import flask\napp = flask.Flask(__name__)")
+    app = installed_path / "installed_package"
+    app.mkdir()
+    (app / "__init__.py").write_text("import flask\napp = flask.Flask(__name__)\n")
     purge_module("installed_package")
 
     from installed_package import app
 
-    assert app.instance_path == modules_tmpdir.join("var").join(
-        "installed_package-instance"
+    assert app.instance_path == os.fspath(
+        modules_tmp_path / "var" / "installed_package-instance"
     )
 
 
 def test_prefix_package_paths(
-    limit_loader, modules_tmpdir, modules_tmpdir_prefix, purge_module, site_packages
+    limit_loader, modules_tmp_path, modules_tmp_path_prefix, purge_module, site_packages
 ):
-    app = site_packages.mkdir("site_package")
-    init = app.join("__init__.py")
-    init.write("import flask\napp = flask.Flask(__name__)")
+    app = site_packages / "site_package"
+    app.mkdir()
+    (app / "__init__.py").write_text("import flask\napp = flask.Flask(__name__)\n")
     purge_module("site_package")
 
     import site_package
 
-    assert site_package.app.instance_path == modules_tmpdir.join("var").join(
-        "site_package-instance"
+    assert site_package.app.instance_path == os.fspath(
+        modules_tmp_path / "var" / "site_package-instance"
     )

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 
 import flask
@@ -107,19 +105,3 @@ def test_prefix_package_paths(
     assert site_package.app.instance_path == modules_tmpdir.join("var").join(
         "site_package-instance"
     )
-
-
-def test_egg_installed_paths(install_egg, modules_tmpdir, modules_tmpdir_prefix):
-    modules_tmpdir.mkdir("site_egg").join("__init__.py").write(
-        "import flask\n\napp = flask.Flask(__name__)"
-    )
-    install_egg("site_egg")
-    try:
-        import site_egg
-
-        assert site_egg.app.instance_path == str(
-            modules_tmpdir.join("var/").join("site_egg-instance")
-        )
-    finally:
-        if "site_egg" in sys.modules:
-            del sys.modules["site_egg"]


### PR DESCRIPTION
* Remove test that used `.egg` file, eggs aren't supported and Python 3.12 venv removes setuptools which we used to build it.
* Use pytest's `tmp_path` fixture instead of `tmpdir`.