### PR TITLE
use python 3.9 to test dev versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,7 @@ jobs:
           - {python: '3.8'}
           - {name: PyPy, python: 'pypy-3.10', tox: pypy310}
           - {name: Minimum Versions, python: '3.12', tox: py-min}
-          - {name: Development Versions, python: '3.8', tox: py-dev}
+          - {name: Development Versions, python: '3.9', tox: py-dev}
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py3{13,12,11,10,9,8}
     pypy310
     py312-min
-    py38-dev
+    py39-dev
     style
     typing
     docs


### PR DESCRIPTION
Minimum supported version of dev versions is now Python 3.9 (MarkupSafe got there first). 3.8 is still supported by the 3.0.x branch, but testing dev versions needs to be bumped.
