### PR TITLE
Lock werkzeug version to <3 to avoid compatability issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "Werkzeug>=2.3.7",
+    "Werkzeug>=2.3.7, <3.0",
     "Jinja2>=3.1.2",
     "itsdangerous>=2.1.2",
     "click>=8.1.3",


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- I did not file any issue for this because I consider it minor

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

While it is recommended to using tools like [pip-tools ](https://pypi.org/project/pip-tools/) to manage dependencies, both direct and transitive ones, sometimes for smaller projects, one will just go with a requirements.txt that list only `flask` and meet some issues when werkzeug was just upgraded 3 days ago on Sept 30. 

Therefore, I propose locking the major version of Werkzeug on flask 2.3.x. This change would safeguard users from errors that happen because Werkzeug was upgraded to version 3.x (one of them I have met myself is `ImportError: cannot import name 'url_quote' from 'werkzeug.urls'`)

Checklist: ( _I am checking those but dont  think they are necessary_ )

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
