### PR TITLE
docs(lazyloading): fix duplicate "is"

### DIFF
--- a/docs/patterns/lazyloading.rst
+++ b/docs/patterns/lazyloading.rst
@@ -73,7 +73,7 @@ function but internally imports the real function on first use::
         def __call__(self, *args, **kwargs):
             return self.view(*args, **kwargs)
 
-What's important here is is that `__module__` and `__name__` are properly
+What's important here is that `__module__` and `__name__` are properly
 set.  This is used by Flask internally to figure out how to name the
 URL rules in case you don't provide a name for the rule yourself.
 


### PR DESCRIPTION
> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

## What

Fix a duplicate `is` in `docs/patterns/lazyloading.rst` — `What's important here is is that` → `What's important here is that`.

## Why

Small reST docs cleanup. The published Lazy Loading pattern page reads cleaner.

## How verified

Single-character/word change in a `.rst` file, no directive structure touched.

## Maintainer note

Feel free to close if not worth the review cycle.
