### PR TITLE
Edited variable names in quickstart guide

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -375,7 +375,7 @@ Here's a simple example of how to render a template::
     @app.route('/hello/')
     @app.route('/hello/<name>')
     def hello(name=None):
-        return render_template('hello.html', name=name)
+        return render_template('hello.html', person=name)
 
 Flask will look for templates in the :file:`templates` folder.  So if your
 application is a module, this folder is next to that module, if it's a
@@ -404,8 +404,8 @@ Here is an example template:
 
     <!doctype html>
     <title>Hello from Flask</title>
-    {% if name %}
-      <h1>Hello {{ name }}!</h1>
+    {% if person %}
+      <h1>Hello {{ person }}!</h1>
     {% else %}
       <h1>Hello, World!</h1>
     {% endif %}
@@ -419,7 +419,7 @@ know how that works, see :doc:`patterns/templateinheritance`. Basically
 template inheritance makes it possible to keep certain elements on each
 page (like header, navigation and footer).
 
-Automatic escaping is enabled, so if ``name`` contains HTML it will be escaped
+Automatic escaping is enabled, so if ``person`` contains HTML it will be escaped
 automatically.  If you can trust a variable and you know that it will be
 safe HTML (for example because it came from a module that converts wiki
 markup to HTML) you can mark it as safe by using the


### PR DESCRIPTION
Changed variable names in the rendering templates code snippets. This was to remove confusion between the differences of the html variables and the python variables.

Also discussed here: #5484  