### PR TITLE
autoescape selection uses case-insensitive comparison

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Unreleased
     such as HTMX. :issue:`5895`
 -   ``provide_automatic_options=True`` can be used to enable it for a view when
     it's disabled in config. Previously, only disabling worked. :issue:`5916`
+-   ``Flask.select_jinja_autoescape`` uses case-insensitive comparison instead
+    of only lower case file extensions. :pr:`6012`
 
 
 Version 3.1.3

--- a/src/flask/sansio/app.py
+++ b/src/flask/sansio/app.py
@@ -534,6 +534,9 @@ class App(Scaffold):
         """Returns ``True`` if autoescaping should be active for the given
         template name. If no template name is given, returns `True`.
 
+        .. versionchanged:: 3.2
+            Use case-insensitive comparison instead of only lower case.
+
         .. versionchanged:: 2.2
             Autoescaping is now enabled by default for ``.svg`` files.
 
@@ -541,7 +544,7 @@ class App(Scaffold):
         """
         if filename is None:
             return True
-        return filename.endswith((".html", ".htm", ".xml", ".xhtml", ".svg"))
+        return filename.lower().endswith((".html", ".htm", ".xml", ".xhtml", ".svg"))
 
     @property
     def debug(self) -> bool:


### PR DESCRIPTION
Use case-insensitive comparison on file extension. Previously only lower case was used.