### PR TITLE
AI spam

### DIFF
--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -7,6 +7,7 @@ import inspect
 import os
 import platform
 import re
+import ssl
 import sys
 import traceback
 import typing as t
@@ -25,8 +26,6 @@ from .helpers import get_debug_flag
 from .helpers import get_load_dotenv
 
 if t.TYPE_CHECKING:
-    import ssl
-
     from _typeshed.wsgi import StartResponse
     from _typeshed.wsgi import WSGIApplication
     from _typeshed.wsgi import WSGIEnvironment

--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -33,6 +33,10 @@ if t.TYPE_CHECKING:
 
     from .app import Flask
 
+    _CertParamTypeBase = click.ParamType[str | os.PathLike[str] | ssl.SSLContext]
+else:
+    _CertParamTypeBase = click.ParamType
+
 
 class NoAppException(click.UsageError):
     """Raised if an application cannot be found or loaded."""
@@ -777,7 +781,7 @@ def show_server_banner(debug: bool, app_import_path: str | None) -> None:
         click.echo(f" * Debug mode: {'on' if debug else 'off'}")
 
 
-class CertParamType(click.ParamType):
+class CertParamType(_CertParamTypeBase):
     """Click option type for the ``--cert`` option. Allows either an
     existing file, the string ``'adhoc'``, or an import for a
     :class:`~ssl.SSLContext` object.

--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -7,7 +7,6 @@ import inspect
 import os
 import platform
 import re
-import ssl
 import sys
 import traceback
 import typing as t
@@ -26,6 +25,8 @@ from .helpers import get_debug_flag
 from .helpers import get_load_dotenv
 
 if t.TYPE_CHECKING:
+    import ssl
+
     from _typeshed.wsgi import StartResponse
     from _typeshed.wsgi import WSGIApplication
     from _typeshed.wsgi import WSGIEnvironment
@@ -776,7 +777,7 @@ def show_server_banner(debug: bool, app_import_path: str | None) -> None:
         click.echo(f" * Debug mode: {'on' if debug else 'off'}")
 
 
-class CertParamType(click.ParamType[str | os.PathLike[str] | ssl.SSLContext]):
+class CertParamType(click.ParamType):
     """Click option type for the ``--cert`` option. Allows either an
     existing file, the string ``'adhoc'``, or an import for a
     :class:`~ssl.SSLContext` object.


### PR DESCRIPTION
## Summary

Avoid subscripted `click.ParamType[...]` at runtime for the `flask run --cert` option type, while preserving the generic base for static type checking.

## Root cause

`CertParamType` inherited from `click.ParamType[str | os.PathLike[str] | ssl.SSLContext]`. That expression is evaluated when `flask.cli` is imported. With Flask's minimum Click version, `ParamType` is not subscriptable at runtime; with newer Click, the expression also requires `ssl` at runtime. Both cases can break `import flask` before any CLI command runs.

## Checks

- `uv run python -c "import flask"`
- `uv run pytest tests/test_cli.py -q`
- `uv run ruff check src/flask/cli.py`
- `uv run --locked --no-default-groups --group dev tox run -e tests-min -- tests/test_cli.py -q`
- `uv run --locked --no-default-groups --group dev tox run -e typing`