### PR TITLE
remove extra logic

### DIFF
--- a/src/flask/sansio/blueprints.py
+++ b/src/flask/sansio/blueprints.py
@@ -314,7 +314,6 @@ class Blueprint(Scaffold):
             )
 
         first_bp_registration = not any(bp is self for bp in app.blueprints.values())
-        first_name_registration = name not in app.blueprints
 
         app.blueprints[name] = self
         self._got_registered_once = True
@@ -328,7 +327,7 @@ class Blueprint(Scaffold):
             )
 
         # Merge blueprint data into parent.
-        if first_bp_registration or first_name_registration:
+        if first_bp_registration:
             self._merge_blueprint_funcs(app, name)
 
         for deferred in self.deferred_functions:


### PR DESCRIPTION
first_name_registration should always be True, as this check already happens:

```
        if name in app.blueprints:
            bp_desc = "this" if app.blueprints[name] is self else "a different"
            existing_at = f" '{name}'" if self_name != name else ""
            raise ValueError(
                f"The name '{self_name}' is already registered for"
                f" {bp_desc} blueprint{existing_at}. Use 'name=' to"
                f" provide a unique name."
            )
```