### PR TITLE
AI junk

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,43 +2,22 @@ import os
 import sys
 
 import pytest
-from _pytest import monkeypatch
 
 from flask import Flask
 from flask.globals import app_ctx as _app_ctx
 
 
-@pytest.fixture(scope="session", autouse=True)
-def _standard_os_environ():
-    """Set up ``os.environ`` at the start of the test session to have
-    standard values. Returns a list of operations that is used by
-    :func:`._reset_os_environ` after each test.
-    """
-    mp = monkeypatch.MonkeyPatch()
-    out = (
-        (os.environ, "FLASK_ENV_FILE", monkeypatch.notset),
-        (os.environ, "FLASK_APP", monkeypatch.notset),
-        (os.environ, "FLASK_DEBUG", monkeypatch.notset),
-        (os.environ, "FLASK_RUN_FROM_CLI", monkeypatch.notset),
-        (os.environ, "WERKZEUG_RUN_MAIN", monkeypatch.notset),
-    )
-
-    for _, key, value in out:
-        if value is monkeypatch.notset:
-            mp.delenv(key, False)
-        else:
-            mp.setenv(key, value)
-
-    yield out
-    mp.undo()
-
-
 @pytest.fixture(autouse=True)
-def _reset_os_environ(monkeypatch, _standard_os_environ):
-    """Reset ``os.environ`` to the standard environ after each test,
-    in case a test changed something without cleaning up.
-    """
-    monkeypatch._setitem.extend(_standard_os_environ)
+def _standard_os_environ(monkeypatch):
+    """Start each test with the Flask CLI environment variables unset."""
+    for key in (
+        "FLASK_ENV_FILE",
+        "FLASK_APP",
+        "FLASK_DEBUG",
+        "FLASK_RUN_FROM_CLI",
+        "WERKZEUG_RUN_MAIN",
+    ):
+        monkeypatch.delenv(key, raising=False)
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import click
 import pytest
-from _pytest.monkeypatch import notset
 from click.testing import CliRunner
 
 from flask import Blueprint
@@ -533,12 +532,21 @@ need_dotenv = pytest.mark.skipif(
 )
 
 
-@need_dotenv
-def test_load_dotenv(monkeypatch):
-    # can't use monkeypatch.delitem since the keys don't exist yet
-    for item in ("FOO", "BAR", "SPAM", "HAM"):
-        monkeypatch._setitem.append((os.environ, item, notset))
+@pytest.fixture
+def clean_dotenv_vars():
+    keys = ("FOO", "BAR", "SPAM", "HAM", "EGGS")
 
+    for key in keys:
+        os.environ.pop(key, None)
+
+    yield
+
+    for key in keys:
+        os.environ.pop(key, None)
+
+
+@need_dotenv
+def test_load_dotenv(monkeypatch, clean_dotenv_vars):
     monkeypatch.setenv("EGGS", "3")
     monkeypatch.chdir(test_path)
     assert load_dotenv()
@@ -558,16 +566,13 @@ def test_load_dotenv(monkeypatch):
 
 
 @need_dotenv
-def test_dotenv_path(monkeypatch):
-    for item in ("FOO", "BAR", "EGGS"):
-        monkeypatch._setitem.append((os.environ, item, notset))
-
+def test_dotenv_path(monkeypatch, clean_dotenv_vars):
     load_dotenv(test_path / ".flaskenv")
     assert Path.cwd() == cwd
     assert "FOO" in os.environ
 
 
-def test_dotenv_optional(monkeypatch):
+def test_dotenv_optional(monkeypatch, clean_dotenv_vars):
     monkeypatch.setitem(sys.modules, "dotenv", None)
     monkeypatch.chdir(test_path)
     load_dotenv()
@@ -575,7 +580,7 @@ def test_dotenv_optional(monkeypatch):
 
 
 @need_dotenv
-def test_disable_dotenv_from_env(monkeypatch, runner):
+def test_disable_dotenv_from_env(monkeypatch, runner, clean_dotenv_vars):
     monkeypatch.chdir(test_path)
     monkeypatch.setitem(os.environ, "FLASK_SKIP_DOTENV", "1")
     runner.invoke(FlaskGroup())


### PR DESCRIPTION
Closes #6071

Avoid private pytest monkeypatch internals in the test suite so collection works with pytest 9.1, where `notset` is no longer exported from `_pytest.monkeypatch`.

- Set the Flask CLI environment baseline with public `monkeypatch.delenv(..., raising=False)` calls for each test.
- Replace direct `_setitem` manipulation in dotenv tests with an explicit fixture that ensures their test variables are absent before and after each test.

The existing per-test environment isolation is preserved without relying on pytest's internal sentinel or undo-stack representation.

Tests:

- `.venv\\Scripts\\python.exe -m pytest tests/test_cli.py -q` (58 passed)
- `.venv\\Scripts\\python.exe -m pytest tests -q` (491 passed)
- `.venv\\Scripts\\ruff.exe check tests/conftest.py tests/test_cli.py`
