### PR TITLE
AI junk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ Unreleased
     it's disabled in config. Previously, only disabling worked. :issue:`5916`
 -   ``Flask.select_jinja_autoescape`` uses case-insensitive comparison instead
     of only lower case file extensions. :pr:`6012`
+-   Add ``query`` route shortcut and ``MethodView`` dispatch support for the
+    HTTP ``QUERY`` method. :issue:`6065`
 
 
 Version 3.1.3

--- a/src/flask/sansio/scaffold.py
+++ b/src/flask/sansio/scaffold.py
@@ -333,6 +333,14 @@ class Scaffold:
         return self._method_route("PATCH", rule, options)
 
     @setupmethod
+    def query(self, rule: str, **options: t.Any) -> t.Callable[[T_route], T_route]:
+        """Shortcut for :meth:`route` with ``methods=["QUERY"]``.
+
+        .. versionadded:: 3.2
+        """
+        return self._method_route("QUERY", rule, options)
+
+    @setupmethod
     def route(self, rule: str, **options: t.Any) -> t.Callable[[T_route], T_route]:
         """Decorate a view function to register it with the given URL
         rule and options. Calls :meth:`add_url_rule`, which has more

--- a/src/flask/views.py
+++ b/src/flask/views.py
@@ -9,7 +9,17 @@ from .globals import request
 F = t.TypeVar("F", bound=t.Callable[..., t.Any])
 
 http_method_funcs = frozenset(
-    ["get", "post", "head", "options", "delete", "put", "trace", "patch"]
+    [
+        "get",
+        "post",
+        "head",
+        "options",
+        "delete",
+        "put",
+        "trace",
+        "patch",
+        "query",
+    ]
 )
 
 
@@ -141,6 +151,9 @@ class MethodView(View):
     handle ``GET`` requests.
 
     This can be useful for defining a REST API.
+
+    .. versionchanged:: 3.2
+        The ``query`` method is recognized for HTTP ``QUERY`` requests.
 
     :attr:`methods` is automatically set based on the methods defined on
     the class.

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -39,6 +39,25 @@ def test_method_based_view(app):
     common_test(app)
 
 
+def test_query_method_view(app, client):
+    class Index(flask.views.MethodView):
+        def query(self):
+            return "QUERY"
+
+    app.add_url_rule("/", view_func=Index.as_view("index"))
+
+    assert client.open("/", method="QUERY").data == b"QUERY"
+    assert Index.methods == {"QUERY"}
+
+
+def test_query_route_shortcut(app, client):
+    @app.query("/")
+    def index():
+        return "QUERY"
+
+    assert client.open("/", method="QUERY").data == b"QUERY"
+
+
 def test_view_patching(app):
     class Index(flask.views.MethodView):
         def get(self):


### PR DESCRIPTION
fixes #6065

Add the `query()` route shortcut and recognize `query` methods when deriving `MethodView.methods` and dispatching HTTP `QUERY` requests. The existing `route(..., methods=["QUERY"])` behavior remains unchanged.

The change includes focused view tests, code documentation for the new shortcut and dispatch behavior, and an entry in `CHANGES.rst`.
