### PR TITLE
Handle missing secret key during session save

### DIFF
--- a/src/flask/sessions.py
+++ b/src/flask/sessions.py
@@ -13,6 +13,12 @@ from werkzeug.datastructures import CallbackDict
 
 from .json.tag import TaggedJSONSerializer
 
+_missing_secret_key_err_msg = (
+    "The session is unavailable because no secret "
+    "key was set.  Set the secret_key on the "
+    "application to something unique and secret."
+)
+
 if t.TYPE_CHECKING:  # pragma: no cover
     import typing_extensions as te
 
@@ -87,11 +93,7 @@ class NullSession(SecureCookieSession):
     """
 
     def _fail(self, *args: t.Any, **kwargs: t.Any) -> t.NoReturn:
-        raise RuntimeError(
-            "The session is unavailable because no secret "
-            "key was set.  Set the secret_key on the "
-            "application to something unique and secret."
-        )
+        raise RuntimeError(_missing_secret_key_err_msg)
 
     __setitem__ = __delitem__ = clear = pop = popitem = update = setdefault = _fail
     del _fail
@@ -370,7 +372,12 @@ class SecureCookieSessionInterface(SessionInterface):
             return
 
         expires = self.get_expiration_time(app, session)
-        val = self.get_signing_serializer(app).dumps(dict(session))  # type: ignore[union-attr]
+        s = self.get_signing_serializer(app)
+
+        if s is None:
+            raise RuntimeError(_missing_secret_key_err_msg)
+
+        val = s.dumps(dict(session))
         response.set_cookie(
             name,
             val,

--- a/tests/test_session_interface.py
+++ b/tests/test_session_interface.py
@@ -1,3 +1,5 @@
+import pytest
+
 import flask
 from flask.globals import app_ctx
 from flask.sessions import SessionInterface
@@ -26,3 +28,16 @@ def test_open_session_with_endpoint():
 
     response = app.test_client().get("/")
     assert response.status_code == 200
+
+
+def test_save_session_without_secret_key(app):
+    app.secret_key = "test key"
+    session = app.session_interface.session_class({"foo": "bar"})
+    session.modified = True
+    app.secret_key = None
+
+    with pytest.raises(RuntimeError) as e:
+        app.session_interface.save_session(app, session, app.response_class())
+
+    assert e.value.args and "session is unavailable" in e.value.args[0]
+    assert "no secret key was set" in e.value.args[0]


### PR DESCRIPTION
I noticed a real crash path in session saving: `SecureCookieSessionInterface.save_session` called `dumps()` on `get_signing_serializer(app)` without checking whether the serializer existed.

I validated the behavior locally with a minimal reproduction where a session object was present, then `app.secret_key` became falsy before save. In that flow, Flask raised an internal `AttributeError` (`'NoneType' object has no attribute 'dumps'`) instead of the normal session configuration error.

Then I fixed the code in a streamlined way:

- I added a guard in `save_session` to handle a missing serializer explicitly.
- I raised the same user-facing `RuntimeError` message Flask already uses for missing secret key session failures.
- I removed the `type: ignore[union-attr]` usage by handling the union properly.
- I deduplicated the error message by using a shared constant for both `NullSession` and `save_session`.

After that, I added a focused regression test that reproduces the exact scenario:

- Start with a valid secret key.
- Create a modified session.
- Clear the secret key.
- Call `save_session` and assert Flask raises the expected runtime error message.

I also made sure the patch stayed minimal and clean:

- Only two files are changed:
  - `src/flask/sessions.py`
  - `tests/test_session_interface.py`
- No scratch files or unrelated edits remain.

Validation I ran:

- Direct repro before/after behavior check (crash replaced with expected runtime error).
- Focused test run:
  - `pytest tests/test_session_interface.py -q`
  - Result: `2 passed`
