### PR TITLE
Update app factory docs

### DIFF
--- a/docs/patterns/appfactories.rst
+++ b/docs/patterns/appfactories.rst
@@ -99,9 +99,9 @@ to the factory like this:
 
 .. code-block:: text
 
-    $ flask --app hello:create_app(local_auth=True) run
+    $ flask --app 'hello:create_app(local_auth=True)' run
 
-Then the ``create_app`` factory in ``myapp`` is called with the keyword
+Then the ``create_app`` factory in ``hello`` is called with the keyword
 argument ``local_auth=True``. See :doc:`/cli` for more detail.
 
 Factory Improvements


### PR DESCRIPTION
Update app factory documentation

1. 
```
> flask --app app:create_app(testing=True) run
bash: syntax error near unexpected token `('
```

2. Update example application name from `myapp` (old name) to `hello`