### PR TITLE
AI junk

### DIFF
--- a/src/flask/cli.py
+++ b/src/flask/cli.py
@@ -777,7 +777,18 @@ def show_server_banner(debug: bool, app_import_path: str | None) -> None:
         click.echo(f" * Debug mode: {'on' if debug else 'off'}")
 
 
-class CertParamType(click.ParamType[t.Any]):
+if t.TYPE_CHECKING:
+
+    class _CertParamTypeBase(click.ParamType[t.Any]):
+        pass
+
+else:
+
+    class _CertParamTypeBase(click.ParamType):
+        pass
+
+
+class CertParamType(_CertParamTypeBase):
     """Click option type for the ``--cert`` option. Allows either an
     existing file, the string ``'adhoc'``, or an import for a
     :class:`~ssl.SSLContext` object.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,10 @@ from _pytest import monkeypatch
 from flask import Flask
 from flask.globals import app_ctx as _app_ctx
 
+_MONKEYPATCH_NOTSET = (
+    monkeypatch.NOTSET if hasattr(monkeypatch, "NOTSET") else monkeypatch.notset
+)
+
 
 @pytest.fixture(scope="session", autouse=True)
 def _standard_os_environ():
@@ -16,15 +20,15 @@ def _standard_os_environ():
     """
     mp = monkeypatch.MonkeyPatch()
     out = (
-        (os.environ, "FLASK_ENV_FILE", monkeypatch.notset),
-        (os.environ, "FLASK_APP", monkeypatch.notset),
-        (os.environ, "FLASK_DEBUG", monkeypatch.notset),
-        (os.environ, "FLASK_RUN_FROM_CLI", monkeypatch.notset),
-        (os.environ, "WERKZEUG_RUN_MAIN", monkeypatch.notset),
+        (os.environ, "FLASK_ENV_FILE", _MONKEYPATCH_NOTSET),
+        (os.environ, "FLASK_APP", _MONKEYPATCH_NOTSET),
+        (os.environ, "FLASK_DEBUG", _MONKEYPATCH_NOTSET),
+        (os.environ, "FLASK_RUN_FROM_CLI", _MONKEYPATCH_NOTSET),
+        (os.environ, "WERKZEUG_RUN_MAIN", _MONKEYPATCH_NOTSET),
     )
 
     for _, key, value in out:
-        if value is monkeypatch.notset:
+        if value is _MONKEYPATCH_NOTSET:
             mp.delenv(key, False)
         else:
             mp.setenv(key, value)

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -1,6 +1,11 @@
 import pytest
 from jinja2 import TemplateNotFound
-from werkzeug.http import parse_cache_control_header
+from werkzeug.datastructures.cache_control import ResponseCacheControl
+
+if hasattr(ResponseCacheControl, "from_header"):
+    parse_cache_control_header = ResponseCacheControl.from_header
+else:
+    from werkzeug.http import parse_cache_control_header
 
 import flask
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import click
 import pytest
-from _pytest.monkeypatch import notset
+from _pytest import monkeypatch as _pytest_monkeypatch
 from click.testing import CliRunner
 
 from flask import Blueprint
@@ -31,6 +31,11 @@ from flask.cli import with_appcontext
 
 cwd = Path.cwd()
 test_path = (Path(__file__) / ".." / "test_apps").resolve()
+_MONKEYPATCH_NOTSET = (
+    _pytest_monkeypatch.NOTSET
+    if hasattr(_pytest_monkeypatch, "NOTSET")
+    else _pytest_monkeypatch.notset
+)
 
 
 @pytest.fixture
@@ -537,7 +542,7 @@ need_dotenv = pytest.mark.skipif(
 def test_load_dotenv(monkeypatch):
     # can't use monkeypatch.delitem since the keys don't exist yet
     for item in ("FOO", "BAR", "SPAM", "HAM"):
-        monkeypatch._setitem.append((os.environ, item, notset))
+        monkeypatch._setitem.append((os.environ, item, _MONKEYPATCH_NOTSET))
 
     monkeypatch.setenv("EGGS", "3")
     monkeypatch.chdir(test_path)
@@ -560,7 +565,7 @@ def test_load_dotenv(monkeypatch):
 @need_dotenv
 def test_dotenv_path(monkeypatch):
     for item in ("FOO", "BAR", "EGGS"):
-        monkeypatch._setitem.append((os.environ, item, notset))
+        monkeypatch._setitem.append((os.environ, item, _MONKEYPATCH_NOTSET))
 
     load_dotenv(test_path / ".flaskenv")
     assert Path.cwd() == cwd

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,10 @@
 import pytest
-from werkzeug.http import parse_set_header
+from werkzeug.datastructures import HeaderSet
+
+if hasattr(HeaderSet, "from_header"):
+    parse_set_header = HeaderSet.from_header
+else:
+    from werkzeug.http import parse_set_header
 
 import flask.views
 from flask.testing import FlaskClient


### PR DESCRIPTION
Use the monkeypatch module's current sentinel name instead of importing the removed `_pytest.monkeypatch.notset` symbol directly.

Pytest 9.1 exposes the sentinel as `_pytest.monkeypatch.NOTSET`, while pytest 9.0 still uses `_pytest.monkeypatch.notset`. This keeps the existing monkeypatch bookkeeping behavior on both versions, while allowing Flask's tests to collect and run with pytest 9.1.

This also keeps `CertParamType` generic for static type checkers while avoiding runtime subscripting of `click.ParamType` on older supported Click versions, and avoids Werkzeug main deprecation warnings in tests by preferring the newer datastructure parsing helpers when they are available.

fixes #6071

Validation:
- With pytest 9.0.3 / Click 8.1.3 / Werkzeug 3.1.0:
  - `python -m pytest tests -q`
- With pytest 9.1.1 / Click 8.4.2 / Werkzeug 3.1.8:
  - `python -m pytest tests -q`
- `python -m mypy`
- `pyright --pythonpath <venv>/bin/python`
- `python -m py_compile src/flask/cli.py tests/conftest.py tests/test_cli.py tests/test_blueprints.py tests/test_views.py`
- `python -m ruff check src/flask/cli.py tests/conftest.py tests/test_cli.py tests/test_blueprints.py tests/test_views.py`
- `git diff --check`
