### PR TITLE
update `__version__` deprecation

### DIFF
--- a/src/flask/__init__.py
+++ b/src/flask/__init__.py
@@ -50,7 +50,7 @@ def __getattr__(name: str) -> t.Any:
 
         warnings.warn(
             "The '__version__' attribute is deprecated and will be removed in"
-            " Flask 3.1. Use feature detection or"
+            " Flask 3.2. Use feature detection or"
             " 'importlib.metadata.version(\"flask\")' instead.",
             DeprecationWarning,
             stacklevel=2,


### PR DESCRIPTION
`__version__` was marked to be removed in 3.1, but I forgot to actually remove it. Update the warning to say it will be removed in 3.2.
