### PR TITLE
update helpers.send_from_directory docstring

### DIFF
--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -546,8 +546,8 @@ def send_from_directory(
     If the final path does not point to an existing regular file,
     raises a 404 :exc:`~werkzeug.exceptions.NotFound` error.
 
-    :param directory: The directory that ``path`` must be located under,
-        relative to the current application's root path.
+    :param directory: The directory that ``path`` must be located under. This *must not*
+        be a value provided by the client, otherwise it becomes insecure.
     :param path: The path to the file to send, relative to
         ``directory``.
     :param kwargs: Arguments to pass to :func:`send_file`.

--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -546,7 +546,8 @@ def send_from_directory(
     If the final path does not point to an existing regular file,
     raises a 404 :exc:`~werkzeug.exceptions.NotFound` error.
 
-    :param directory: The directory that ``path`` must be located under. This *must not*
+    :param directory: The directory that ``path`` must be located under,
+        relative to the current application's root path. This *must not*
         be a value provided by the client, otherwise it becomes insecure.
     :param path: The path to the file to send, relative to
         ``directory``.


### PR DESCRIPTION
Update helpers.send_from_directory docstring to match werkzeug.utils.send_from_directory docstring on the :param directory: line.

The previous "relative to the current application's root path" is misleading to actual behaviour.

[Current: send_from_directory](https://flask.palletsprojects.com/en/3.0.x/api/#flask.send_from_directory)