### PR TITLE
untag without `object_hook`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Unreleased
 
 -   Correct type for ``path`` argument to ``send_file``. :issue:`5230`
 -   Fix a typo in an error message for the ``flask run --key`` option. :pr:`5344`
+-   Session data is untagged without relying on the built-in ``json.loads``
+    ``object_hook``. This allows other JSON providers that don't implement that.
+    :issue:`5381`
 
 
 Version 3.0.0

--- a/src/flask/json/tag.py
+++ b/src/flask/json/tag.py
@@ -305,10 +305,22 @@ class TaggedJSONSerializer:
 
         return self.tags[key].to_python(value[key])
 
+    def _untag_scan(self, value: t.Any) -> t.Any:
+        if isinstance(value, dict):
+            # untag each item recursively
+            value = {k: self._untag_scan(v) for k, v in value.items()}
+            # untag the dict itself
+            value = self.untag(value)
+        elif isinstance(value, list):
+            # untag each item recursively
+            value = [self._untag_scan(item) for item in value]
+
+        return value
+
     def dumps(self, value: t.Any) -> str:
         """Tag the value and dump it to a compact JSON string."""
         return dumps(self.tag(value), separators=(",", ":"))
 
     def loads(self, value: str) -> t.Any:
         """Load data from a JSON string and deserialized any tagged objects."""
-        return loads(value, object_hook=self.untag)
+        return self._untag_scan(loads(value))


### PR DESCRIPTION
Load session JSON without using `object_hook`, then recursively untag the data.

fixes #5381