### PR TITLE
tests: add test for config.from_file missing file with silent option

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -45,6 +45,13 @@ def test_config_from_file_toml():
     common_object_test(app)
 
 
+def test_config_from_file_missing_silent():
+    app = flask.Flask(__name__)
+    assert not app.config.from_file("nonexistent.json", json.load, silent=True)
+    with pytest.raises(OSError):
+        app.config.from_file("nonexistent.json", json.load, silent=False)
+
+
 def test_from_prefixed_env(monkeypatch):
     monkeypatch.setenv("FLASK_STRING", "value")
     monkeypatch.setenv("FLASK_BOOL", "true")


### PR DESCRIPTION
### Summary
- In `tests/test_config.py`, add `test_config_from_file_missing_silent` to explicitly test that `app.config.from_file(..., silent=True)` returns `False` on missing files and `silent=False` raises `OSError`.