### PR TITLE
Address a mypy failure in CI

### DIFF
--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -103,7 +103,7 @@ def stream_with_context(
             gen = generator_or_function(*args, **kwargs)  # type: ignore[operator]
             return stream_with_context(gen)
 
-        return update_wrapper(decorator, generator_or_function)  # type: ignore[arg-type, return-value]
+        return update_wrapper(decorator, generator_or_function)  # type: ignore[arg-type]
 
     def generator() -> t.Iterator[t.AnyStr | None]:
         ctx = _cv_request.get(None)


### PR DESCRIPTION
mypy 1.11.1 is reporting that [`return-value` is an unused ignore in CI](https://github.com/pallets/flask/actions/runs/10655465924/job/29533008516#step:6:25), and when running `tox -e typing` locally.

As this is a code comment for mypy's benefit, I'm anticipating that this doesn't need to be added to the CHANGELOG, but please let me know if that's incorrect. Thanks!