### PR TITLE
Remove HTTP Public Key Pinning from docs

### DIFF
--- a/docs/web-security.rst
+++ b/docs/web-security.rst
@@ -269,19 +269,6 @@ values (or any values that need secure signatures).
 .. _samesite_support: https://caniuse.com/#feat=same-site-cookie-attribute
 
 
-HTTP Public Key Pinning (HPKP)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This tells the browser to authenticate with the server using only the specific
-certificate key to prevent MITM attacks.
-
-.. warning::
-   Be careful when enabling this, as it is very difficult to undo if you set up
-   or upgrade your key incorrectly.
-
-- https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning
-
-
 Copy/Paste to Terminal
 ----------------------
 


### PR DESCRIPTION
This PR simply removes the section on HTTP Public Key Pinning from the security headers documentation.
The header is considered obsolete and no longer supported by any major browser.
The MDN link is dead/redirects to an explanation of the certificate transparency system. The only remaining reference I found within MDN is in the [glossary](https://developer.mozilla.org/en-US/docs/Glossary/HPKP).