### PR TITLE
Fix `redefined-outer-name`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,7 @@ html_show_sourcelink = False
 
 def github_link(name, rawtext, text, lineno, inliner, options=None, content=None):
     app = inliner.document.settings.env.app
-    release = app.config.release
+    app_release = app.config.release
     base_url = "https://github.com/pallets/flask/tree/"
 
     if text.endswith(">"):
@@ -76,10 +76,10 @@ def github_link(name, rawtext, text, lineno, inliner, options=None, content=None
     else:
         words = None
 
-    if packaging.version.parse(release).is_devrelease:
+    if packaging.version.parse(app_release).is_devrelease:
         url = f"{base_url}main/{text}"
     else:
-        url = f"{base_url}{release}/{text}"
+        url = f"{base_url}{app_release}/{text}"
 
     if words is None:
         words = url

--- a/examples/celery/src/task_app/views.py
+++ b/examples/celery/src/task_app/views.py
@@ -8,13 +8,13 @@ bp = Blueprint("tasks", __name__, url_prefix="/tasks")
 
 
 @bp.get("/result/<id>")
-def result(id: str) -> dict[str, object]:
-    result = AsyncResult(id)
-    ready = result.ready()
+def get_result(id: str) -> dict[str, object]:
+    async_result = AsyncResult(id)
+    ready = async_result.ready()
     return {
         "ready": ready,
-        "successful": result.successful() if ready else None,
-        "value": result.get() if ready else result.result,
+        "successful": async_result.successful() if ready else None,
+        "value": async_result.get() if ready else async_result.result,
     }
 
 
@@ -22,17 +22,17 @@ def result(id: str) -> dict[str, object]:
 def add() -> dict[str, object]:
     a = request.form.get("a", type=int)
     b = request.form.get("b", type=int)
-    result = tasks.add.delay(a, b)
-    return {"result_id": result.id}
+    task_result = tasks.add.delay(a, b)
+    return {"result_id": task_result.id}
 
 
 @bp.post("/block")
 def block() -> dict[str, object]:
-    result = tasks.block.delay()
-    return {"result_id": result.id}
+    task_result = tasks.block.delay()
+    return {"result_id": task_result.id}
 
 
 @bp.post("/process")
 def process() -> dict[str, object]:
-    result = tasks.process.delay(total=request.form.get("total", type=int))
-    return {"result_id": result.id}
+    task_result = tasks.process.delay(total=request.form.get("total", type=int))
+    return {"result_id": task_result.id}

--- a/examples/javascript/tests/conftest.py
+++ b/examples/javascript/tests/conftest.py
@@ -11,5 +11,5 @@ def fixture_app():
 
 
 @pytest.fixture
-def client(app):
-    return app.test_client()
+def client(app_):
+    return app_.test_client()

--- a/examples/tutorial/tests/conftest.py
+++ b/examples/tutorial/tests/conftest.py
@@ -18,14 +18,14 @@ def app():
     # create a temporary file to isolate the database for each test
     db_fd, db_path = tempfile.mkstemp()
     # create the app with common test config
-    app = create_app({"TESTING": True, "DATABASE": db_path})
+    test_app = create_app({"TESTING": True, "DATABASE": db_path})
 
     # create the database and load test data
-    with app.app_context():
+    with test_app.app_context():
         init_db()
         get_db().executescript(_data_sql)
 
-    yield app
+    yield test_app
 
     # close and remove the temporary database
     os.close(db_fd)
@@ -33,20 +33,20 @@ def app():
 
 
 @pytest.fixture
-def client(app):
+def client(app_):
     """A test client for the app."""
-    return app.test_client()
+    return app_.test_client()
 
 
 @pytest.fixture
-def runner(app):
+def runner(app_):
     """A test runner for the app's Click commands."""
-    return app.test_cli_runner()
+    return app_.test_cli_runner()
 
 
 class AuthActions:
-    def __init__(self, client):
-        self._client = client
+    def __init__(self, client_obj):
+        self._client = client_obj
 
     def login(self, username="test", password="test"):
         return self._client.post(

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -399,7 +399,7 @@ class Flask(App):
         rv.policies["json.dumps_function"] = self.json.dumps
         return rv
 
-    def create_url_adapter(self, request: Request | None) -> MapAdapter | None:
+    def create_url_adapter(self, request_obj: Request | None) -> MapAdapter | None:
         """Creates a URL adapter for the given request. The URL adapter
         is created at a point where the request context is not yet set
         up so the request is passed explicitly.
@@ -414,7 +414,7 @@ class Flask(App):
             :data:`SERVER_NAME` no longer implicitly enables subdomain
             matching. Use :attr:`subdomain_matching` instead.
         """
-        if request is not None:
+        if request_obj is not None:
             # If subdomain matching is disabled (the default), use the
             # default subdomain in all cases. This should be the default
             # in Werkzeug but it currently does not have that feature.
@@ -424,7 +424,7 @@ class Flask(App):
                 subdomain = None
 
             return self.url_map.bind_to_environ(
-                request.environ,
+                request_obj.environ,
                 server_name=self.config["SERVER_NAME"],
                 subdomain=subdomain,
             )
@@ -439,7 +439,7 @@ class Flask(App):
 
         return None
 
-    def raise_routing_exception(self, request: Request) -> t.NoReturn:
+    def raise_routing_exception(self, req: Request) -> t.NoReturn:
         """Intercept routing exceptions and possibly do something else.
 
         In debug mode, intercept a routing redirect and replace it with
@@ -457,15 +457,15 @@ class Flask(App):
         """
         if (
             not self.debug
-            or not isinstance(request.routing_exception, RequestRedirect)
-            or request.routing_exception.code in {307, 308}
-            or request.method in {"GET", "HEAD", "OPTIONS"}
+            or not isinstance(req.routing_exception, RequestRedirect)
+            or req.routing_exception.code in {307, 308}
+            or req.method in {"GET", "HEAD", "OPTIONS"}
         ):
-            raise request.routing_exception  # type: ignore[misc]
+            raise req.routing_exception  # type: ignore[misc]
 
         from .debughelpers import FormDataRoutingRedirect
 
-        raise FormDataRoutingRedirect(request)
+        raise FormDataRoutingRedirect(req)
 
     def update_template_context(self, context: dict[str, t.Any]) -> None:
         """Update the template context with some commonly used variables.

--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -545,7 +545,7 @@ class FlaskGroup(AppGroup):
         add_default_commands: bool = True,
         create_app: t.Callable[..., Flask] | None = None,
         add_version_option: bool = True,
-        load_dotenv: bool = True,
+        load_env_vars: bool = True,
         set_debug_flag: bool = True,
         **extra: t.Any,
     ) -> None:
@@ -567,7 +567,7 @@ class FlaskGroup(AppGroup):
         super().__init__(params=params, **extra)
 
         self.create_app = create_app
-        self.load_dotenv = load_dotenv
+        self.load_env_vars = load_env_vars
         self.set_debug_flag = set_debug_flag
 
         if add_default_commands:

--- a/tests/test_appctx.py
+++ b/tests/test_appctx.py
@@ -131,7 +131,7 @@ def test_app_tearing_down_with_unhandled_exception(app, client):
     assert str(cleanup_stuff[0]) == "dummy"
 
 
-def test_app_ctx_globals_methods(app, app_ctx):
+def test_app_ctx_globals_methods(app, app_ctx_local):
     # get
     assert flask.g.get("foo") is None
     assert flask.g.get("foo", "bar") == "bar"

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -196,8 +196,8 @@ def test_json_decimal():
 def test_json_attr(app, client):
     @app.route("/add", methods=["POST"])
     def add():
-        json = flask.request.get_json()
-        return str(json["a"] + json["b"])
+        data = flask.request.get_json()
+        return str(data["a"] + data["b"])
 
     rv = client.post(
         "/add",


### PR DESCRIPTION
Changes Made:

- Applied automated fixes for the pylint warning `redefined-outer-name`.
"Used when a variable's name hides a name defined in an outer scope or except handler."

Note:
This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.