### PR TITLE
Fix `.partition(":")` usage on potential IPv6 addresses

### DIFF
--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -12,6 +12,7 @@ from inspect import iscoroutinefunction
 from itertools import chain
 from types import TracebackType
 from urllib.parse import quote as _url_quote
+from urllib.parse import urlsplit
 
 import click
 from werkzeug.datastructures import Headers
@@ -721,7 +722,9 @@ class Flask(App):
         sn_host = sn_port = None
 
         if server_name:
-            sn_host, _, sn_port = server_name.partition(":")
+            server_url = urlsplit(f"//{server_name}")
+            sn_host = server_url.hostname
+            sn_port = server_url.port
 
         if not host:
             if sn_host:
@@ -731,8 +734,8 @@ class Flask(App):
 
         if port or port == 0:
             port = int(port)
-        elif sn_port:
-            port = int(sn_port)
+        elif sn_port is not None:
+            port = sn_port
         else:
             port = 5000
 
@@ -745,7 +748,7 @@ class Flask(App):
         from werkzeug.serving import run_simple
 
         try:
-            run_simple(t.cast(str, host), port, self, **options)
+            run_simple(host, port, self, **options)
         finally:
             # reset the first request information if the development server
             # reset normally.  This makes it possible to restart the server

--- a/src/flask/testing.py
+++ b/src/flask/testing.py
@@ -177,7 +177,7 @@ class FlaskClient(Client):
             app.session_interface.save_session(app, sess, resp)
 
         self._update_cookies_from_response(
-            ctx.request.host.partition(":")[0],
+            urlsplit(ctx.request.host_url).hostname or "localhost",
             ctx.request.path,
             resp.headers.getlist("Set-Cookie"),
         )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1910,6 +1910,7 @@ def test_run_server_port(monkeypatch, app):
         ("localhost", 0, "localhost:8080", "localhost", 0),
         (None, None, "localhost:8080", "localhost", 8080),
         (None, None, "localhost:0", "localhost", 0),
+        (None, None, "[::1]:8080", "::1", 8080),
     ),
 )
 def test_run_from_config(

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -171,6 +171,20 @@ def test_session_transactions(app, client):
             assert sess["foo"] == [42]
 
 
+def test_session_transaction_ipv6(app):
+    base_url = "http://[::1]:8000/"
+    client = app.test_client()
+
+    @app.get("/")
+    def index():
+        return str(flask.session.get("value"))
+
+    with client.session_transaction(base_url=base_url) as sess:
+        sess["value"] = 42
+
+    assert client.get("/", base_url=base_url).text == "42"
+
+
 def test_session_transactions_no_null_sessions():
     app = flask.Flask(__name__)
 


### PR DESCRIPTION
Fix two usages of `.partition(":")` on potential IPv6 addresses.
Replace them with alternatives.

Fixes https://github.com/pallets/flask/issues/6093

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:
- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
