### PR TITLE
docs: added scroll-to-top button with JS and CSS

### DIFF
--- a/docs/_static/scrolltop.css
+++ b/docs/_static/scrolltop.css
@@ -1,0 +1,15 @@
+#scrollToTop {
+  position: fixed;
+  top: 20px;       
+  right: 20px;       
+  background-color: #5EABD6;
+  color: white;
+  border: none;
+  padding: 10px 15px;
+  border-radius: 5px;
+  font-size: 14px;
+  cursor: pointer;
+  z-index: 1000;
+  display: none;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}

--- a/docs/_static/scrolltop.js
+++ b/docs/_static/scrolltop.js
@@ -1,0 +1,17 @@
+window.addEventListener("scroll", function () {
+  const btn = document.getElementById("scrollToTop");
+  btn.style.display = window.scrollY > 300 ? "block" : "none";
+});
+
+function scrollToTop() {
+  window.scrollTo({ top: 0, behavior: "smooth" });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const btn = document.createElement("button");
+  btn.id = "scrollToTop";
+  btn.textContent = "↑ Top";
+  btn.setAttribute("aria-label", "Scroll to top");
+  btn.onclick = scrollToTop;
+  document.body.appendChild(btn);
+});

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,10 @@ html_favicon = "_static/flask-icon.svg"
 html_logo = "_static/flask-logo.svg"
 html_title = f"Flask Documentation ({version})"
 html_show_sourcelink = False
+html_static_path = ['_static']
+html_js_files = ['scrolltop.js']
+html_css_files = ['scrolltop.css']
+
 
 gettext_uuid = True
 gettext_compact = False


### PR DESCRIPTION
 **Pull Request Description**
This pull request adds a scroll-to-top button to documentation pages using dynamically injected JavaScript and CSS. The button appears after scrolling down 300px and smoothly scrolls the page to the top when clicked.

No changes were made to HTML templates—this feature is fully implemented via scrolltop.js and scrolltop.css, added to docs/_static/. The configuration in conf.py ensures these assets are loaded automatically.

fixes #5784 

 **Checklist**
Feature is scoped to documentation only

Scroll-to-top button is injected via JavaScript and styled with CSS

No changes made to HTML templates

Static assets (scrolltop.js and scrolltop.css) added to docs/_static/

conf.py updated to include new static files

No tests required for this non-code enhancement

No changelog entry needed for documentation-only changes

Linked to relevant issue using fixes #5784