### PR TITLE
docs: fix doubled word "the" in TESTING config description

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -80,7 +80,7 @@ The following configuration values are used internally by Flask:
 .. py:data:: TESTING
 
     Enable testing mode. Exceptions are propagated rather than handled by the
-    the app's error handlers. Extensions may also change their behavior to
+    app's error handlers. Extensions may also change their behavior to
     facilitate easier testing. You should enable this in your own tests.
 
     Default: ``False``


### PR DESCRIPTION
The `TESTING` config description in `docs/config.rst` contained a doubled word "the the".

Fixes pallets/flask#5988