### PR TITLE
Security: Path traversal risk in Blueprint.open_resource

### DIFF
--- a/src/flask/blueprints.py
+++ b/src/flask/blueprints.py
@@ -121,6 +121,10 @@ class Blueprint(SansioBlueprint):
             raise ValueError("Resources can only be opened for reading.")
 
         path = os.path.join(self.root_path, resource)
+        resolved = os.path.realpath(path)
+
+        if not resolved.startswith(os.path.realpath(self.root_path) + os.sep) and resolved != os.path.realpath(self.root_path):
+            raise ValueError("Detected path traversal: the resource path must be within root_path.")
 
         if mode == "rb":
             return open(path, mode)  # pyright: ignore


### PR DESCRIPTION
## Problem

The open_resource method joins the user-provided 'resource' parameter with root_path using os.path.join without sanitizing for path traversal sequences (e.g., '../'). If a developer passes user-controlled input to this method, it could allow reading arbitrary files on the filesystem.

**Severity**: `low`
**File**: `src/flask/blueprints.py`

## Solution

Add path traversal validation by resolving the final path and checking it is still within root_path: resolved = os.path.realpath(path); if not resolved.startswith(os.path.realpath(self.root_path)): raise ValueError('Path traversal detected').

## Changes

- `src/flask/blueprints.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
