### PR TITLE
docs: clarify JSON parsing error conditions in Flask views

### DIFF
--- a/docs/patterns/javascript.rst
+++ b/docs/patterns/javascript.rst
@@ -244,8 +244,9 @@ Receiving JSON in Views
 
 Use the :attr:`~flask.Request.json` property of the
 :data:`~flask.request` object to decode the request's body as JSON. If
-the body is not valid JSON, or the ``Content-Type`` header is not set to
-``application/json``, a 400 Bad Request error will be raised.
+the body is not valid JSON, or if parsing fails for any reason (including
+a missing or incorrect ``Content-Type`` header), a 400 Bad Request error
+will be raised.
 
 .. code-block:: python
 


### PR DESCRIPTION
## Update Documentation: JSON Parsing Behavior

Update the documentation to specify that JSON parsing fails for any reason, including a missing or incorrect `Content-Type` header, not just invalid JSON or an unset header. This improves accuracy and clarity for developers.
