### PR TITLE
Add is_json_response hook for custom JSON response types

### DIFF
--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -1227,7 +1227,7 @@ class Flask(App):
                     headers=headers,  # type: ignore[arg-type]
                 )
                 status = headers = None
-            elif isinstance(rv, (dict, list)):
+            elif self.is_json_response(rv):
                 rv = self.json.response(rv)
             elif isinstance(rv, BaseResponse) or callable(rv):
                 # evaluate a WSGI callable, or coerce a different response
@@ -1267,6 +1267,16 @@ class Flask(App):
             rv.headers.update(headers)
 
         return rv
+
+    @staticmethod
+    def is_json_response(rv: object) -> bool:
+        """Return whether a view return value should be serialized as a
+        JSON response by :attr:`json`. Override in a subclass to support
+        additional types.
+
+        .. versionadded:: 3.2
+        """
+        return isinstance(rv, (dict, list))
 
     def preprocess_request(self) -> ft.ResponseReturnValue | None:
         """Called before the request is dispatched. Calls


### PR DESCRIPTION
### Summary

Add `is_json_response` hook on `Flask` so subclasses can extend which return types get serialized as JSON, e.g. `msgspec.Struct` or `pydantic.BaseModel`. The default implementation matches `dict` and `list` — same behavior as before.

### Usage Example

```python
import typing as t

import msgspec
from flask import Flask as _Flask, Response
from flask.json.provider import DefaultJSONProvider


class User(msgspec.Struct):
    name: str
    age: int


class MsgspecJSONProvider(DefaultJSONProvider):
    # dumps and loads omitted

    def response(self, *args: t.Any, **kwargs: t.Any) -> Response:
        obj = self._prepare_response_obj(args, kwargs)
        data: bytes = msgspec.json.encode(obj)
        return self._app.response_class(data, mimetype=self.mimetype)


class Flask(_Flask):
    json_provider_class = MsgspecJSONProvider

    @staticmethod
    def is_json_response(rv: object) -> bool:
        return isinstance(rv, (dict, list, msgspec.Struct))


app = Flask(__name__)


@app.get("/user")
def get_user() -> User:
    return User(name="Douglas", age=42)
```