### PR TITLE
Add devcontainer with Python 3.13 and uv support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+# Base image: Match with .readthedocs.yaml and pyproject.toml
+FROM mcr.microsoft.com/devcontainers/python:3.13
+
+# Install uv and pre-commit globally
+RUN pip install --upgrade pip setuptools wheel uv pre-commit
+
+# Set workdir and default shell
+WORKDIR /workspaces/flask
+SHELL ["/bin/bash", "-c"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,8 @@
 {
   "name": "pallets/flask",
-  "image": "mcr.microsoft.com/devcontainers/python:3",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
   "customizations": {
     "vscode": {
       "settings": {

--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 set -e
+
+# Create a virtual environment and upgrade pip/setuptools/wheel
 python3 -m venv --upgrade-deps .venv
 . .venv/bin/activate
-pip install -r requirements/dev.txt
-pip install -e .
-pre-commit install --install-hooks
+
+# uv is already available (installed via Dockerfile). Use uv to install:
+# 1) the project in editable mode
+# 2) all dev dependencies (from pyproject.toml [project.optional-dependencies])
+uv pip install --editable . --group dev
+
+
+# Set up pre-commit hooks
+pre-commit install


### PR DESCRIPTION
This PR adds a development container setup under `.devcontainer/` using Microsoft's Python 3.13 image, with uv support for dependency management.

Changes include:
- Custom Dockerfile using `mcr.microsoft.com/devcontainers/python:3.13`
- Switching to uv for editable installs and dev dependencies
- Config updates in `devcontainer.json` and `on-create-command.sh`