### PR TITLE
give priority to '-e/--env-file' option over default files (#5628)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Unreleased
     about resource limits to the security page. :issue:`5625`
 -   Add support for the ``Partitioned`` cookie attribute (CHIPS), with the
     ``SESSION_COOKIE_PARTITIONED`` config. :issue`5472`
+-   Give priority to file specified through the -e/--env-file option
+    over default .env & .flaskenv files in CLI.
 
 
 Version 3.0.3

--- a/tests/test_apps/.customenv
+++ b/tests/test_apps/.customenv
@@ -1,0 +1,4 @@
+FOO=customenv
+BAZ=1
+BAR=custombar
+EGGS=custom

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -565,6 +565,21 @@ def test_disable_dotenv_from_env(monkeypatch, runner):
     assert "FOO" not in os.environ
 
 
+@need_dotenv
+def test_custom_dotenv_takes_priority(monkeypatch, runner):
+    monkeypatch.chdir(test_path)
+    runner.invoke(FlaskGroup(), "-e .customenv")
+
+    # .customenv is loaded
+    assert "BAZ" in os.environ
+
+    # .customenv takes priority over .flaskenv
+    assert os.environ["BAR"] == "custombar"
+
+    # .customenv takes priority over .env
+    assert os.environ["FOO"] == "customenv"
+
+
 def test_run_cert_path():
     # no key
     with pytest.raises(click.BadParameter):


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

This PR fixes issue #5628 . The issue arose from the fact that `FlaskGroup().make_context()` was loading the default env files before loading the arguments (by calling `super().make_context()`. Simply reversing the order of these actions fixes the issue. I have added the relevant tests to make sure it works.

- [x] Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.