### PR TITLE
AI junk

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,10 @@ import sys
 
 import pytest
 from _pytest import monkeypatch
+try:
+    from _pytest.compat import NOTSET as notset
+except ImportError:
+    from _pytest.monkeypatch import notset
 
 from flask import Flask
 from flask.globals import app_ctx as _app_ctx
@@ -16,15 +20,15 @@ def _standard_os_environ():
     """
     mp = monkeypatch.MonkeyPatch()
     out = (
-        (os.environ, "FLASK_ENV_FILE", monkeypatch.notset),
-        (os.environ, "FLASK_APP", monkeypatch.notset),
-        (os.environ, "FLASK_DEBUG", monkeypatch.notset),
-        (os.environ, "FLASK_RUN_FROM_CLI", monkeypatch.notset),
-        (os.environ, "WERKZEUG_RUN_MAIN", monkeypatch.notset),
+        (os.environ, "FLASK_ENV_FILE", notset),
+        (os.environ, "FLASK_APP", notset),
+        (os.environ, "FLASK_DEBUG", notset),
+        (os.environ, "FLASK_RUN_FROM_CLI", notset),
+        (os.environ, "WERKZEUG_RUN_MAIN", notset),
     )
 
     for _, key, value in out:
-        if value is monkeypatch.notset:
+        if value is notset:
             mp.delenv(key, False)
         else:
             mp.setenv(key, value)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,10 @@ from pathlib import Path
 
 import click
 import pytest
-from _pytest.monkeypatch import notset
+try:
+    from _pytest.compat import NOTSET as notset
+except ImportError:
+    from _pytest.monkeypatch import notset
 from click.testing import CliRunner
 
 from flask import Blueprint


### PR DESCRIPTION
`pytest 9.1` removed the internal `notset` sentinel object from `_pytest.monkeypatch` (moving it to `_pytest.compat.NOTSET`). This causes a collection-time crash because the test suite imports `notset` from the old location in `conftest.py` and `test_cli.py`.

We resolve this by falling back to import `NOTSET` from `_pytest.compat` first, then `_pytest.monkeypatch` for backward compatibility.