### PR TITLE
Fix pytest >= 9.1 compatibility

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,11 @@ import sys
 import pytest
 from _pytest import monkeypatch
 
+try:
+    _notset = monkeypatch.notset
+except AttributeError:
+    from _pytest.compat import NOTSET as _notset
+
 from flask import Flask
 from flask.globals import app_ctx as _app_ctx
 
@@ -16,15 +21,15 @@ def _standard_os_environ():
     """
     mp = monkeypatch.MonkeyPatch()
     out = (
-        (os.environ, "FLASK_ENV_FILE", monkeypatch.notset),
-        (os.environ, "FLASK_APP", monkeypatch.notset),
-        (os.environ, "FLASK_DEBUG", monkeypatch.notset),
-        (os.environ, "FLASK_RUN_FROM_CLI", monkeypatch.notset),
-        (os.environ, "WERKZEUG_RUN_MAIN", monkeypatch.notset),
+        (os.environ, "FLASK_ENV_FILE", _notset),
+        (os.environ, "FLASK_APP", _notset),
+        (os.environ, "FLASK_DEBUG", _notset),
+        (os.environ, "FLASK_RUN_FROM_CLI", _notset),
+        (os.environ, "WERKZEUG_RUN_MAIN", _notset),
     )
 
     for _, key, value in out:
-        if value is monkeypatch.notset:
+        if value is _notset:
             mp.delenv(key, False)
         else:
             mp.setenv(key, value)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,11 @@ from pathlib import Path
 
 import click
 import pytest
-from _pytest.monkeypatch import notset
+
+try:
+    from _pytest.monkeypatch import notset
+except ImportError:
+    from _pytest.compat import NOTSET as notset
 from click.testing import CliRunner
 
 from flask import Blueprint


### PR DESCRIPTION
pytest 9.1 removed the private `notset` sentinel from `_pytest.monkeypatch` (now `NOTSET` in `_pytest.compat`). Add compatibility shim in tests/test_cli.py

Assisted-by: Claude Opus 4.6

fixes #6071 
