### PR TITLE
fix update import of declarative_base from SQLAlchemy

### DIFF
--- a/docs/patterns/sqlalchemy.rst
+++ b/docs/patterns/sqlalchemy.rst
@@ -34,8 +34,7 @@ official documentation on the `declarative`_ extension.
 Here's the example :file:`database.py` module for your application::
 
     from sqlalchemy import create_engine
-    from sqlalchemy.orm import scoped_session, sessionmaker
-    from sqlalchemy.ext.declarative import declarative_base
+    from sqlalchemy.orm import scoped_session, sessionmaker, declarative_base
 
     engine = create_engine('sqlite:////tmp/test.db')
     db_session = scoped_session(sessionmaker(autocommit=False,


### PR DESCRIPTION
We advise that an update be made to the import statement for the declarative_base() function within the patterns section in SQLAlchemy.srt.


- fixes #5169


Checklist:

- [X] Add or update relevant docs, in the docs folder and in code.
