### PR TITLE
examples/javascript: replace obsolete link

### DIFF
--- a/examples/javascript/README.rst
+++ b/examples/javascript/README.rst
@@ -15,7 +15,7 @@ page. Demonstrates using |fetch|_, |XMLHttpRequest|_,  and
 .. |jQuery.ajax| replace:: ``jQuery.ajax``
 .. _jQuery.ajax: https://api.jquery.com/jQuery.ajax/
 
-.. _Flask docs: https://flask.palletsprojects.com/patterns/jquery/
+.. _Flask docs: https://flask.palletsprojects.com/patterns/javascript/
 
 
 Install


### PR DESCRIPTION
This pull request proposes a minor fix where the actual replaces the obsolete page.