### PR TITLE
AI junk

### DIFF
--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -470,7 +470,7 @@ def _set_debug(ctx: click.Context, param: click.Option, value: bool) -> bool | N
     # that, let debug be set by env in that case.
     source = ctx.get_parameter_source(param.name)
 
-    if source is not None and source in (
+    if source is None or source in (
         ParameterSource.DEFAULT,
         ParameterSource.DEFAULT_MAP,
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -382,6 +382,30 @@ def test_flaskgroup_debug(runner, set_debug_flag):
     assert result.output == f"{not set_debug_flag}\n"
 
 
+def test_flaskgroup_debug_env(monkeypatch, runner):
+    """FLASK_DEBUG=1 env var should not be overwritten when --debug is not
+    explicitly passed. Regression test for click 8.4.0 where
+    get_parameter_source returns None during eager callbacks.
+    """
+    monkeypatch.setenv("FLASK_DEBUG", "1")
+
+    def create_app():
+        app = Flask("flaskgroup")
+        return app
+
+    @click.group(cls=FlaskGroup, create_app=create_app)
+    def cli(**params):
+        pass
+
+    @cli.command()
+    def test():
+        click.echo(os.environ.get("FLASK_DEBUG"))
+
+    result = runner.invoke(cli, ["test"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "1"
+
+
 def test_flaskgroup_nested(app, runner):
     cli = click.Group("cli")
     flask_group = FlaskGroup(name="flask", create_app=lambda: app)


### PR DESCRIPTION
## Summary

Fixes #6025.

- In click 8.4.0, `ctx.get_parameter_source()` returns `None` during eager callbacks instead of `ParameterSource.DEFAULT`
- The guard in `_set_debug` only skipped for `source is not None`, so when `source=None` (click 8.4.0), the callback proceeded to overwrite `FLASK_DEBUG=1` with `"0"`
- Changed `if source is not None and source in (...)` → `if source is None or source in (...)` to treat `None` the same as `DEFAULT`

## Changes

- `src/flask/cli.py`: 1-line fix in `_set_debug` guard condition
- `tests/test_cli.py`: Regression test that sets `FLASK_DEBUG=1` env var and verifies it isn't overwritten when `--debug` isn't explicitly passed

## Test plan

- [x] Added `test_flaskgroup_debug_env` regression test
- [x] Verified the fix matches the root cause analysis in #6025
- [x] `_set_app` callback does not have this issue (it checks `value is None`, not parameter source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)