### PR TITLE
AI junk

### DIFF
--- a/src/flask/sansio/scaffold.py
+++ b/src/flask/sansio/scaffold.py
@@ -288,7 +288,10 @@ class Scaffold:
         options: dict[str, t.Any],
     ) -> t.Callable[[T_route], T_route]:
         if "methods" in options:
-            raise TypeError("Use the 'route' decorator to use the 'methods' argument.")
+            raise TypeError(
+                "The 'methods' argument is not allowed when using "
+                f"'{method.lower()}' decorator. Use the 'route' decorator instead."
+            )
 
         return self.route(rule, methods=[method], **options)
 


### PR DESCRIPTION
## Summary

Improves the error message when users mistakenly pass the 'methods' argument to HTTP method decorators like , , etc.

## Changes

- Updated the TypeError message to be more descriptive
- Now tells users which decorator they used and explicitly states to use  instead

## Before


## After


This helps developers understand the issue faster and how to fix it.