### PR TITLE
Async Iterable Response

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Unreleased
 -   Fix type hint for `cli_runner.invoke`. :issue:`5645`
 -   ``flask --help`` loads the app and plugins first to make sure all commands
     are shown. :issue:5673`
+-   Mark sans-io base class as being able to handle views that return
+    ``AsyncIterable``. This is not accurate for Flask, but makes typing easier
+    for Quart. :pr:`5659`
 
 
 Version 3.1.0

--- a/src/flask/typing.py
+++ b/src/flask/typing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections.abc as cabc
 import typing as t
 
 if t.TYPE_CHECKING:  # pragma: no cover
@@ -17,6 +18,8 @@ ResponseValue = t.Union[
     t.Mapping[str, t.Any],
     t.Iterator[str],
     t.Iterator[bytes],
+    cabc.AsyncIterable[str],  # for Quart, until App is generic.
+    cabc.AsyncIterable[bytes],
 ]
 
 # the possible types for an individual HTTP header


### PR DESCRIPTION
In this pull request, we fix the typing for what is allowed to be used as a response type, allowing responses to be `AsyncIterable[str]` or `AsyncIterable[bytes]`.

Flask sans-io is used by Quart

Through a huge chain of things, this pull request fixes #5322, because https://github.com/pallets/quart/pull/341 doesn't actually fix the root issue unfortunately.