### PR TITLE
Replace `run --debug` with `--debug run` in docs.

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -95,7 +95,7 @@ the ``--debug`` option.
 
 .. code-block:: console
 
-     $ flask --app hello run --debug
+     $ flask --app hello --debug run
       * Serving Flask app "hello"
       * Debug mode: on
       * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
@@ -109,7 +109,7 @@ debug mode for any command. The following two ``run`` calls are equivalent.
 .. code-block:: console
 
     $ flask --app hello --debug run
-    $ flask --app hello run --debug
+    $ flask --app hello --debug run
 
 
 Watch and Ignore Files with the Reloader
@@ -543,7 +543,7 @@ a name such as "flask run".
 Click the *Script path* dropdown and change it to *Module name*, then input ``flask``.
 
 The *Parameters* field is set to the CLI command to execute along with any arguments.
-This example uses ``--app hello run --debug``, which will run the development server in
+This example uses ``--app hello --debug run``, which will run the development server in
 debug mode. ``--app hello`` should be the import or file with your Flask app.
 
 If you installed your project as a package in your virtualenv, you may uncheck the

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -52,7 +52,7 @@ interactive debugger and reloader by default in debug mode.
 
 .. code-block:: text
 
-    $ flask --app hello run --debug
+    $ flask --app hello --debug run
 
 Using the option is recommended. While it is possible to set :data:`DEBUG` in your
 config or code, this is strongly discouraged. It can't be read early by the

--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -43,7 +43,7 @@ The debugger is enabled by default when the development server is run in debug m
 
 .. code-block:: text
 
-    $ flask --app hello run --debug
+    $ flask --app hello --debug run
 
 When running from Python code, passing ``debug=True`` enables debug mode, which is
 mostly equivalent.
@@ -72,7 +72,7 @@ reloader should be disabled so they don't interfere with the external debugger.
 
 .. code-block:: text
 
-    $ flask --app hello run --debug --no-debugger --no-reload
+    $ flask --app hello --debug run --no-debugger --no-reload
 
 When running from Python:
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -108,7 +108,7 @@ To enable debug mode, use the ``--debug`` option.
 
 .. code-block:: text
 
-    $ flask --app hello run --debug
+    $ flask --app hello --debug run
      * Serving Flask app 'hello'
      * Debug mode: on
      * Running on http://127.0.0.1:5000 (Press CTRL+C to quit)

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -24,7 +24,7 @@ debug mode.
 
 .. code-block:: text
 
-    $ flask --app hello run --debug
+    $ flask --app hello --debug run
 
 This enables debug mode, including the interactive debugger and reloader, and then
 starts the server on http://localhost:5000/. Use ``flask run --help`` to see the

--- a/docs/tutorial/factory.rst
+++ b/docs/tutorial/factory.rst
@@ -137,7 +137,7 @@ follow the tutorial.
 
 .. code-block:: text
 
-    $ flask --app flaskr run --debug
+    $ flask --app flaskr --debug run
 
 You'll see output similar to this:
 

--- a/examples/celery/README.md
+++ b/examples/celery/README.md
@@ -19,7 +19,7 @@ In a separate terminal, activate the virtualenv and run the Flask development se
 
 ```shell
 $ . ./.venv/bin/activate
-$ flask -A task_app run --debug
+$ flask -A task_app --debug run
 ```
 
 Go to http://localhost:5000/ and use the forms to submit tasks. You can see the polling

--- a/examples/tutorial/README.rst
+++ b/examples/tutorial/README.rst
@@ -48,7 +48,7 @@ Run
 .. code-block:: text
 
     $ flask --app flaskr init-db
-    $ flask --app flaskr run --debug
+    $ flask --app flaskr --debug run
 
 Open http://127.0.0.1:5000 in a browser.
 


### PR DESCRIPTION
Running `flask run` with `--debug` after `run` does not work. It seems `--debug` must be before `run`.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
