### PR TITLE
add `app.query` route decorator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ Unreleased
 -   ``Flask.select_jinja_autoescape`` uses case-insensitive comparison instead
     of only lower case file extensions. :pr:`6012`
 -   Fix parsing IPv6 with port in ``run`` and the test client. :pr:`6096`
+-   Add ``app.query`` route decorator for the HTTP QUERY method.
 
 
 Version 3.1.3

--- a/src/flask/sansio/scaffold.py
+++ b/src/flask/sansio/scaffold.py
@@ -301,6 +301,14 @@ class Scaffold:
         return self._method_route("GET", rule, options)
 
     @setupmethod
+    def query(self, rule: str, **options: t.Any) -> t.Callable[[T_route], T_route]:
+        """Shortcut for :meth:`route` with ``methods=["QUERY"]``.
+
+        .. versionadded:: 3.2
+        """
+        return self._method_route("QUERY", rule, options)
+
+    @setupmethod
     def post(self, rule: str, **options: t.Any) -> t.Callable[[T_route], T_route]:
         """Shortcut for :meth:`route` with ``methods=["POST"]``.
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -7,6 +7,7 @@ import weakref
 from contextlib import nullcontext
 from datetime import datetime
 from datetime import timezone
+from functools import partial
 from platform import python_implementation
 
 import pytest
@@ -52,10 +53,12 @@ def test_options_on_multiple_rules(app, client):
     assert sorted(rv.allow) == ["GET", "HEAD", "OPTIONS", "POST", "PUT"]
 
 
-@pytest.mark.parametrize("method", ["get", "post", "put", "delete", "patch"])
+@pytest.mark.parametrize("method", ["get", "query", "post", "put", "delete", "patch"])
 def test_method_route(app, client, method):
     method_route = getattr(app, method)
-    client_method = getattr(client, method)
+    client_method = getattr(
+        client, method, partial(client.open, method=method.capitalize())
+    )
 
     @method_route("/")
     def hello():


### PR DESCRIPTION
[RFC 10008](https://datatracker.ietf.org/doc/html/rfc10008) isn't accepted yet, but it's been kicking around for years and looks like it will pass. I'm adding it now so I don't have to watch it anymore.

Added `client.query` method in https://github.com/pallets/werkzeug/pull/3219. Adjusted the test here to account for Werkzeug not being released yet.

closes #3193 