### PR TITLE
AI junk

### DIFF
--- a/src/flask/views.py
+++ b/src/flask/views.py
@@ -12,7 +12,6 @@ http_method_funcs = frozenset(
     ["get", "post", "head", "options", "delete", "put", "trace", "patch"]
 )
 
-
 class View:
     """Subclass this class and override :meth:`dispatch_request` to
     create a generic class-based view. Call :meth:`as_view` to create a
@@ -75,7 +74,7 @@ class View:
     #: .. versionadded:: 2.2
     init_every_request: t.ClassVar[bool] = True
 
-    def dispatch_request(self) -> ft.ResponseReturnValue:
+    def dispatch_request(self, *args: t.Any, **kwargs: t.Any) -> ft.ResponseReturnValue:
         """The actual view function behavior. Subclasses must override
         this and return a valid response. Any variables from the URL
         rule are passed as keyword arguments.
@@ -103,17 +102,17 @@ class View:
         """
         if cls.init_every_request:
 
-            def view(**kwargs: t.Any) -> ft.ResponseReturnValue:
+            def view(*args: t.Any, **kwargs: t.Any) -> ft.ResponseReturnValue:
                 self = view.view_class(  # type: ignore[attr-defined]
                     *class_args, **class_kwargs
                 )
-                return current_app.ensure_sync(self.dispatch_request)(**kwargs)  # type: ignore[no-any-return]
+                return current_app.ensure_sync(self.dispatch_request)(*args, **kwargs)  # type: ignore[no-any-return]
 
         else:
             self = cls(*class_args, **class_kwargs)  # pyright: ignore
 
-            def view(**kwargs: t.Any) -> ft.ResponseReturnValue:
-                return current_app.ensure_sync(self.dispatch_request)(**kwargs)  # type: ignore[no-any-return]
+            def view(*args: t.Any, **kwargs: t.Any) -> ft.ResponseReturnValue:
+                return current_app.ensure_sync(self.dispatch_request)(*args, **kwargs)  # type: ignore[no-any-return]
 
         if cls.decorators:
             view.__name__ = name
@@ -133,7 +132,6 @@ class View:
         view.methods = cls.methods  # type: ignore
         view.provide_automatic_options = cls.provide_automatic_options  # type: ignore
         return view
-
 
 class MethodView(View):
     """Dispatches request methods to the corresponding instance methods.
@@ -179,7 +177,7 @@ class MethodView(View):
             if methods:
                 cls.methods = methods
 
-    def dispatch_request(self, **kwargs: t.Any) -> ft.ResponseReturnValue:
+    def dispatch_request(self, *args: t.Any, **kwargs: t.Any) -> ft.ResponseReturnValue:
         meth = getattr(self, request.method.lower(), None)
 
         # If the request method is HEAD and we don't have a handler for it
@@ -188,4 +186,4 @@ class MethodView(View):
             meth = getattr(self, "get", None)
 
         assert meth is not None, f"Unimplemented method {request.method!r}"
-        return current_app.ensure_sync(meth)(**kwargs)  # type: ignore[no-any-return]
+        return current_app.ensure_sync(meth)(*args, **kwargs)  # type: ignore[no-any-return]


### PR DESCRIPTION
Fixes #5200.

### Root Cause Hypothesis
The issue is caused by the lack of support for passing positional arguments to class-based views in Flask.

### Approach
To fix this issue, we need to modify the `dispatch_request` method in the `View` and `MethodView` classes to accept positional arguments. We can do this by changing the method signature to `def dispatch_request(self, *args, **kwargs)` and then passing these arguments to the view function. This will allow class-based views to accept positional arguments.

### Explanation
The `dispatch_request` method in the `View` and `MethodView` classes has been modified to accept positional arguments. The `as_view` method in the `View` class has also been updated to pass these arguments to the view function.

Automated pull request submitted by Autonomous SWE Agent.