### PR TITLE
Security upgrade cryptography from 42.0.2 to 42.0.4

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -30,7 +30,7 @@ click==8.1.7
     # via pip-tools
 colorama==0.4.6
     # via tox
-cryptography==42.0.2
+cryptography==42.0.4
     # via -r typing.in
 distlib==0.3.8
     # via virtualenv

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -8,7 +8,7 @@ asgiref==3.7.2
     # via -r typing.in
 cffi==1.16.0
     # via cryptography
-cryptography==42.0.2
+cryptography==42.0.4
     # via -r typing.in
 mypy==1.8.0
     # via -r typing.in


### PR DESCRIPTION
This pull request **upgrades** the **cryptography**  from version **42.0.2** to version **42.0.4**. The upgrade is essential to ensure that our application benefits from the latest **security patches**, **bug fixes**, and potentially **performance improvements** provided by the **newer version.**

**42.0.4 - 2024-02-20**[](https://cryptography.io/en/latest/changelog/#v42-0-4)
Fixed a **null-pointer-dereference** and segfault that could occur when creating a PKCS#12 bundle. Credit to Alexander-Programming for reporting the issue. CVE-2024-26130

Fixed ASN.1 encoding for PKCS7/SMIME signed messages. The fields SMIMECapabilities and SignatureAlgorithmIdentifier should now be correctly encoded according to the definitions in [RFC 2633](https://datatracker.ietf.org/doc/html/rfc2633.html) [RFC 3370](https://datatracker.ietf.org/doc/html/rfc3370.html).