### PR TITLE
Provide more clear flask -e, --env-file flag desription

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Released 2024-04-07
     :issue:`5448`
 -   Don't initialize the ``cli`` attribute in the sansio scaffold, but rather in
     the ``Flask`` concrete class. :pr:`5270`
-
+-   Provide more clear ``flask`` ``-e, --env-file`` flag desription. :pr:`5532`
 
 Version 3.0.2
 -------------

--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -504,7 +504,12 @@ def _env_file_callback(
 _env_file_option = click.Option(
     ["-e", "--env-file"],
     type=click.Path(exists=True, dir_okay=False),
-    help="Load environment variables from this file. python-dotenv must be installed.",
+    help=(
+        "Load environment variables from this FILE in addition to environment "
+        "variables from '.env' and '.flaskenv' files. Does not override "
+        "environment variables from '.env' and '.flaskenv'. "
+        "python-dotenv must be installed."
+    ),
     is_eager=True,
     expose_value=False,
     callback=_env_file_callback,


### PR DESCRIPTION
Currently the description for `flask` cli command `-e, --env-file` flag is misleading. I understand that this functionality is covered and perfectly explained in docs, but in case you are not familiar with documentation you will just use `flask --help` command to read which flags are allowed.

This PR just adds few sentences to make `-e, --env-file` flag description more clear and exhaustive.
**Before:**
![image](https://github.com/user-attachments/assets/39b7fb57-93b6-4604-bb3e-3eccfe44cb29)
**After**
![image](https://github.com/user-attachments/assets/7957d673-685e-4bee-aecf-65922bdd3886)

Initial PR with for `-e, --env-file` flag: https://github.com/pallets/flask/pull/4646
