### PR TITLE
ignore jinja suffix when selecting autoescape

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ Unreleased
     it's disabled in config. Previously, only disabling worked. :issue:`5916`
 -   ``Flask.select_jinja_autoescape`` uses case-insensitive comparison instead
     of only lower case file extensions. :pr:`6012`
+-   ``Flask.select_jinja_autoescape`` ignores a trailing Jinja suffix such as
+    ``.jinja`` or ``.j2``, so autoescaping is enabled for a template named
+    ``page.html.jinja`` the same as ``page.html``.
 
 
 Version 3.1.3

--- a/src/flask/sansio/app.py
+++ b/src/flask/sansio/app.py
@@ -535,6 +535,10 @@ class App(Scaffold):
         template name. If no template name is given, returns `True`.
 
         .. versionchanged:: 3.2
+            A trailing Jinja suffix such as ``.jinja`` or ``.j2`` is ignored,
+            so ``page.html.jinja`` is treated as ``page.html``.
+
+        .. versionchanged:: 3.2
             Use case-insensitive comparison instead of only lower case.
 
         .. versionchanged:: 2.2
@@ -544,7 +548,16 @@ class App(Scaffold):
         """
         if filename is None:
             return True
-        return filename.lower().endswith((".html", ".htm", ".xml", ".xhtml", ".svg"))
+
+        filename = filename.lower()
+
+        # A template may use a Jinja-specific suffix, such as
+        # "page.html.jinja". Strip it so the preceding extension decides
+        # autoescaping, otherwise an HTML template would go unescaped.
+        if filename.endswith((".jinja", ".jinja2", ".j2")):
+            filename = filename.rsplit(".", 1)[0]
+
+        return filename.endswith((".html", ".htm", ".xml", ".xhtml", ".svg"))
 
     @property
     def debug(self) -> bool:


### PR DESCRIPTION
strip a trailing .jinja/.jinja2/.j2 suffix in select_jinja_autoescape before matching the extension, otherwise a template using the common Jinja naming convention like page.html.jinja or icon.svg.j2 renders without HTML escaping while a plain notes.txt.j2 stays unescaped.