### PR TITLE
fix #5729: raise TypeError when @app.template_filter is used without parenthesis

### DIFF
--- a/src/flask/sansio/app.py
+++ b/src/flask/sansio/app.py
@@ -672,9 +672,18 @@ class App(Scaffold):
           def reverse(s):
               return s[::-1]
 
+        You must include parentheses when using this decorator,
+        even if no arguments are provided.
+
         :param name: the optional name of the filter, otherwise the
                      function name will be used.
         """
+
+        if callable(name):
+            raise TypeError(
+                "Did you mean to use @app.template_filter()? "
+                "Missing parentheses () in decorator"
+            )
 
         def decorator(f: T_template_filter) -> T_template_filter:
             self.add_template_filter(f, name=name)

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -130,6 +130,14 @@ def test_template_filter(app):
     assert app.jinja_env.filters["my_reverse"]("abcd") == "dcba"
 
 
+def test_template_filter_requires_parentheses(app):
+    with pytest.raises(TypeError):
+
+        @app.template_filter
+        def my_reverse(s):
+            return s[::-1]
+
+
 def test_add_template_filter(app):
     def my_reverse(s):
         return s[::-1]


### PR DESCRIPTION
Raise a clear `TypeError` when `@app.template_filter` is used without parentheses.

This prevents silent failures when users mistakenly write `@app.template_filter` instead of `@app.template_filter()`, which previously led to confusing Jinja2 errors as mentioned by @alexwlchan like:

```
jinja2.exceptions.TemplateAssertionError: No filter named 'double'
```

when `app.py` is, for example,

```
from flask import Flask, render_template_string


app = Flask(__name__)


@app.template_filter
def double(x):
    return x * 2


@app.route("/")
def index():
    return render_template_string("2 times 2 is {{ 2 | double }}")
```

Note:
**reason i did it this way and not accept when its just `@app.template_filter` is because it aligns with the behavior of other Flask decorators such as `@app.route`, which already enforce required parentheses when arguments are expected.**

---

fixes #5729 

---

- [x] Added test: `test_template_filter_requires_parens` in `tests/test_templating.py`
- [x] Confirmed `pytest` and `pre-commit` both pass
