### PR TITLE
remove tests about deprecated pkgutil.get_loader

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-import pkgutil
 import sys
 
 import pytest
@@ -94,37 +93,6 @@ def leak_detector():
         request_ctx.pop()
 
     assert leaks == []
-
-
-@pytest.fixture(params=(True, False))
-def limit_loader(request, monkeypatch):
-    """Patch pkgutil.get_loader to give loader without get_filename or archive.
-
-    This provides for tests where a system has custom loaders, e.g. Google App
-    Engine's HardenedModulesHook, which have neither the `get_filename` method
-    nor the `archive` attribute.
-
-    This fixture will run the testcase twice, once with and once without the
-    limitation/mock.
-    """
-    if not request.param:
-        return
-
-    class LimitedLoader:
-        def __init__(self, loader):
-            self.loader = loader
-
-        def __getattr__(self, name):
-            if name in {"archive", "get_filename"}:
-                raise AttributeError(f"Mocking a loader which does not have {name!r}.")
-            return getattr(self.loader, name)
-
-    old_get_loader = pkgutil.get_loader
-
-    def get_loader(*args, **kwargs):
-        return LimitedLoader(old_get_loader(*args, **kwargs))
-
-    monkeypatch.setattr(pkgutil, "get_loader", get_loader)
 
 
 @pytest.fixture

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -63,7 +63,7 @@ def test_uninstalled_namespace_paths(tmp_path, monkeypatch, purge_module):
 
 
 def test_installed_module_paths(
-    modules_tmp_path, modules_tmp_path_prefix, purge_module, site_packages, limit_loader
+    modules_tmp_path, modules_tmp_path_prefix, purge_module, site_packages
 ):
     (site_packages / "site_app.py").write_text(
         "import flask\napp = flask.Flask(__name__)\n"
@@ -78,7 +78,7 @@ def test_installed_module_paths(
 
 
 def test_installed_package_paths(
-    limit_loader, modules_tmp_path, modules_tmp_path_prefix, purge_module, monkeypatch
+    modules_tmp_path, modules_tmp_path_prefix, purge_module, monkeypatch
 ):
     installed_path = modules_tmp_path / "path"
     installed_path.mkdir()
@@ -97,7 +97,7 @@ def test_installed_package_paths(
 
 
 def test_prefix_package_paths(
-    limit_loader, modules_tmp_path, modules_tmp_path_prefix, purge_module, site_packages
+    modules_tmp_path, modules_tmp_path_prefix, purge_module, site_packages
 ):
     app = site_packages / "site_package"
     app.mkdir()


### PR DESCRIPTION
Seems that the code being tested isn't affected by this anymore, and it will go away completely in Python 3.14, so remove these so tests can still pass at that point.

fixes #5692 