### PR TITLE
AI junk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ Unreleased
     it's disabled in config. Previously, only disabling worked. :issue:`5916`
 -   ``Flask.select_jinja_autoescape`` uses case-insensitive comparison instead
     of only lower case file extensions. :pr:`6012`
+-   Reject scalar string or bytes values for ``SECRET_KEY_FALLBACKS`` instead
+    of treating each character as a fallback signing key.
 
 
 Version 3.1.3

--- a/src/flask/sessions.py
+++ b/src/flask/sessions.py
@@ -307,6 +307,12 @@ class SecureCookieSessionInterface(SessionInterface):
         keys: list[str | bytes] = []
 
         if fallbacks := app.config["SECRET_KEY_FALLBACKS"]:
+            if isinstance(fallbacks, (str, bytes)):
+                raise TypeError(
+                    "SECRET_KEY_FALLBACKS must be a list of strings or bytes,"
+                    " not a single string or bytes value."
+                )
+
             keys.extend(fallbacks)
 
         keys.append(app.secret_key)  # itsdangerous expects current key at top

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -11,6 +11,7 @@ from platform import python_implementation
 
 import pytest
 import werkzeug.serving
+from itsdangerous import URLSafeTimedSerializer
 from markupsafe import Markup
 from werkzeug.exceptions import BadRequest
 from werkzeug.exceptions import Forbidden
@@ -416,6 +417,33 @@ def test_session_secret_key_fallbacks(app, client) -> None:
         ["0 key", "-1 key"],
     )
     assert client.get().json == {"a": 1}
+
+
+@pytest.mark.parametrize("fallbacks", ["old-secret", b"old-secret"])
+def test_session_secret_key_fallbacks_rejects_string_or_bytes(
+    fallbacks, app, client
+) -> None:
+    app.secret_key = "new-secret"
+    app.config["SECRET_KEY_FALLBACKS"] = fallbacks
+
+    @app.get("/")
+    def get_session() -> dict[str, t.Any]:
+        return dict(flask.session)
+
+    signer = URLSafeTimedSerializer(
+        "o",
+        salt=app.session_interface.salt,
+        serializer=app.session_interface.serializer,
+        signer_kwargs={
+            "key_derivation": app.session_interface.key_derivation,
+            "digest_method": app.session_interface.digest_method,
+        },
+    )
+
+    client.set_cookie(app.config["SESSION_COOKIE_NAME"], signer.dumps({"a": 1}))
+
+    with pytest.raises(TypeError, match="SECRET_KEY_FALLBACKS"):
+        client.get()
 
 
 def test_session_expiration(app, client):


### PR DESCRIPTION
## Summary

`SECRET_KEY_FALLBACKS` is documented and implemented as a list of old signing keys. If an app accidentally configures it as a scalar string or bytes value, the session interface currently calls `keys.extend(fallbacks)`, which expands the value into one-character or one-byte fallback keys before constructing the `itsdangerous` serializer.

This rejects scalar `str` and `bytes` fallback values before building the key list, while preserving the existing list-based key rotation behavior.

## Security impact

For an affected app using signed cookie sessions, a misconfigured value such as `SECRET_KEY_FALLBACKS = "old-secret"` could make Flask accept cookies signed with a single-character fallback key such as `"o"`. I verified the pre-fix behavior with a cookie signed using `"o"`; the session loaded successfully when `SECRET_KEY_FALLBACKS` was a string. After this change, the same request raises a configuration `TypeError` instead of accepting the forged session.

This can also happen through environment configuration if a value is supplied as a plain string instead of JSON/list syntax.

## Validation

- `python3 -m py_compile src/flask/sessions.py tests/test_basic.py`
- `/tmp/flask-verify-venv/bin/ruff check src/flask/sessions.py tests/test_basic.py`
- `/tmp/flask-verify-venv/bin/ruff format --check src/flask/sessions.py tests/test_basic.py`
- `/tmp/flask-verify-venv/bin/python -m pytest tests/test_basic.py::test_session_secret_key_fallbacks tests/test_basic.py::test_session_secret_key_fallbacks_rejects_string_or_bytes -q`
- local full suite before cleanup: `493 passed in 6.36s`
