### PR TITLE
docs: Fix grammar and article usage in documentation

### DIFF
--- a/docs/errorhandling.rst
+++ b/docs/errorhandling.rst
@@ -261,7 +261,7 @@ Custom Error Pages
 Sometimes when building a Flask application, you might want to raise a
 :exc:`~werkzeug.exceptions.HTTPException` to signal to the user that
 something is wrong with the request. Fortunately, Flask comes with a handy
-:func:`~flask.abort` function that aborts a request with a HTTP error from
+:func:`~flask.abort` function that aborts a request with an HTTP error from
 werkzeug as desired. It will also provide a plain black and white error page
 for you with a basic description, but nothing fancy.
 

--- a/docs/lifecycle.rst
+++ b/docs/lifecycle.rst
@@ -83,7 +83,7 @@ will return data that is translated into an HTTP response.
     to a view function, handle errors, etc.
 #.  Flask translates View function return into WSGI response data, passes it to WSGI
     server.
-#.  WSGI server creates and send an HTTP response.
+#.  WSGI server creates and sends an HTTP response.
 #.  Client receives the HTTP response.
 
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -535,7 +535,7 @@ attributes mentioned above::
 
 What happens if the key does not exist in the ``form`` attribute?  In that
 case a special :exc:`KeyError` is raised.  You can catch it like a
-standard :exc:`KeyError` but if you don't do that, a HTTP 400 Bad Request
+standard :exc:`KeyError` but if you don't do that, an HTTP 400 Bad Request
 error page is shown instead.  So for many situations you don't have to
 deal with that problem.
 


### PR DESCRIPTION
- Fix verb agreement in lifecycle.rst: 'creates and send'
   -> 'creates and sends'
  - Fix article usage: 'a HTTP' -> 'an HTTP' in quickstart.rst and errorhandling.rst