### PR TITLE
AI junk

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,11 @@ import sys
 import pytest
 from _pytest import monkeypatch
 
+try:
+    from _pytest.monkeypatch import notset
+except ImportError:
+    from _pytest.compat import NOTSET as notset
+
 from flask import Flask
 from flask.globals import app_ctx as _app_ctx
 
@@ -16,15 +21,15 @@ def _standard_os_environ():
     """
     mp = monkeypatch.MonkeyPatch()
     out = (
-        (os.environ, "FLASK_ENV_FILE", monkeypatch.notset),
-        (os.environ, "FLASK_APP", monkeypatch.notset),
-        (os.environ, "FLASK_DEBUG", monkeypatch.notset),
-        (os.environ, "FLASK_RUN_FROM_CLI", monkeypatch.notset),
-        (os.environ, "WERKZEUG_RUN_MAIN", monkeypatch.notset),
+        (os.environ, "FLASK_ENV_FILE", notset),
+        (os.environ, "FLASK_APP", notset),
+        (os.environ, "FLASK_DEBUG", notset),
+        (os.environ, "FLASK_RUN_FROM_CLI", notset),
+        (os.environ, "WERKZEUG_RUN_MAIN", notset),
     )
 
     for _, key, value in out:
-        if value is monkeypatch.notset:
+        if value is notset:
             mp.delenv(key, False)
         else:
             mp.setenv(key, value)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,11 @@ from pathlib import Path
 
 import click
 import pytest
-from _pytest.monkeypatch import notset
+
+try:
+    from _pytest.monkeypatch import notset
+except ImportError:
+    from _pytest.compat import NOTSET as notset
 from click.testing import CliRunner
 
 from flask import Blueprint


### PR DESCRIPTION
## Summary

Updates Flask's tests to support pytest 9.1, where the `notset` sentinel is no longer available from `_pytest.monkeypatch`.

The tests now use a small compatibility import:

- older pytest: `_pytest.monkeypatch.notset`
- pytest 9.1+: `_pytest.compat.NOTSET`

This keeps the existing monkeypatch behavior while allowing the test suite to collect and run with pytest 9.1.

## Problem observed

With pytest 9.1.1, test collection failed with:

`ImportError: cannot import name 'notset' from '_pytest.monkeypatch'`

## Validation

pytest 9.1.1:

`uv run --with pytest==9.1.1 pytest tests/`

Result:

`491 passed`

Current project pytest:

`uv run pytest tests/`

Result:

`491 passed`

Ruff check:

`uv run ruff check tests/conftest.py tests/test_cli.py`

Result:

`All checks passed!`

## Related issue

Fixes #6071.
