### PR TITLE
fix: template_filter function ( function parameter was overridden by 'name')

### DIFF
--- a/src/flask/sansio/app.py
+++ b/src/flask/sansio/app.py
@@ -679,7 +679,7 @@ class App(Scaffold):
         def decorator(f: T_template_filter) -> T_template_filter:
             self.add_template_filter(f, name=name)
             return f
-        
+
         if not f:
             return decorator
         return decorator(f)

--- a/src/flask/sansio/app.py
+++ b/src/flask/sansio/app.py
@@ -662,7 +662,7 @@ class App(Scaffold):
 
     @setupmethod
     def template_filter(
-        self, name: str | None = None
+        self, f: T_template_filter | None = None, name: str | None = None
     ) -> t.Callable[[T_template_filter], T_template_filter]:
         """A decorator that is used to register custom template filter.
         You can specify a name for the filter, otherwise the function
@@ -679,8 +679,10 @@ class App(Scaffold):
         def decorator(f: T_template_filter) -> T_template_filter:
             self.add_template_filter(f, name=name)
             return f
-
-        return decorator
+        
+        if not f:
+            return decorator
+        return decorator(f)
 
     @setupmethod
     def add_template_filter(


### PR DESCRIPTION
with ref #5729 
This issue was happening bcs in template_filter decorator "name" argument was overriding default "function" argument by which decorator never receives the actual function lets.
bcs this the function also not being set in filter too.

I have added the function argument in decorator now .

Now no need to called with parenthesis it work as standard decorator now.



