### PR TITLE
Loosen send_file type annotation to include typing.IO[bytes]

### DIFF
--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -398,7 +398,7 @@ def _prepare_send_file_kwargs(**kwargs: t.Any) -> dict[str, t.Any]:
 
 
 def send_file(
-    path_or_file: os.PathLike[t.AnyStr] | str | t.BinaryIO,
+    path_or_file: os.PathLike[t.AnyStr] | str | t.BinaryIO | t.IO[bytes],
     mimetype: str | None = None,
     as_attachment: bool = False,
     download_name: str | None = None,


### PR DESCRIPTION
Loosen send_file's path_or_file annotation to accept typing.IO[bytes] alongside str and BinaryIO. This aligns Flask's annotation with Werkzeug and resolves type checker errors.

Fixes #5776.