### PR TITLE
AI spam

### DIFF
--- a/src/flask/config.py
+++ b/src/flask/config.py
@@ -177,6 +177,11 @@ class Config(dict):  # type: ignore[type-arg]
                 # If an intermediate dict does not exist, create it.
                 if part not in current:
                     current[part] = {}
+                elif not isinstance(current[part], dict):
+                    raise ValueError(
+                        f"The environment variable {(prefix + key)!r} cannot be"
+                        f" set because {part!r} is already a non-dict config value."
+                    )
 
                 current = current[part]
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -107,6 +107,18 @@ def test_from_prefixed_env_nested(monkeypatch):
     assert app.config["NEW"] == {"K": "v"}
 
 
+def test_from_prefixed_env_non_dict_intermediate(monkeypatch):
+    """from_prefixed_env raises ValueError with a clear message when a flat
+    env var is already set and a later nested key tries to traverse into it.
+    Sorted order guarantees FLASK_FOO is processed before FLASK_FOO__X."""
+    monkeypatch.setenv("FLASK_FOO", "bar")
+    monkeypatch.setenv("FLASK_FOO__X", "1")
+
+    app = flask.Flask(__name__)
+    with pytest.raises(ValueError, match="FLASK_FOO__X"):
+        app.config.from_prefixed_env()
+
+
 def test_config_from_mapping():
     app = flask.Flask(__name__)
     app.config.from_mapping({"SECRET_KEY": "config", "TEST_KEY": "foo"})


### PR DESCRIPTION
## Bug

`Config.from_prefixed_env` silently crashes with an opaque `TypeError` when a flat env var and a nested env var share the same config key prefix.

**Root cause:** env vars are loaded in `sorted()` order, so `FLASK_FOO=bar` is always processed before `FLASK_FOO__X=1`. After the flat key sets `self["FOO"] = "bar"`, the nested traversal does:

```python
current = self["FOO"]   # "bar" (str)
current["X"] = value    # TypeError: 'str' object does not support item assignment
```

The internal `TypeError` gives no hint which env var caused the conflict.

## Fix

Add an `isinstance` check before descending into the intermediate dict. When the existing value is not a `dict`, raise a `ValueError` that names the conflicting environment variable.

## Verification

```
$ pytest tests/test_config.py -v -k prefixed
tests/test_config.py::test_from_prefixed_env PASSED
tests/test_config.py::test_from_prefixed_env_custom_prefix PASSED
tests/test_config.py::test_from_prefixed_env_nested PASSED
tests/test_config.py::test_from_prefixed_env_non_dict_intermediate PASSED
4 passed in 0.07s
```

> AI-assisted contribution.