### PR TITLE
examples/javascript: Update Documentation URL in pyproject.toml

### DIFF
--- a/examples/javascript/pyproject.toml
+++ b/examples/javascript/pyproject.toml
@@ -8,7 +8,7 @@ maintainers = [{name = "Pallets", email = "contact@palletsprojects.com"}]
 dependencies = ["flask"]
 
 [project.urls]
-Documentation = "https://flask.palletsprojects.com/patterns/jquery/"
+Documentation = "https://flask.palletsprojects.com/patterns/javascript/"
 
 [project.optional-dependencies]
 test = ["pytest"]


### PR DESCRIPTION
Changed the documentation URL to match the one in [README.rst](https://github.com/pallets/flask/blob/main/examples/javascript/README.rst)