### PR TITLE
docs: fix request args examples in errorhandling

### DIFF
--- a/docs/errorhandling.rst
+++ b/docs/errorhandling.rst
@@ -280,7 +280,7 @@ username and we can't find it, we raise a "404 Not Found".
     # a successful request would be like /profile?username=jack
     @app.route("/profile")
     def user_profile():
-        username = request.arg.get("username")
+        username = request.args.get("username")
         # if a username isn't supplied in the request, return a 400 bad request
         if username is None:
             abort(400)
@@ -493,8 +493,8 @@ This is a simple example:
     # an API app route for getting user information
     # a correct request might be /api/user?user_id=420
     @app.route("/api/user")
-    def user_api(user_id):
-        user_id = request.arg.get("user_id")
+    def user_api():
+        user_id = request.args.get("user_id")
         if not user_id:
             raise InvalidAPIUsage("No user id provided!")
 


### PR DESCRIPTION
### Description

This PR fixes documentation examples in `docs/errorhandling.rst`.

Changes:

* Replace `request.arg.get(...)` with `request.args.get(...)` in two examples.
* Fix the `user_api` example signature to match the route definition.

These changes ensure the examples are accurate and prevent confusion for users following the documentation.
