### PR TITLE
AI junk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ Unreleased
     it's disabled in config. Previously, only disabling worked. :issue:`5916`
 -   ``Flask.select_jinja_autoescape`` uses case-insensitive comparison instead
     of only lower case file extensions. :pr:`6012`
+-   ``register_blueprint`` rejects a ``name`` option that contains a dot,
+    matching the validation the ``Blueprint`` constructor already applies.
+    :pr:`6081`
 
 
 Version 3.1.3

--- a/src/flask/sansio/blueprints.py
+++ b/src/flask/sansio/blueprints.py
@@ -301,6 +301,10 @@ class Blueprint(Scaffold):
         """
         name_prefix = options.get("name_prefix", "")
         self_name = options.get("name", self.name)
+
+        if "." in self_name:
+            raise ValueError("'name' may not contain a dot '.' character.")
+
         name = f"{name_prefix}.{self_name}".lstrip(".")
 
         if name in app.blueprints:

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -247,6 +247,12 @@ def test_dotted_name_not_allowed(app, client):
         flask.Blueprint("app.ui", __name__)
 
 
+def test_dotted_name_from_register_option_not_allowed(app, client):
+    bp = flask.Blueprint("bp", __name__)
+    with pytest.raises(ValueError):
+        app.register_blueprint(bp, name="app.ui")
+
+
 def test_empty_name_not_allowed(app, client):
     with pytest.raises(ValueError):
         flask.Blueprint("", __name__)


### PR DESCRIPTION
The Blueprint constructor rejects a name that contains a dot, because dots are the separator used for nested blueprint names and endpoints. The name can also be overridden at registration with the name option, but that path was not validated, so a dotted name was silently accepted.

A dotted registered name is then treated as a nested hierarchy. For example register_blueprint(bp, name="a.b") registers the blueprint as "a.b" while request.blueprints reports ["a.b", "a"], referencing a parent scope "a" that was never registered. Endpoints and blueprint scoped lookups (error handlers, url_for, request.blueprint) walk that non existent scope.

Apply the same check to the name option so both paths raise the same ValueError. Added a test alongside the existing constructor test.