### PR TITLE
Fix jinja_loader typehint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 3.0.2
 
 Unreleased
 
+-   Correct type for ``jinja_loader`` property. :issue:`5388`
+
 
 Version 3.0.1
 -------------

--- a/src/flask/sansio/scaffold.py
+++ b/src/flask/sansio/scaffold.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from functools import update_wrapper
 
 import click
+from jinja2 import BaseLoader
 from jinja2 import FileSystemLoader
 from werkzeug.exceptions import default_exceptions
 from werkzeug.exceptions import HTTPException
@@ -272,7 +273,7 @@ class Scaffold:
         self._static_url_path = value
 
     @cached_property
-    def jinja_loader(self) -> FileSystemLoader | None:
+    def jinja_loader(self) -> BaseLoader | None:
         """The Jinja loader for this object's templates. By default this
         is a class :class:`jinja2.loaders.FileSystemLoader` to
         :attr:`template_folder` if it is set.


### PR DESCRIPTION
mypy is complaining about
```Python
from jinja2 import ChoiceLoader
jinja_loader = jinja2.ChoiceLoader([FileSystemLoader(
```

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->
This changes the type hint for jinja_loader to be BaseLoader which is the parent class of `ChoiceLoader` and `FileSystemLoader`.

- fixes #5388

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
