### PR TITLE
fix missing quote in `--key` error message

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Version 3.0.1
 Unreleased
 
 -   Correct type for ``path`` argument to ``send_file``. :issue:`5230`
+-   Fix a typo in an error message for the ``flask run --key`` option. :pr:`5344`
 
 
 Version 3.0.0

--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -795,7 +795,9 @@ def _validate_key(ctx, param, value):
 
         if is_context:
             raise click.BadParameter(
-                'When "--cert" is an SSLContext object, "--key is not used.', ctx, param
+                'When "--cert" is an SSLContext object, "--key" is not used.',
+                ctx,
+                param,
             )
 
         if not cert:


### PR DESCRIPTION
Adding the missing double quotes at line 798 of cli.py.

- fixes #5342 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
