### PR TITLE
Config from Data Files to match from_file API

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -410,8 +410,8 @@ from a TOML file:
 
 .. code-block:: python
 
-    import toml
-    app.config.from_file("config.toml", load=toml.load)
+    import tomllib
+    app.config.from_file("config.toml", load=tomllib.load, text=False)
 
 Or from a JSON file:
 


### PR DESCRIPTION
In the API docs using a TOML file to load config is referred to as https://flask.palletsprojects.com/en/2.3.x/api/#flask.Config.from_file

To keep docs consistent a small change to the config docs.

- fixes Issue #5139 

**First time contributing**
Is this checklist necessary for doc clarifications?

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
