### PR TITLE
Add unit tests to show, that encoding parameter in open_resource method is required

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -349,7 +349,7 @@ class TestHelpers:
             os.remove("tests/static/test.txt")
 
         with open("tests/static/test.txt", "w", encoding=encoding) as f:
-            f.write("" + "Hello World!")
+            f.write("Hello World!")
 
         with app.open_resource("static/test.txt", mode="r", encoding=encoding) as f:
             assert "Hello World!" in f.read()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -341,6 +341,19 @@ class TestHelpers:
         with app.open_resource("static/index.html", mode) as f:
             assert "<h1>Hello World!</h1>" in str(f.read())
 
+    @pytest.mark.skip(reason="this feature is not yet implemented")
+    @pytest.mark.parametrize("encoding", ("utf-8", 'utf-16-le'))
+    def test_open_resource_with_encoding(self, encoding):
+        app = flask.Flask(__name__)
+        if os.path.isfile('tests/static/test.txt'):
+            os.remove('tests/static/test.txt')
+
+        with open('tests/static/test.txt', 'w', encoding=encoding) as f:
+            f.write(u'' + 'Hello World!')
+
+        with app.open_resource("static/test.txt", mode='r', encoding=encoding) as f:
+            assert "Hello World!" in f.read()
+
     @pytest.mark.parametrize("mode", ("w", "x", "a", "r+"))
     def test_open_resource_exceptions(self, mode):
         app = flask.Flask(__name__)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -342,16 +342,16 @@ class TestHelpers:
             assert "<h1>Hello World!</h1>" in str(f.read())
 
     @pytest.mark.skip(reason="this feature is not yet implemented")
-    @pytest.mark.parametrize("encoding", ("utf-8", 'utf-16-le'))
+    @pytest.mark.parametrize("encoding", ("utf-8", "utf-16-le"))
     def test_open_resource_with_encoding(self, encoding):
         app = flask.Flask(__name__)
-        if os.path.isfile('tests/static/test.txt'):
-            os.remove('tests/static/test.txt')
+        if os.path.isfile("tests/static/test.txt"):
+            os.remove("tests/static/test.txt")
 
-        with open('tests/static/test.txt', 'w', encoding=encoding) as f:
-            f.write(u'' + 'Hello World!')
+        with open("tests/static/test.txt", "w", encoding=encoding) as f:
+            f.write("" + "Hello World!")
 
-        with app.open_resource("static/test.txt", mode='r', encoding=encoding) as f:
+        with app.open_resource("static/test.txt", mode="r", encoding=encoding) as f:
             assert "Hello World!" in f.read()
 
     @pytest.mark.parametrize("mode", ("w", "x", "a", "r+"))


### PR DESCRIPTION
I am creating this PR so you can see the necessity of fixing issue #5504 
Tests are marked as skipped, so it will not break.
