### PR TITLE
Allow self as an argument to url_for

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
     ``importlib.metadata.version("flask")``, instead. :issue:`5230`
 -   Restructure the code such that the Flask (app) and Blueprint
     classes have Sans-IO bases. :pr:`5127`
+-   Allow self as an argument to url_for. :pr:`5264`
 
 
 Version 2.3.3

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -952,6 +952,7 @@ class Flask(App):
 
     def url_for(
         self,
+        /,
         endpoint: str,
         *,
         _anchor: str | None = None,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -161,6 +161,13 @@ class TestUrlFor:
         assert flask.url_for("myview", id=42, _method="GET") == "/myview/42"
         assert flask.url_for("myview", _method="POST") == "/myview/create"
 
+    def test_url_for_with_self(self, app, req_ctx):
+        @app.route("/<self>")
+        def index(self):
+            return "42"
+
+        assert flask.url_for("index", self="2") == "/2"
+
 
 def test_redirect_no_app():
     response = flask.redirect("https://localhost", 307)


### PR DESCRIPTION
This makes the Flask.url_for self argument positional only (Flask supports Python 3.8+) thereby restoring the ability to pass self as a value argument to url_for.

Closes #5258

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
