### PR TITLE
Handle help arg by itself the same as no args

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Version 3.1.1
 Unreleased
 
 -   Fix type hint for `cli_runner.invoke`. :issue:`5645`
+-   ``flask --help`` loads the app and plugins first to make sure all commands
+    are shown. :issue:5673`
 
 
 Version 3.1.0

--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -684,7 +684,9 @@ class FlaskGroup(AppGroup):
         return super().make_context(info_name, args, parent=parent, **extra)
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
-        if not args and self.no_args_is_help:
+        if (not args and self.no_args_is_help) or (
+            len(args) == 1 and args[0] in self.get_help_option_names(ctx)
+        ):
             # Attempt to load --env-file and --app early in case they
             # were given as env vars. Otherwise no_args_is_help will not
             # see commands from app.cli.


### PR DESCRIPTION
When the `flask` command is used with only the `--help` parameter, this change will make sure to try and load the app before the help callback is run. This was previously only being done when the `flask` command was used by itself. This meant when passing in `--help`, any custom commands were not getting shown in the help message. With this change, custom commands will be included in the help message when running `flask` on the command line by itself or with the `--help` parameter.

This addresses #5673.

If you want me to update anything else for this PR please let me know!