### PR TITLE
fix use of `importlib.util.find_spec`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased
 
 -   Python 3.12 compatibility.
 -   Update Werkzeug requirement to >=2.3.5.
+-   Refactor how an app's root and instance paths are determined. :issue:`5160`
 
 
 Version 2.3.2

--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -575,13 +575,20 @@ def get_root_path(import_name: str) -> str:
         return os.path.dirname(os.path.abspath(mod.__file__))
 
     # Next attempt: check the loader.
-    spec = importlib.util.find_spec(import_name)
-    loader = spec.loader if spec is not None else None
+    try:
+        spec = importlib.util.find_spec(import_name)
+
+        if spec is None:
+            raise ValueError
+    except (ImportError, ValueError):
+        loader = None
+    else:
+        loader = spec.loader
 
     # Loader does not exist or we're referring to an unloaded main
     # module or a main module without path (interactive sessions), go
     # with the current working directory.
-    if loader is None or import_name == "__main__":
+    if loader is None:
         return os.getcwd()
 
     if hasattr(loader, "get_filename"):


### PR DESCRIPTION
`importlib.util.find_spec` raises a `ValueError` in some cases, which is different than how `pkgutil.get_loader` worked. fixes #5160 

While fixing this, I noticed that the "fallback" part of the `_find_package_path` code is redundant, since `find_spec` is already handling all cases. `get_root_path` could probably also be cleaned up, but I'm leaving that for now.