### PR TITLE
[invalid] Add support for custom JSON serialization with `__json__`

### DIFF
--- a/src/flask/json/provider.py
+++ b/src/flask/json/provider.py
@@ -115,6 +115,9 @@ def _default(o: t.Any) -> t.Any:
     if dataclasses and dataclasses.is_dataclass(o):
         return dataclasses.asdict(o)  # type: ignore[arg-type]
 
+    if hasattr(o, "__json__"):
+        return str(o.__json__())
+
     if hasattr(o, "__html__"):
         return str(o.__html__())
 


### PR DESCRIPTION
Allow classes to provide a JSON serialiser which is higher priority than the html method.

This allows classes to support both JSON and HTML with appropriate output.