### PR TITLE
AI junk

### DIFF
--- a/src/flask/config.py
+++ b/src/flask/config.py
@@ -293,7 +293,7 @@ class Config(dict):  # type: ignore[type-arg]
             with open(filename, "r" if text else "rb") as f:
                 obj = load(f)
         except OSError as e:
-            if silent and e.errno in (errno.ENOENT, errno.EISDIR):
+            if silent and e.errno in (errno.ENOENT, errno.EISDIR, errno.ENOTDIR):
                 return False
 
             e.strerror = f"Unable to load configuration file ({e.strerror})"


### PR DESCRIPTION
## What

`Config.from_file()` was missing `errno.ENOTDIR` from its silent error check, making it behave inconsistently with `Config.from_pyfile()`.

**Before (from_file):**
```python
if silent and e.errno in (errno.ENOENT, errno.EISDIR):
    return False
```

**After (from_file):**
```python
if silent and e.errno in (errno.ENOENT, errno.EISDIR, errno.ENOTDIR):
    return False
```

`from_pyfile()` has always included `errno.ENOTDIR` in this check.

## Why it matters

`ENOTDIR` is raised when a path component in the given filename is a regular file rather than a directory (e.g. trying to open `/some/file/config.json` where `/some/file` is a regular file). With `silent=True`, callers expect all "file not accessible" errors to be swallowed and `False` returned. The missing code caused an unexpected `OSError` to bubble up instead.

Fixes #6023