### PR TITLE
Fixing missing closing </li> statements in the base layout of the flaskr tutorial

### DIFF
--- a/docs/tutorial/templates.rst
+++ b/docs/tutorial/templates.rst
@@ -53,11 +53,11 @@ specific sections.
       <h1>Flaskr</h1>
       <ul>
         {% if g.user %}
-          <li><span>{{ g.user['username'] }}</span>
-          <li><a href="{{ url_for('auth.logout') }}">Log Out</a>
+          <li><span>{{ g.user['username'] }}</span></li>
+          <li><a href="{{ url_for('auth.logout') }}">Log Out</a></li>
         {% else %}
-          <li><a href="{{ url_for('auth.register') }}">Register</a>
-          <li><a href="{{ url_for('auth.login') }}">Log In</a>
+          <li><a href="{{ url_for('auth.register') }}">Register</a></li>
+          <li><a href="{{ url_for('auth.login') }}">Log In</a></li>
         {% endif %}
       </ul>
     </nav>

--- a/examples/tutorial/flaskr/templates/base.html
+++ b/examples/tutorial/flaskr/templates/base.html
@@ -5,11 +5,11 @@
   <h1><a href="{{ url_for('index') }}">Flaskr</a></h1>
   <ul>
     {% if g.user %}
-      <li><span>{{ g.user['username'] }}</span>
-      <li><a href="{{ url_for('auth.logout') }}">Log Out</a>
+      <li><span>{{ g.user['username'] }}</span></li>
+      <li><a href="{{ url_for('auth.logout') }}">Log Out</a></li>
     {% else %}
-      <li><a href="{{ url_for('auth.register') }}">Register</a>
-      <li><a href="{{ url_for('auth.login') }}">Log In</a>
+      <li><a href="{{ url_for('auth.register') }}">Register</a></li>
+      <li><a href="{{ url_for('auth.login') }}">Log In</a></li>
     {% endif %}
   </ul>
 </nav>


### PR DESCRIPTION
I did not create an issue for this.

In my opinion, the closing tags `</li>` were missing in the `g.user` auth part of the `base.html` template of the flaskr tutorial. I added them in two places:
- docs/tutorial/templates.rst
- examples/tutorial/flaskr/templates/base.html

So far I have not changed the CHANGES.rst, as I think this is a minor change.
