### PR TITLE
fix for 5709: explicitly delete error references to prevent memory leaks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Version 3.2.0
 Unreleased
 
 -   Remove previously deprecated code: ``__version__``. :pr:`5648`
+-   Fix reference cycle in exception handling: :issue:`5709`
 
 
 Version 3.1.1

--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1525,6 +1525,7 @@ class Flask(App):
                 error = None
 
             ctx.pop(error)
+            del error
 
     def __call__(
         self, environ: WSGIEnvironment, start_response: StartResponse


### PR DESCRIPTION
Fix for https://github.com/pallets/flask/issues/5709
Add explicit "del error" statement to prevent reference cycles between exception objects and local variables. This helps the garbage collector promptly reclaim memory after request processing, which is especially important in high-traffic web applications where exception objects with traceback information can consume significant memory.