### PR TITLE
support FIPS builds without SHA-1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,10 @@ Version 3.0.3
 
 Unreleased
 
+-   The default ``hashlib.sha1`` may not be available in FIPS builds. Don't
+    access it at import time so the developer has time to change the default.
+    :issue:`5448`
+
 
 Version 3.0.2
 -------------

--- a/src/flask/sessions.py
+++ b/src/flask/sessions.py
@@ -277,6 +277,14 @@ class SessionInterface:
 session_json_serializer = TaggedJSONSerializer()
 
 
+def _lazy_sha1(string: bytes = b"") -> t.Any:
+    """Don't access ``hashlib.sha1`` until runtime. FIPS builds may not include
+    SHA-1, in which case the import and use as a default would fail before the
+    developer can configure something else.
+    """
+    return hashlib.sha1(string)
+
+
 class SecureCookieSessionInterface(SessionInterface):
     """The default session interface that stores sessions in signed cookies
     through the :mod:`itsdangerous` module.
@@ -286,7 +294,7 @@ class SecureCookieSessionInterface(SessionInterface):
     #: signing of cookie based sessions.
     salt = "cookie-session"
     #: the hash function to use for the signature.  The default is sha1
-    digest_method = staticmethod(hashlib.sha1)
+    digest_method = staticmethod(_lazy_sha1)
     #: the name of the itsdangerous supported key derivation.  The default
     #: is hmac.
     key_derivation = "hmac"


### PR DESCRIPTION
`hashlib.sha1` may not be available in some FIPS builds that go beyond what FIPS requires into what it recommends. Apparently some RedHat containers do this. We don't want to change the default, but now it is accessed lazily so that it fails at runtime rather than at import time. This way, the developer has time after importing to change the default before using.

fixes #5448 