### PR TITLE
AI junk

### DIFF
--- a/src/flask/config.py
+++ b/src/flask/config.py
@@ -293,7 +293,7 @@ class Config(dict):  # type: ignore[type-arg]
             with open(filename, "r" if text else "rb") as f:
                 obj = load(f)
         except OSError as e:
-            if silent and e.errno in (errno.ENOENT, errno.EISDIR):
+            if silent and e.errno in (errno.ENOENT, errno.EISDIR, errno.ENOTDIR):
                 return False
 
             e.strerror = f"Unable to load configuration file ({e.strerror})"
@@ -302,7 +302,9 @@ class Config(dict):  # type: ignore[type-arg]
         return self.from_mapping(obj)
 
     def from_mapping(
-        self, mapping: t.Mapping[str, t.Any] | None = None, **kwargs: t.Any
+        self,
+        mapping: t.Mapping[str, t.Any] | t.Iterable[tuple[str, t.Any]] | None = None,
+        **kwargs: t.Any,
     ) -> bool:
         """Updates the config like :meth:`update` ignoring items with
         non-upper keys.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -193,6 +193,10 @@ def test_config_missing_file():
     )
     assert msg.endswith("missing.json'")
     assert not app.config.from_file("missing.json", load=json.load, silent=True)
+    # Not a directory parent path
+    assert not app.config.from_file(
+        "missing.json/not_exist.json", load=json.load, silent=True
+    )
 
 
 def test_custom_config_class():


### PR DESCRIPTION
<!--
Thanks for contributing to Flask!

Keep in mind that Flask is in "maintenance mode": only bug fixes, docs, and
internal improvements will be accepted.

Please be sure you've discussed this change with the Pallets maintainers before
opening a pull request, so we can ensure it's something we can accept.
-->

- Handle `errno.ENOTDIR` in `Config.from_file` when `silent=True`, matching the behavior of `Config.from_pyfile`.
- Expand `Config.from_mapping` type annotations to include `t.Iterable[tuple[str, t.Any]]` (such as `dict.items()` or sequence of tuples), which is supported by `dict.update`.
- Add test in `tests/test_config.py`.
