### PR TITLE
bumping werkzueg version to 3.0.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+Version 3.1.1
+-------------
+
+-   Require Werkzeug >= 3.0.3.
+
 Version 3.1.0
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "Werkzeug>=3.0.0",
+    "Werkzeug>=3.0.3",
     "Jinja2>=3.1.2",
     "itsdangerous>=2.1.2",
     "click>=8.1.3",

--- a/requirements-skip/tests-min.in
+++ b/requirements-skip/tests-min.in
@@ -1,4 +1,4 @@
-werkzeug==3.0.0
+werkzeug==3.0.3
 jinja2==3.1.2
 markupsafe==2.1.1
 itsdangerous==2.1.2

--- a/requirements-skip/tests-min.txt
+++ b/requirements-skip/tests-min.txt
@@ -17,5 +17,5 @@ markupsafe==2.1.1
     #   -r tests-min.in
     #   jinja2
     #   werkzeug
-werkzeug==3.0.0
+werkzeug==3.0.3
     # via -r tests-min.in


### PR DESCRIPTION
Update Werkzeug to 3.0.3 to address vulnerability found in Werkzeug debugger.
https://werkzeug.palletsprojects.com/en/3.0.x/changes/

Updating Werkzeug to version 3.0.3 addresses the debugger vulnerability.

fixes #5523

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
