### PR TITLE
Add query() route shortcut and MethodView support for HTTP QUERY

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ Unreleased
     it's disabled in config. Previously, only disabling worked. :issue:`5916`
 -   ``Flask.select_jinja_autoescape`` uses case-insensitive comparison instead
     of only lower case file extensions. :pr:`6012`
+-   Add ``query`` method route shortcut for the ``QUERY`` HTTP method
+    (:rfc:`10008`). ``MethodView`` dispatches ``QUERY`` requests to a ``query``
+    handler. :issue:`XXXX`
 
 
 Version 3.1.3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,7 @@ Unreleased
     of only lower case file extensions. :pr:`6012`
 -   Add ``query`` method route shortcut for the ``QUERY`` HTTP method
     (:rfc:`10008`). ``MethodView`` dispatches ``QUERY`` requests to a ``query``
-    handler. :issue:`XXXX`
+    handler. :issue:`6065`
 
 
 Version 3.1.3

--- a/src/flask/sansio/scaffold.py
+++ b/src/flask/sansio/scaffold.py
@@ -333,6 +333,17 @@ class Scaffold:
         return self._method_route("PATCH", rule, options)
 
     @setupmethod
+    def query(self, rule: str, **options: t.Any) -> t.Callable[[T_route], T_route]:
+        """Shortcut for :meth:`route` with ``methods=["QUERY"]``.
+
+        The ``QUERY`` method is a safe, idempotent request method that
+        carries content in the request body, defined in :rfc:`10008`.
+
+        .. versionadded:: 3.2
+        """
+        return self._method_route("QUERY", rule, options)
+
+    @setupmethod
     def route(self, rule: str, **options: t.Any) -> t.Callable[[T_route], T_route]:
         """Decorate a view function to register it with the given URL
         rule and options. Calls :meth:`add_url_rule`, which has more

--- a/src/flask/views.py
+++ b/src/flask/views.py
@@ -9,7 +9,7 @@ from .globals import request
 F = t.TypeVar("F", bound=t.Callable[..., t.Any])
 
 http_method_funcs = frozenset(
-    ["get", "post", "head", "options", "delete", "put", "trace", "patch"]
+    ["get", "post", "head", "options", "delete", "put", "trace", "patch", "query"]
 )
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -69,6 +69,19 @@ def test_method_route_no_methods(app):
         app.get("/", methods=["GET", "POST"])
 
 
+def test_query_method_route(app, client):
+    @app.query("/")
+    def query():
+        return flask.request.get_data(as_text=True)
+
+    rv = client.open("/", method="QUERY", data="select=*")
+    assert rv.status_code == 200
+    assert rv.data == b"select=*"
+    # The QUERY method is advertised like any other registered method.
+    rv = client.open("/", method="OPTIONS")
+    assert "QUERY" in rv.allow
+
+
 def test_provide_automatic_options_attr_disable(
     app: flask.Flask, client: FlaskClient
 ) -> None:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -39,6 +39,20 @@ def test_method_based_view(app):
     common_test(app)
 
 
+def test_query_method_view(app, client):
+    class Index(flask.views.MethodView):
+        def query(self):
+            return flask.request.get_data(as_text=True)
+
+    app.add_url_rule("/", view_func=Index.as_view("index"))
+
+    assert Index.methods == {"QUERY"}
+    rv = client.open("/", method="QUERY", data="select=*")
+    assert rv.status_code == 200
+    assert rv.data == b"select=*"
+    assert client.get("/").status_code == 405
+
+
 def test_view_patching(app):
     class Index(flask.views.MethodView):
         def get(self):


### PR DESCRIPTION
## Description

[RFC 10008](https://www.rfc-editor.org/info/rfc10008/) (June 2026) standardizes
the `QUERY` HTTP method: a safe, idempotent request method that carries content
in the request body (standardizing the "POST for a read-only query with a large
body" workaround used by GraphQL and REST search endpoints).

Flask already routes and dispatches arbitrary method names, so this adds the
idiomatic ergonomics that mirror the existing
`get`/`post`/`put`/`delete`/`patch` shortcuts:

- `Scaffold.query()` registers a route with `methods=["QUERY"]`, inherited by
  both `Flask` and `Blueprint`.
- `"query"` is added to `views.http_method_funcs`, so `MethodView` dispatches a
  `QUERY` request to a `query` handler.

Higher-level RFC 10008 features (the `Accept-Query` header, server-assigned
query-result URIs, caching semantics) are application/Werkzeug concerns and are
intentionally out of scope.

## Related

fixes #6065

## Checklist

- [x] Tests added that fail without the change (`test_query_method_route`,
      `test_query_method_view`).
- [x] Code docs updated (`query()` docstring with `.. versionadded:: 3.2`); the
      method is surfaced via the `Flask`/`Blueprint` autoclass, so no manual
      `docs/` change is needed.
- [x] `CHANGES.rst` entry added, linking to the issue.
- [x] `.. versionadded::` added (new method, so `versionadded` rather than
      `versionchanged`).

---

Note: tests use `client.open(method="QUERY")` rather than `client.query()` so
they pass against the released Werkzeug. A `Client.query()` shortcut is a
separate, independent Werkzeug change (pallets/werkzeug#3194).
