### PR TITLE
DOC: fix typo in src/flask/helpers.py

### DIFF
--- a/src/flask/helpers.py
+++ b/src/flask/helpers.py
@@ -446,7 +446,7 @@ def send_file(
     :param path_or_file: The path to the file to send, relative to the
         current working directory if a relative path is given.
         Alternatively, a file-like object opened in binary mode. Make
-        sure the file pointer is seeked to the start of the data.
+        sure the file pointer is sought to the start of the data.
     :param mimetype: The MIME type to send for the file. If not
         provided, it will try to detect it from the file name.
     :param as_attachment: Indicate to a browser that it should offer to


### PR DESCRIPTION
Fix a single-word typo in a docstring in src/flask/helpers.py (line 449):

  seeked -> sought

"sought" is the correct past participle of "seek".