### PR TITLE
Fix global CONTRIBUTING link

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,7 +1,7 @@
 Contributing
 ============
 
-See the Pallets `detailed contributing documentation <_contrib>`_ for many ways
+See the Pallets `detailed contributing documentation <contrib_>`_ for many ways
 to contribute, including reporting issues, requesting features, asking or
 answering questions, and making PRs.
 


### PR DESCRIPTION
Fixes the live contributing guidelines link, which just links to https://flask.palletsprojects.com/en/stable/contributing/_contrib (i.e. it puts the RST slug in the URL somehow).

I wrapped to 80 characters, let me know if that's incorrect.