### PR TITLE
Update GitHub Actions workflow for artifact handling

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,8 +5,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      artifact-id: ${{ steps.upload-artifact.outputs.artifact-id }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # v6.5.0
         with:
           enable-cache: true
@@ -17,8 +21,11 @@ jobs:
       - run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
       - run: uv build
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        id: upload-artifact
         with:
-          path: ./dist
+          name: dist
+          path: dist/
+          if-no-files-found: error
   create-release:
     needs: [build]
     runs-on: ubuntu-latest
@@ -26,8 +33,11 @@ jobs:
       contents: write
     steps:
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          artifact-ids: ${{ needs.build.outputs.artifact-id }}
+          path: dist/
       - name: create release
-        run: gh release create --draft --repo ${{ github.repository }} ${{ github.ref_name }} artifact/*
+        run: gh release create --draft --repo ${{ github.repository }} ${{ github.ref_name }} dist/*
         env:
           GH_TOKEN: ${{ github.token }}
   publish-pypi:
@@ -40,6 +50,9 @@ jobs:
       id-token: write
     steps:
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          artifact-ids: ${{ needs.build.outputs.artifact-id }}
+          path: dist/
       - uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
-          packages-dir: artifact/
+          packages-dir: "dist/"


### PR DESCRIPTION
## Use `artifact-id` instead of (default assumed) `name` with Actions Artifacts 🔒 

This pull updates the **publish** workflow to use `artifact-id` instead of the default assumed `name` (in this case the literal word `artifact`) when downloading artifacts that have been previously published in prior workflow steps. This is important because artifacts produced by GitHub Actions can be completely overwritten by other workflow runs if they use the same `name` under very unique circumstances (like passing the `run-id` value to the download-artifact action to point to an entirely different workflow run - don't do that). To avoid potential TOCTOU issues/vulnerabilities where an artifact might be replaced between upload and download, the new `artifact-ids` input allows you to download artifacts by their specific ID rather than by name. This is safer but also helps lead to more deterministic workflow builds by referencing the artifact you wish to download by its _exact id_.

This PR also hardens the workflow a bit by adding `persist-credentials: false` to the checkout step.

---

I recently did some work to land these exact changes in the [urllib3/urllib3](https://github.com/urllib3/urllib3/pulls?q=is%3Apr+is%3Aclosed+author%3AGrantBirki) and wanted to contribute those same changes here as well! Also recently made updates to Python's [requests](https://github.com/psf/requests/pull/7005) library to do the same.