### PR TITLE
fix(sec): upgrade werkzeug to 3.0.1

### DIFF
--- a/examples/celery/requirements.txt
+++ b/examples/celery/requirements.txt
@@ -54,5 +54,5 @@ vine==5.0.0
     #   kombu
 wcwidth==0.2.6
     # via prompt-toolkit
-werkzeug==2.3.3
+werkzeug==3.0.1
     # via flask


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in werkzeug 2.3.3
- [CVE-2023-46136](https://www.oscs1024.com/hd/CVE-2023-46136)


### What did I do？
Upgrade werkzeug from 2.3.3 to 3.0.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS