### PR TITLE
AI junk

### DIFF
--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -12,6 +12,7 @@ from inspect import iscoroutinefunction
 from itertools import chain
 from types import TracebackType
 from urllib.parse import quote as _url_quote
+from urllib.parse import urlsplit
 
 import click
 from werkzeug.datastructures import Headers
@@ -721,7 +722,9 @@ class Flask(App):
         sn_host = sn_port = None
 
         if server_name:
-            sn_host, _, sn_port = server_name.partition(":")
+            parsed_server_name = urlsplit(f"//{server_name}", allow_fragments=False)
+            sn_host = parsed_server_name.hostname
+            sn_port = parsed_server_name.port
 
         if not host:
             if sn_host:
@@ -731,8 +734,8 @@ class Flask(App):
 
         if port or port == 0:
             port = int(port)
-        elif sn_port:
-            port = int(sn_port)
+        elif sn_port is not None:
+            port = sn_port
         else:
             port = 5000
 

--- a/src/flask/testing.py
+++ b/src/flask/testing.py
@@ -176,8 +176,10 @@ class FlaskClient(Client):
         with ctx:
             app.session_interface.save_session(app, sess, resp)
 
+        host = urlsplit(f"//{ctx.request.host}", allow_fragments=False).hostname
+
         self._update_cookies_from_response(
-            ctx.request.host.partition(":")[0],
+            host,
             ctx.request.path,
             resp.headers.getlist("Set-Cookie"),
         )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1910,6 +1910,7 @@ def test_run_server_port(monkeypatch, app):
         ("localhost", 0, "localhost:8080", "localhost", 0),
         (None, None, "localhost:8080", "localhost", 8080),
         (None, None, "localhost:0", "localhost", 0),
+        (None, None, "[::1]:8080", "::1", 8080),
     ),
 )
 def test_run_from_config(

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -171,6 +171,22 @@ def test_session_transactions(app, client):
             assert sess["foo"] == [42]
 
 
+def test_session_transaction_ipv6(app):
+    app.config["SECRET_KEY"] = "test"
+
+    @app.get("/")
+    def index():
+        return str(flask.session.get("value"))
+
+    client = app.test_client()
+    base_url = "http://[::1]:8000/"
+
+    with client.session_transaction(base_url=base_url) as sess:
+        sess["value"] = 42
+
+    assert client.get("/", base_url=base_url).text == "42"
+
+
 def test_session_transactions_no_null_sessions():
     app = flask.Flask(__name__)
 


### PR DESCRIPTION
Fixes pallets/flask#6093

IPv6 literals contain colons, so partitioning server names at the first colon breaks session cookie handling and SERVER_NAME parsing. Use urlsplit for host and port parsing and add regression tests for IPv6 session transactions and app.run.

Tests:
- PYTHONPATH=src python -m pytest tests/test_testing.py tests/test_basic.py -q (159 passed)
- Full suite: 484 passed, 1 skipped; one environment-only failure because optional asgiref is not installed.