### PR TITLE
AI junk

### DIFF
--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -130,19 +130,27 @@ def stream_with_context(
                 " context is active, such as in a view function."
             )
 
-        with ctx:
-            yield None  # type: ignore[misc]
+        # Push the context only while advancing the wrapped iterator. Keeping
+        # it pushed across a yield means that generator finalization on a
+        # different thread cannot reset the context variable.
+        yield None  # type: ignore[misc]
 
-            try:
-                yield from gen
-            finally:
-                # Clean up in case the user wrapped a WSGI iterator.
-                if hasattr(gen, "close"):
+        try:
+            while True:
+                with ctx:
+                    try:
+                        item = next(gen)
+                    except StopIteration:
+                        return
+                yield item
+        finally:
+            # Clean up in case the user wrapped a WSGI iterator.
+            if hasattr(gen, "close"):
+                with ctx:
                     gen.close()
 
-    # Execute the generator to the sentinel value. This captures the current
-    # context and pushes it to preserve it. Further iteration will yield from
-    # the original iterator.
+    # Execute the generator to the sentinel value to capture the current
+    # context. Further iteration will advance the original iterator under it.
     wrapped_g = generator()
     next(wrapped_g)
     return wrapped_g

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,8 @@
+import gc
 import io
 import os
+import queue
+import threading
 
 import pytest
 import werkzeug.exceptions
@@ -252,6 +255,44 @@ class TestStreaming:
 
         rv = client.get("/?name=World")
         assert rv.data == b"Hello World!"
+
+    def test_streaming_with_context_cleanup_after_cross_thread_close(self, app):
+        teardowns = []
+        abandoned = queue.Queue()
+        continue_worker = threading.Event()
+
+        @app.teardown_appcontext
+        def record_teardown(_):
+            teardowns.append(threading.current_thread().name)
+
+        @app.route("/stream")
+        def stream():
+            def generate():
+                yield "chunk"
+
+            return flask.Response(flask.stream_with_context(generate()))
+
+        def worker():
+            client = app.test_client()
+            response = client.get("/stream", buffered=False)
+
+            body = iter(response.response)
+            next(body)
+            abandoned.put(body)
+            del body, response
+
+            continue_worker.wait()
+            client.get("/next")
+
+        thread = threading.Thread(target=worker, name="stream-worker")
+        thread.start()
+        body = abandoned.get()
+        del body
+        gc.collect()
+        continue_worker.set()
+        thread.join()
+
+        assert "stream-worker" in teardowns
 
     def test_streaming_with_context_and_custom_close(self, app, client):
         called = []


### PR DESCRIPTION
## What changed

`stream_with_context` now pushes the captured context only while advancing or closing the wrapped iterator. This prevents an abandoned stream finalized on another thread from leaving the worker thread with a stale application context.

Added a regression test covering a cross-thread stream finalization and a subsequent request on the same worker.

## Testing

- `uv run --project C:/oss-flask pytest C:/oss-flask/tests -q` (492 passed)
- Ruff check and format check passed

Fixes #6123