### PR TITLE
fix type hint for `cli_runner.invoke`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 3.1.1
 
 Unreleased
 
+-   Fix type hint for `cli_runner.invoke`. :issue:`5645`
+
 
 Version 3.1.0
 -------------

--- a/src/flask/testing.py
+++ b/src/flask/testing.py
@@ -10,6 +10,7 @@ from urllib.parse import urlsplit
 
 import werkzeug.test
 from click.testing import CliRunner
+from click.testing import Result
 from werkzeug.test import Client
 from werkzeug.wrappers import Request as BaseRequest
 
@@ -273,7 +274,7 @@ class FlaskCliRunner(CliRunner):
 
     def invoke(  # type: ignore
         self, cli: t.Any = None, args: t.Any = None, **kwargs: t.Any
-    ) -> t.Any:
+    ) -> Result:
         """Invokes a CLI command in an isolated environment. See
         :meth:`CliRunner.invoke <click.testing.CliRunner.invoke>` for
         full method documentation. See :ref:`testing-cli` for examples.


### PR DESCRIPTION
https://github.com/pallets/flask/issues/5645

Hello! I love Flask! This is my first attempt to start participating in open source, so I'm very nervous, even though the changes I've made are insignificant. Thank you!

From `testing.invoke() -> t.Any` to `testing.invoke() -> Result`