### PR TITLE
AI junk

### DIFF
--- a/src/flask/app.py
+++ b/src/flask/app.py
@@ -721,7 +721,15 @@ class Flask(App):
         sn_host = sn_port = None
 
         if server_name:
-            sn_host, _, sn_port = server_name.partition(":")
+            if "]:" in server_name:
+                sn_host, _, sn_port = server_name.rpartition("]:")
+                sn_host += "]"
+            elif server_name.startswith("[") and server_name.endswith("]"):
+                sn_host, sn_port = server_name, None
+            elif ":" in server_name:
+                sn_host, _, sn_port = server_name.rpartition(":")
+            else:
+                sn_host, sn_port = server_name, None
 
         if not host:
             if sn_host:

--- a/src/flask/testing.py
+++ b/src/flask/testing.py
@@ -176,8 +176,18 @@ class FlaskClient(Client):
         with ctx:
             app.session_interface.save_session(app, sess, resp)
 
+        host = ctx.request.host
+        if "]:" in host:
+            host_name = host.rpartition("]:")[0].lstrip("[")
+        elif host.startswith("[") and host.endswith("]"):
+            host_name = host.strip("[]")
+        elif ":" in host:
+            host_name = host.rpartition(":")[0]
+        else:
+            host_name = host
+
         self._update_cookies_from_response(
-            ctx.request.host.partition(":")[0],
+            host_name,
             ctx.request.path,
             resp.headers.getlist("Set-Cookie"),
         )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1910,6 +1910,7 @@ def test_run_server_port(monkeypatch, app):
         ("localhost", 0, "localhost:8080", "localhost", 0),
         (None, None, "localhost:8080", "localhost", 8080),
         (None, None, "localhost:0", "localhost", 0),
+        (None, None, "[::1]:8080", "[::1]", 8080),
     ),
 )
 def test_run_from_config(

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -27,6 +27,21 @@ def test_environ_defaults_from_config(app, client):
     assert rv.data == b"http://example.com:1234/foo/"
 
 
+def test_session_transaction_ipv6(app):
+    app.secret_key = "secret"
+    base_url = "http://[::1]:8000/"
+    client = app.test_client()
+
+    @app.get("/")
+    def index():
+        return str(flask.session.get("value"))
+
+    with client.session_transaction(base_url=base_url) as sess:
+        sess["value"] = 42
+
+    assert client.get("/", base_url=base_url).text == "42"
+
+
 def test_environ_defaults(app, client, app_ctx, req_ctx):
     @app.route("/")
     def index():


### PR DESCRIPTION
# What does this PR do?

Fixes #6093 where IPv6 addresses (e.g. `[::1]:8080` or `http://[::1]:8000/`) were parsed incorrectly using `.partition(":")`, causing string splits on colons inside IPv6 host brackets.

### Root Cause
1. In `src/flask/app.py`: `server_name.partition(":")` split `"[::1]:8080"` into `sn_host = "["`, `sn_port = ":1]:8080"`.
2. In `src/flask/testing.py`: `ctx.request.host.partition(":")[0]` returned `"["` instead of normalized IPv6 host `"::1"`.

### Solution
1. Updated `src/flask/app.py` `SERVER_NAME` parsing to check for `"]:"` or `rpartition(":")` to extract IPv6 host and port correctly.
2. Updated `src/flask/testing.py` `session_transaction` cookie host parsing to handle IPv6 bracketed hosts.
3. Added test case in `tests/test_basic.py` `test_run_from_config` for `[::1]:8080`.
4. Added `test_session_transaction_ipv6` in `tests/test_testing.py`.

- [x] This PR fixes #6093.
- [x] Included unit tests.
