### PR TITLE
remove previously deprecated code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 3.2.0
 
 Unreleased
 
+-   Remove previously deprecated code: ``__version__``. :pr:`5648`
+
 
 Version 3.1.0
 -------------

--- a/src/flask/__init__.py
+++ b/src/flask/__init__.py
@@ -1,7 +1,3 @@
-from __future__ import annotations
-
-import typing as t
-
 from . import json as json
 from .app import Flask as Flask
 from .blueprints import Blueprint as Blueprint
@@ -41,20 +37,3 @@ from .templating import stream_template as stream_template
 from .templating import stream_template_string as stream_template_string
 from .wrappers import Request as Request
 from .wrappers import Response as Response
-
-
-def __getattr__(name: str) -> t.Any:
-    if name == "__version__":
-        import importlib.metadata
-        import warnings
-
-        warnings.warn(
-            "The '__version__' attribute is deprecated and will be removed in"
-            " Flask 3.1. Use feature detection or"
-            " 'importlib.metadata.version(\"flask\")' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return importlib.metadata.version("flask")
-
-    raise AttributeError(name)


### PR DESCRIPTION
`__version__` was marked to be removed in 3.1, but I forgot to actually remove it. So now it's removed in 3.2 instead.