### PR TITLE
setting `SERVER_NAME` does not restrict routing for both `subdomain_matching` and `host_matching`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,9 @@ Unreleased
 -   Support key rotation with the ``SECRET_KEY_FALLBACKS`` config, a list of old
     secret keys that can still be used for unsigning. Extensions will need to
     add support. :issue:`5621`
+-   Fix how setting ``host_matching=True`` or ``subdomain_matching=False``
+    interacts with ``SERVER_NAME``. Setting ``SERVER_NAME`` no longer restricts
+    requests to only that domain. :issue:`5553`
 
 
 Version 3.0.3

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -260,13 +260,22 @@ The following configuration values are used internally by Flask:
 
 .. py:data:: SERVER_NAME
 
-    Inform the application what host and port it is bound to. Required
-    for subdomain route matching support.
+    Inform the application what host and port it is bound to.
 
-    If set, ``url_for`` can generate external URLs with only an application
-    context instead of a request context.
+    Must be set if ``subdomain_matching`` is enabled, to be able to extract the
+    subdomain from the request.
+
+    Must be set for ``url_for`` to generate external URLs outside of a
+    request context.
 
     Default: ``None``
+
+    .. versionchanged:: 3.1
+        Does not restrict requests to only this domain, for both
+        ``subdomain_matching`` and ``host_matching``.
+
+    .. versionchanged:: 1.0
+        Does not implicitly enable ``subdomain_matching``.
 
     .. versionchanged:: 2.3
         Does not affect ``SESSION_COOKIE_DOMAIN``.

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -425,32 +425,40 @@ class Flask(App):
         is created at a point where the request context is not yet set
         up so the request is passed explicitly.
 
-        .. versionadded:: 0.6
-
-        .. versionchanged:: 0.9
-           This can now also be called without a request object when the
-           URL adapter is created for the application context.
+        .. versionchanged:: 3.1
+            If :data:`SERVER_NAME` is set, it does not restrict requests to
+            only that domain, for both ``subdomain_matching`` and
+            ``host_matching``.
 
         .. versionchanged:: 1.0
             :data:`SERVER_NAME` no longer implicitly enables subdomain
             matching. Use :attr:`subdomain_matching` instead.
+
+        .. versionchanged:: 0.9
+           This can be called outside a request when the URL adapter is created
+           for an application context.
+
+        .. versionadded:: 0.6
         """
         if request is not None:
-            # If subdomain matching is disabled (the default), use the
-            # default subdomain in all cases. This should be the default
-            # in Werkzeug but it currently does not have that feature.
-            if not self.subdomain_matching:
-                subdomain = self.url_map.default_subdomain or None
-            else:
-                subdomain = None
+            subdomain = None
+            server_name = self.config["SERVER_NAME"]
+
+            if self.url_map.host_matching:
+                # Don't pass SERVER_NAME, otherwise it's used and the actual
+                # host is ignored, which breaks host matching.
+                server_name = None
+            elif not self.subdomain_matching:
+                # Werkzeug doesn't implement subdomain matching yet. Until then,
+                # disable it by forcing the current subdomain to the default, or
+                # the empty string.
+                subdomain = self.url_map.default_subdomain or ""
 
             return self.url_map.bind_to_environ(
-                request.environ,
-                server_name=self.config["SERVER_NAME"],
-                subdomain=subdomain,
+                request.environ, server_name=server_name, subdomain=subdomain
             )
-        # We need at the very least the server name to be set for this
-        # to work.
+
+        # Need at least SERVER_NAME to match/build outside a request.
         if self.config["SERVER_NAME"] is not None:
             return self.url_map.bind(
                 self.config["SERVER_NAME"],

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,6 +4,7 @@ import typing as t
 import uuid
 import warnings
 import weakref
+from contextlib import nullcontext
 from datetime import datetime
 from datetime import timezone
 from platform import python_implementation
@@ -1481,6 +1482,48 @@ def test_static_route_with_host_matching():
 def test_request_locals():
     assert repr(flask.g) == "<LocalProxy unbound>"
     assert not flask.g
+
+
+@pytest.mark.parametrize(
+    ("subdomain_matching", "host_matching", "expect_base", "expect_abc", "expect_xyz"),
+    [
+        (False, False, "default", "default", "default"),
+        (True, False, "default", "abc", "<invalid>"),
+        (False, True, "default", "abc", "default"),
+    ],
+)
+def test_server_name_matching(
+    subdomain_matching: bool,
+    host_matching: bool,
+    expect_base: str,
+    expect_abc: str,
+    expect_xyz: str,
+) -> None:
+    app = flask.Flask(
+        __name__,
+        subdomain_matching=subdomain_matching,
+        host_matching=host_matching,
+        static_host="example.test" if host_matching else None,
+    )
+    app.config["SERVER_NAME"] = "example.test"
+
+    @app.route("/", defaults={"name": "default"}, host="<name>")
+    @app.route("/", subdomain="<name>", host="<name>.example.test")
+    def index(name: str) -> str:
+        return name
+
+    client = app.test_client()
+
+    r = client.get(base_url="http://example.test")
+    assert r.text == expect_base
+
+    r = client.get(base_url="http://abc.example.test")
+    assert r.text == expect_abc
+
+    with pytest.warns() if subdomain_matching else nullcontext():
+        r = client.get(base_url="http://xyz.other.test")
+
+    assert r.text == expect_xyz
 
 
 def test_server_name_subdomain():


### PR DESCRIPTION
I wrote a bunch in #5553 about investigating this. Essentially, we need to pass `""` to disable subdomain matching, not `None`. The two tests that had to change were accidentally working because setting `SERVER_NAME` was bypassing `subdomain_matching = False`, and the tests should have been setting it to `True` since they were working with subdomains.

Now `SERVER_NAME` only affects routing if `subdomain_matching=True`, in which case it correctly limits routing to subdomains under that name.

fixes #5553 