### PR TITLE
Fix inaccurate documentation for adding a favicon redirect

### DIFF
--- a/docs/patterns/favicon.rst
+++ b/docs/patterns/favicon.rst
@@ -24,8 +24,10 @@ the root path of the domain you either need to configure the web server to
 serve the icon at the root or if you can't do that you're out of luck. If
 however your application is the root you can simply route a redirect::
 
-    app.add_url_rule('/favicon.ico',
-                     redirect_to=url_for('static', filename='favicon.ico'))
+    from flask import url_for
+
+    @app.route('/favicon.ico')
+        return redirect( url_for( 'static', filename='favicon.ico' ) )
 
 If you want to save the extra redirect request you can also write a view
 using :func:`~flask.send_from_directory`::


### PR DESCRIPTION
The code sample in the existing documentation on how to redirect a favicon request assumes that add_url_rule takes a parameter named redirect_to. It does not.

closes #5686