### PR TITLE
Accept dict constructor args for template rendering functions

### DIFF
--- a/src/flask/templating.py
+++ b/src/flask/templating.py
@@ -138,29 +138,52 @@ def _render(app: Flask, template: Template, context: dict[str, t.Any]) -> str:
 
 def render_template(
     template_name_or_list: str | Template | list[str | Template],
-    **context: t.Any,
+    *context_args: t.Iterable[tuple[t.Any, t.Any]] | t.Mapping[t.Any, t.Any],
+    **context_kwargs: t.Any,
 ) -> str:
     """Render a template by name with the given context.
 
     :param template_name_or_list: The name of the template to render. If
         a list is given, the first name to exist will be rendered.
-    :param context: The variables to make available in the template.
+    :param context_args: An Iterable or Mapping of variables to make available
+        in the template.
+    :param context_kargs: Variables to make available in the template.
+
+    Note that `context_args` and `context_kargs` are the same arguments that the
+    `dict` constructor takes. The following are equivalent::
+
+        render_template('index.html', {'key1': 'val1', 'key2': 'val2'})
+        render_template('index.html', [('key1', 'val1')], key2='val2')
+        render_template('index.html', key1='val1', key2='val2')
     """
     app = current_app._get_current_object()  # type: ignore[attr-defined]
     template = app.jinja_env.get_or_select_template(template_name_or_list)
-    return _render(app, template, context)
+    return _render(app, template, dict(*context_args, **context_kwargs))
 
 
-def render_template_string(source: str, **context: t.Any) -> str:
+def render_template_string(
+    source: str,
+    *context_args: t.Iterable[tuple[t.Any, t.Any]] | t.Mapping[t.Any, t.Any],
+    **context_kargs: t.Any,
+) -> str:
     """Render a template from the given source string with the given
     context.
 
     :param source: The source code of the template to render.
-    :param context: The variables to make available in the template.
+    :param context_args: An Iterable or Mapping of variables to make available
+        in the template.
+    :param context_kargs: Variables to make available in the template.
+
+    Note that `context_args` and `context_kargs` are the same arguments that the
+    `dict` constructor takes. The following are all equivalent::
+
+        render_template('index.html', {'key1': 'val1', 'key2': 'val2'})
+        render_template('index.html', [('key1', 'val1')], key2='val2')
+        render_template('index.html', key1='val1', key2='val2')
     """
     app = current_app._get_current_object()  # type: ignore[attr-defined]
     template = app.jinja_env.from_string(source)
-    return _render(app, template, context)
+    return _render(app, template, dict(*context_args, **context_kargs))
 
 
 def _stream(
@@ -188,7 +211,8 @@ def _stream(
 
 def stream_template(
     template_name_or_list: str | Template | list[str | Template],
-    **context: t.Any,
+    *context_args: t.Iterable[tuple[t.Any, t.Any]] | t.Mapping[t.Any, t.Any],
+    **context_kargs: t.Any,
 ) -> t.Iterator[str]:
     """Render a template by name with the given context as a stream.
     This returns an iterator of strings, which can be used as a
@@ -196,25 +220,45 @@ def stream_template(
 
     :param template_name_or_list: The name of the template to render. If
         a list is given, the first name to exist will be rendered.
-    :param context: The variables to make available in the template.
+    :param context_args: An Iterable or Mapping of variables to make available
+        in the template.
+    :param context_kargs: Variables to make available in the template.
+
+    Note that `context_args` and `context_kargs` are the same arguments that the
+    `dict` constructor takes. The following are all equivalent::
+
+        render_template('index.html', {'key1': 'val1', 'key2': 'val2'})
+        render_template('index.html', [('key1', 'val1')], key2='val2')
+        render_template('index.html', key1='val1', key2='val2')
 
     .. versionadded:: 2.2
     """
     app = current_app._get_current_object()  # type: ignore[attr-defined]
     template = app.jinja_env.get_or_select_template(template_name_or_list)
-    return _stream(app, template, context)
+    return _stream(app, template, dict(*context_args, **context_kargs))
 
 
-def stream_template_string(source: str, **context: t.Any) -> t.Iterator[str]:
+def stream_template_string(
+    source: str,
+    *context_args: t.Iterable[tuple[t.Any, t.Any]] | t.Mapping[t.Any, t.Any],
+    **context_kargs: t.Any,
+) -> t.Iterator[str]:
     """Render a template from the given source string with the given
     context as a stream. This returns an iterator of strings, which can
     be used as a streaming response from a view.
 
     :param source: The source code of the template to render.
-    :param context: The variables to make available in the template.
+    :param context_kargs: Variables to make available in the template.
+
+    Note that `context_args` and `context_kargs` are the same arguments that the
+    `dict` constructor takes. The following are all equivalent::
+
+        render_template('index.html', {'key1': 'val1', 'key2': 'val2'})
+        render_template('index.html', [('key1', 'val1')], key2='val2')
+        render_template('index.html', key1='val1', key2='val2')
 
     .. versionadded:: 2.2
     """
     app = current_app._get_current_object()  # type: ignore[attr-defined]
     template = app.jinja_env.from_string(source)
-    return _stream(app, template, context)
+    return _stream(app, template, dict(*context_args, **context_kargs))

--- a/tests/templates/multi_vars.html
+++ b/tests/templates/multi_vars.html
@@ -1,0 +1,1 @@
+{{ greeting }}{{ name }}

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -39,6 +39,41 @@ def test_simple_stream(app, client):
     assert rv.data == b"42"
 
 
+@pytest.mark.parametrize(
+    "render_func, template_arg",
+    [
+        (flask.render_template, "multi_vars.html"),
+        (flask.render_template_string, "{{ greeting }}{{ name }}"),
+        (flask.stream_template, "multi_vars.html"),
+        (flask.stream_template_string, "{{ greeting }}{{ name }}"),
+    ],
+)
+@pytest.mark.parametrize(
+    "context",
+    [
+        {"greeting": "Hello"},
+        [("greeting", "Hello")],
+        (("greeting", "Hello"),),
+    ],
+)
+class TestRenderDictCtor:
+    def test_with_kargs(self, app, client, render_func, template_arg, context):
+        @app.route("/")
+        def index():
+            return render_func(template_arg, context, name="World")
+
+        rv = client.get("/")
+        assert rv.data == b"HelloWorld"
+
+    def test_no_kargs(self, app, client, render_func, template_arg, context):
+        @app.route("/")
+        def index():
+            return render_func(template_arg, context)
+
+        rv = client.get("/")
+        assert rv.data == b"Hello"
+
+
 def test_request_less_rendering(app, app_ctx):
     app.config["WORLD_NAME"] = "Special World"
 


### PR DESCRIPTION
This patch changes `render_template()`, `render_template_string()`, `stream_template()`, and `stream_template_string()` to accept the same args as the dict constructor instead of just named arguments.

Closes #5133 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
