### PR TITLE
AI junk

### DIFF
--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -130,7 +130,8 @@ def stream_with_context(
                 " context is active, such as in a view function."
             )
 
-        with ctx:
+        ctx.push()
+        try:
             yield None  # type: ignore[misc]
 
             try:
@@ -139,6 +140,18 @@ def stream_with_context(
                 # Clean up in case the user wrapped a WSGI iterator.
                 if hasattr(gen, "close"):
                     gen.close()
+        finally:
+            try:
+                ctx.pop()
+            except RuntimeError:
+                # The generator may be garbage collected on a different
+                # thread than the one that pushed the context, e.g. when
+                # a client disconnects mid-stream and the server abandons
+                # the body iterator. pop() fails because the context is
+                # not active on this thread. Reset the push state to
+                # avoid leaking the context on the original thread.
+                ctx._push_count -= 1
+                ctx._cv_token = None
 
     # Execute the generator to the sentinel value. This captures the current
     # context and pushes it to preserve it. Further iteration will yield from


### PR DESCRIPTION
## Description

When a client disconnects mid-stream, the WSGI server abandons the body
iterator. The generator is later finalized by the garbage collector, often
on a **different thread** than the one that pushed the context.

`ctx.pop()` raises `RuntimeError` because `_cv_app.get(None)` returns `None`
on the GC thread. The context stays "stuck" on the original worker thread,
and `teardown_appcontext` never fires for subsequent requests on that thread.

## Fix

Replace `with ctx:` with manual `ctx.push()` / `ctx.pop()` in the
`stream_with_context` generator. Wrap `pop()` in a try/except that catches
`RuntimeError` and resets the context state (`_push_count` and `_cv_token`)
to prevent thread pool poisoning.

## Related

- #5774 fixed the same cross-context token failure for async views
- #5804 covers teardown ordering in the 3.1.2 rewrite

Closes #6123
