### PR TITLE
pass context through dispatch methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ Unreleased
     a deprecated alias. If an app context is already pushed, it is not reused
     when dispatching a request. This greatly simplifies the internal code for tracking
     the active context. :issue:`5639`
+-   Many ``Flask`` methods involved in request dispatch now take the current
+    ``AppContext`` as the first parameter, instead of using the proxy objects.
+    If subclasses were overriding these methods, the old signature is detected,
+    shows a deprecation warning, and will continue to work during the
+    deprecation period. :issue:`5815`
 -   ``template_filter``, ``template_test``, and ``template_global`` decorators
     can be used without parentheses. :issue:`5729`
 

--- a/src/flask/ctx.py
+++ b/src/flask/ctx.py
@@ -471,10 +471,10 @@ class AppContext:
 
         try:
             if self._request is not None:
-                self.app.do_teardown_request(exc)
+                self.app.do_teardown_request(self, exc)
                 self._request.close()
         finally:
-            self.app.do_teardown_appcontext(exc)
+            self.app.do_teardown_appcontext(self, exc)
             _cv_app.reset(self._cv_token)
             self._cv_token = None
             appcontext_popped.send(self.app, _async_wrapper=self.app.ensure_sync)

--- a/tests/test_reqctx.py
+++ b/tests/test_reqctx.py
@@ -288,8 +288,9 @@ def test_bad_environ_raises_bad_request():
     # use a non-printable character in the Host - this is key to this test
     environ["HTTP_HOST"] = "\x8a"
 
-    with app.request_context(environ):
-        response = app.full_dispatch_request()
+    with app.request_context(environ) as ctx:
+        response = app.full_dispatch_request(ctx)
+
     assert response.status_code == 400
 
 
@@ -308,8 +309,8 @@ def test_environ_for_valid_idna_completes():
     # these characters are all IDNA-compatible
     environ["HTTP_HOST"] = "ąśźäüжŠßя.com"
 
-    with app.request_context(environ):
-        response = app.full_dispatch_request()
+    with app.request_context(environ) as ctx:
+        response = app.full_dispatch_request(ctx)
 
     assert response.status_code == 200
 

--- a/tests/test_subclassing.py
+++ b/tests/test_subclassing.py
@@ -5,7 +5,7 @@ import flask
 
 def test_suppressed_exception_logging():
     class SuppressedFlask(flask.Flask):
-        def log_exception(self, exc_info):
+        def log_exception(self, ctx, exc_info):
             pass
 
     out = StringIO()


### PR DESCRIPTION
The current `AppContext` object is passed through the various request dispatch methods, rather than each method accessing the proxies. closes #5815 

@pgjones first proposed this in #5229 as a way to speed up dispatch especially for Quart and async views. This PR applies to more methods, and also implements compatibility during a deprecation period.

Dispatch methods now take `ctx: AppContext` as the first parameter. The following `Flask` methods were changed:

- `update_template_context`
- `handle_http_exception`
- `handle_user_exception`
- `handle_exception`
- `log_exception`
- `dispatch_request`
- `full_dispatch_request`
- `finalize_request`
- `make_default_options_response`
- `preprocess_request`
- `process_response`
- `do_teardown_request`
- `do_teardown_appcontext`

`url_for` and `make_response` were not changed, as it's much more likely that these are called from user code that only has access to the proxy.

An `__init_subclass__` class method is added to detect old signatures on subclasses of `Flask`. The second parameter is inspected (first is self). If it is not annotated, it must be named `ctx`. If it is annotated, it must either be the string or class `AppContext`. If an old signature is detected, the method is wrapped to remove the argument when other `Flask` methods call it during dispatch. The base method is also wrapped to inject the argument so that `super().base_method` from the overridden method will continue to work.

I did not apply the compat wrapper to every base `Flask` method, only the ones that a subclass overrides. Therefore, if user code is directly calling these internal dispatch methods, they will get a `TypeError`. This is only likely (and unlikely at that) to happen during testing. I did this over concern that the wrapper would be unnecessary and a performance hit for most applications. If we get bug reports we can consider adding the wrapper.