### PR TITLE
Docs: Enhance deployment guides, tutorial warnings and API examples

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -336,13 +336,13 @@ Signals are provided by the `Blinker`_ library. See :doc:`signals` for an introd
 
    Example subscriber::
 
+        from flask import template_rendered
+
+        @template_rendered.connect_via(app)
         def log_template_renders(sender, template, context, **extra):
             sender.logger.debug('Rendering template "%s" with context %s',
                                 template.name or 'string template',
                                 context)
-
-        from flask import template_rendered
-        template_rendered.connect(log_template_renders, app)
 
 .. data:: flask.before_render_template
    :noindex:
@@ -370,11 +370,11 @@ Signals are provided by the `Blinker`_ library. See :doc:`signals` for an introd
 
    Example subscriber::
 
+        from flask import request_started
+
+        @request_started.connect_via(app)
         def log_request(sender, **extra):
             sender.logger.debug('Request context is set up')
-
-        from flask import request_started
-        request_started.connect(log_request, app)
 
 .. data:: request_finished
 

--- a/docs/deploying/gunicorn.rst
+++ b/docs/deploying/gunicorn.rst
@@ -74,8 +74,8 @@ errors are shown. To show access logs on stdout, use the
 Configuration File
 ------------------
 
-While passing arguments to Gunicorn via the command line is useful for simple 
-setups, production deployments usually rely on a configuration file. 
+While passing arguments to Gunicorn via the command line is useful for simple
+setups, production deployments usually rely on a configuration file.
 
 Create a file named ``gunicorn.conf.py`` in your project directory:
 
@@ -86,7 +86,7 @@ Create a file named ``gunicorn.conf.py`` in your project directory:
     workers = 4
     accesslog = "-"
 
-You can then run Gunicorn by pointing it to your configuration file using 
+You can then run Gunicorn by pointing it to your configuration file using
 the ``-c`` option:
 
 .. code-block:: text
@@ -97,12 +97,12 @@ the ``-c`` option:
 Running in the Background
 -------------------------
 
-Running Gunicorn from the command line blocks the terminal. For production 
-deployments, you should use a process manager like ``systemd`` or ``supervisor`` 
-to run Gunicorn in the background, start it automatically on boot and restart 
-it if it crashes. 
+Running Gunicorn from the command line blocks the terminal. For production
+deployments, you should use a process manager like ``systemd`` or ``supervisor``
+to run Gunicorn in the background, start it automatically on boot and restart
+it if it crashes.
 
-See the Gunicorn documentation on `Deploying Gunicorn <https://docs.gunicorn.org/en/latest/deploy.html>`_ 
+See the Gunicorn documentation on `Deploying Gunicorn <https://docs.gunicorn.org/en/latest/deploy.html>`_
 for examples of systemd service files.
 
 
@@ -128,10 +128,10 @@ otherwise it will be possible to bypass the proxy.
 IP address in your browser.
 
 .. note::
-    When running Gunicorn behind a reverse proxy, the proxy will intercept the 
-    client's IP address. To ensure your Flask application correctly reads the 
-    forwarded headers (like ``X-Forwarded-For``), you must apply the 
-    :class:`~werkzeug.middleware.proxy_fix.ProxyFix` middleware. See 
+    When running Gunicorn behind a reverse proxy, the proxy will intercept the
+    client's IP address. To ensure your Flask application correctly reads the
+    forwarded headers (like ``X-Forwarded-For``), you must apply the
+    :class:`~werkzeug.middleware.proxy_fix.ProxyFix` middleware. See
     :doc:`proxy_fix` for more information.
 
 

--- a/docs/deploying/gunicorn.rst
+++ b/docs/deploying/gunicorn.rst
@@ -71,6 +71,41 @@ errors are shown. To show access logs on stdout, use the
 ``--access-logfile=-`` option.
 
 
+Configuration File
+------------------
+
+While passing arguments to Gunicorn via the command line is useful for simple 
+setups, production deployments usually rely on a configuration file. 
+
+Create a file named ``gunicorn.conf.py`` in your project directory:
+
+.. code-block:: python
+
+    # gunicorn.conf.py
+    bind = "127.0.0.1:8000"
+    workers = 4
+    accesslog = "-"
+
+You can then run Gunicorn by pointing it to your configuration file using 
+the ``-c`` option:
+
+.. code-block:: text
+
+    $ gunicorn -c gunicorn.conf.py 'example:app'
+
+
+Running in the Background
+-------------------------
+
+Running Gunicorn from the command line blocks the terminal. For production 
+deployments, you should use a process manager like ``systemd`` or ``supervisor`` 
+to run Gunicorn in the background, start it automatically on boot and restart 
+it if it crashes. 
+
+See the Gunicorn documentation on `Deploying Gunicorn <https://docs.gunicorn.org/en/latest/deploy.html>`_ 
+for examples of systemd service files.
+
+
 Binding Externally
 ------------------
 
@@ -91,6 +126,13 @@ otherwise it will be possible to bypass the proxy.
 
 ``0.0.0.0`` is not a valid address to navigate to, you'd use a specific
 IP address in your browser.
+
+.. note::
+    When running Gunicorn behind a reverse proxy, the proxy will intercept the 
+    client's IP address. To ensure your Flask application correctly reads the 
+    forwarded headers (like ``X-Forwarded-For``), you must apply the 
+    :class:`~werkzeug.middleware.proxy_fix.ProxyFix` middleware. See 
+    :doc:`proxy_fix` for more information.
 
 
 Async with gevent

--- a/docs/tutorial/database.rst
+++ b/docs/tutorial/database.rst
@@ -206,6 +206,14 @@ previous page.
     you use a new terminal, remember to change to your project directory
     and activate the env as described in :doc:`/installation`.
 
+.. warning::
+
+    The ``init-db`` command will run the ``schema.sql`` file, which starts by 
+    dropping the existing ``user`` and ``post`` tables. **Running this command 
+    will permanently delete any existing data in your database.** Only run it 
+    when you are setting up the project for the first time or if you intentionally 
+    want to start over with an empty database.
+
 Run the ``init-db`` command:
 
 .. code-block:: none

--- a/docs/tutorial/database.rst
+++ b/docs/tutorial/database.rst
@@ -208,10 +208,10 @@ previous page.
 
 .. warning::
 
-    The ``init-db`` command will run the ``schema.sql`` file, which starts by 
-    dropping the existing ``user`` and ``post`` tables. **Running this command 
-    will permanently delete any existing data in your database.** Only run it 
-    when you are setting up the project for the first time or if you intentionally 
+    The ``init-db`` command will run the ``schema.sql`` file, which starts by
+    dropping the existing ``user`` and ``post`` tables. **Running this command
+    will permanently delete any existing data in your database.** Only run it
+    when you are setting up the project for the first time or if you intentionally
     want to start over with an empty database.
 
 Run the ``init-db`` command:

--- a/docs/tutorial/deploy.rst
+++ b/docs/tutorial/deploy.rst
@@ -73,9 +73,9 @@ will read from if it exists. Copy the generated value into it.
     SECRET_KEY = '192b9bdd22ab9ed4d12e236c78afcb9a393ec15f71bbf5dc987d54727823bcbf'
 
 .. warning::
-    Never commit the file containing your production ``SECRET_KEY`` to version 
-    control. Ensure that your ``.gitignore`` file excludes the ``instance/`` 
-    folder and the specific ``config.py`` file to prevent leaking your secret 
+    Never commit the file containing your production ``SECRET_KEY`` to version
+    control. Ensure that your ``.gitignore`` file excludes the ``instance/``
+    folder and the specific ``config.py`` file to prevent leaking your secret
     key to a public repository.
 
 You can also set any other necessary configuration here, although

--- a/docs/tutorial/deploy.rst
+++ b/docs/tutorial/deploy.rst
@@ -39,9 +39,9 @@ Pip will install your project along with its dependencies.
 Since this is a different machine, you need to run ``init-db`` again to
 create the database in the instance folder.
 
-    .. code-block:: text
+.. code-block:: text
 
-        $ flask --app flaskr init-db
+    $ flask --app flaskr init-db
 
 When Flask detects that it's installed (not in editable mode), it uses
 a different directory for the instance folder. You can find it at
@@ -71,6 +71,12 @@ will read from if it exists. Copy the generated value into it.
     :caption: ``.venv/var/flaskr-instance/config.py``
 
     SECRET_KEY = '192b9bdd22ab9ed4d12e236c78afcb9a393ec15f71bbf5dc987d54727823bcbf'
+
+.. warning::
+    Never commit the file containing your production ``SECRET_KEY`` to version 
+    control. Ensure that your ``.gitignore`` file excludes the ``instance/`` 
+    folder and the specific ``config.py`` file to prevent leaking your secret 
+    key to a public repository.
 
 You can also set any other necessary configuration here, although
 ``SECRET_KEY`` is the only one needed for Flaskr.


### PR DESCRIPTION
This PR introduces quality-of-life and safety improvements across the documentation.

I have separated these changes into seperate commits for easier review:

Gunicorn: Added examples for `gunicorn.conf.py`, background process management, and a note about using `ProxyFix`.
Tutorial (Database): Added a warning that `init-db` drops existing tables to prevent accidental data loss for beginners.
Tutorial (Deploy): Added a security warning advising users to exclude `config.py` from version control to protect `SECRET_KEY`.
API (Signals): Modernized the code examples to use the idiomatic `@signal.connect_via(app)` decorator pattern instead of manual `.connect()` calls.

(Note: No tests, `CHANGES.rst` entries or `.. versionchanged::` directives were added as this is strictly a documentation update to existing features.)