### PR TITLE
AI junk

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,43 +2,38 @@ import os
 import sys
 
 import pytest
-from _pytest import monkeypatch
 
 from flask import Flask
 from flask.globals import app_ctx as _app_ctx
 
+_FLASK_ENV_KEYS = (
+    "FLASK_ENV_FILE",
+    "FLASK_APP",
+    "FLASK_DEBUG",
+    "FLASK_RUN_FROM_CLI",
+    "WERKZEUG_RUN_MAIN",
+)
+
 
 @pytest.fixture(scope="session", autouse=True)
 def _standard_os_environ():
-    """Set up ``os.environ`` at the start of the test session to have
-    standard values. Returns a list of operations that is used by
-    :func:`._reset_os_environ` after each test.
-    """
-    mp = monkeypatch.MonkeyPatch()
-    out = (
-        (os.environ, "FLASK_ENV_FILE", monkeypatch.notset),
-        (os.environ, "FLASK_APP", monkeypatch.notset),
-        (os.environ, "FLASK_DEBUG", monkeypatch.notset),
-        (os.environ, "FLASK_RUN_FROM_CLI", monkeypatch.notset),
-        (os.environ, "WERKZEUG_RUN_MAIN", monkeypatch.notset),
-    )
+    """Remove Flask-related environment variables at the start of the test
+    session so they don't leak in from the developer's shell."""
+    mp = pytest.MonkeyPatch()
 
-    for _, key, value in out:
-        if value is monkeypatch.notset:
-            mp.delenv(key, False)
-        else:
-            mp.setenv(key, value)
+    for key in _FLASK_ENV_KEYS:
+        mp.delenv(key, raising=False)
 
-    yield out
+    yield
     mp.undo()
 
 
 @pytest.fixture(autouse=True)
 def _reset_os_environ(monkeypatch, _standard_os_environ):
-    """Reset ``os.environ`` to the standard environ after each test,
-    in case a test changed something without cleaning up.
-    """
-    monkeypatch._setitem.extend(_standard_os_environ)
+    """Remove Flask-related environment variables before each test in case a
+    previous test set them without cleaning up."""
+    for key in _FLASK_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import click
 import pytest
-from _pytest.monkeypatch import notset
 from click.testing import CliRunner
 
 from flask import Blueprint
@@ -535,9 +534,8 @@ need_dotenv = pytest.mark.skipif(
 
 @need_dotenv
 def test_load_dotenv(monkeypatch):
-    # can't use monkeypatch.delitem since the keys don't exist yet
     for item in ("FOO", "BAR", "SPAM", "HAM"):
-        monkeypatch._setitem.append((os.environ, item, notset))
+        monkeypatch.delenv(item, raising=False)
 
     monkeypatch.setenv("EGGS", "3")
     monkeypatch.chdir(test_path)
@@ -560,7 +558,7 @@ def test_load_dotenv(monkeypatch):
 @need_dotenv
 def test_dotenv_path(monkeypatch):
     for item in ("FOO", "BAR", "EGGS"):
-        monkeypatch._setitem.append((os.environ, item, notset))
+        monkeypatch.delenv(item, raising=False)
 
     load_dotenv(test_path / ".flaskenv")
     assert Path.cwd() == cwd


### PR DESCRIPTION
Fixes #6071.

The test suite imports \
otset\ from \_pytest.monkeypatch\ in two places and also pokes the private \_setitem\ list directly. pytest 9.1 removed \
otset\ from that module, which causes a collection-time crash before any test can run.

Both usages only needed the sentinel to mean 'delete this env var'. \monkeypatch.delenv(key, raising=False)\ does exactly the same thing using the stable public API, so the sentinel is not needed at all.

**tests/conftest.py**
- Drop \rom _pytest import monkeypatch\.
- Replace the \
otset\ tuple with a plain tuple of key names (\_FLASK_ENV_KEYS\).
- Use \pytest.MonkeyPatch()\ directly (public class, available since pytest 6.0).
- \_reset_os_environ\ now calls \monkeypatch.delenv(key, raising=False)\ per key instead of appending to the private \_setitem\ list.

**tests/test_cli.py**
- Remove \rom _pytest.monkeypatch import notset\.
- Replace \monkeypatch._setitem.append((os.environ, item, notset))\ with \monkeypatch.delenv(item, raising=False)\ in \	est_load_dotenv\ and \	est_dotenv_path\. The old comment '# can't use monkeypatch.delitem since the keys don't exist yet' no longer applies — \delenv(raising=False)\ handles missing keys fine.