### PR TITLE
Changed the static annotated type of select_jinja_autoescape method in src/flask/sansio/app.py

### DIFF
--- a/src/flask/sansio/app.py
+++ b/src/flask/sansio/app.py
@@ -533,7 +533,7 @@ class App(Scaffold):
         """
         return DispatchingJinjaLoader(self)
 
-    def select_jinja_autoescape(self, filename: str) -> bool:
+    def select_jinja_autoescape(self, filename: str | None) -> bool:
         """Returns ``True`` if autoescaping should be active for the given
         template name. If no template name is given, returns `True`.
 


### PR DESCRIPTION
Inside the code of the method the filename is checked against a None value and returns True, but the static annotated type is a str. I have changed the static annotation type to `str` to `str | None`.