### PR TITLE
Docs: Fix escaping in HTML escaping example

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -141,7 +141,7 @@ how you're using untrusted data.
 
     from markupsafe import escape
 
-    @app.route("/<name>")
+    @app.route("/<path:name>")
     def hello(name):
         return f"Hello, {escape(name)}!"
 


### PR DESCRIPTION
The code in the [Quickstart's HTML Escaping section](https://flask.palletsprojects.com/en/stable/quickstart/#html-escaping) does not render name=<script>alert("bad")</script> to text because the slash in </script> gets interpreted as a trailing slash, leading to a 404.

Adding the path type converter to the name variable allows:
1. the script tag to be rendered as text if HTML escaping is done
2. the alert in the script tag to be executed if HTML escaping is not done.

Since its a simple one line change for code in the documentation, I wasn't sure if I needed to raise an issue regarding this first. I'd be happy to do so if its required.