### PR TITLE
[rejected AI] add Cloudflare Workers hosting guide

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Unreleased
     of only lower case file extensions. :pr:`6012`
 -   Fix parsing IPv6 with port in ``run`` and the test client. :pr:`6096`
 -   Add ``app.query`` route decorator for the HTTP QUERY method.
+-   Add Cloudflare Workers to the hosting platforms documentation. :issue:`6146`
 
 
 Version 3.1.3

--- a/docs/deploying/index.rst
+++ b/docs/deploying/index.rst
@@ -69,6 +69,7 @@ which have instructions for Flask, WSGI, or Python.
 - `Google Cloud Run <https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-python-service>`_
 - `AWS Elastic Beanstalk <https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create-deploy-python-flask.html>`_
 - `Microsoft Azure <https://docs.microsoft.com/en-us/azure/app-service/quickstart-python>`_
+- `Cloudflare Workers <https://developers.cloudflare.com/workers/languages/python/packages/flask/>`_
 
 This list is not exhaustive, and you should evaluate these and other
 services based on your application's needs. Different services will have


### PR DESCRIPTION
Add the Cloudflare Workers Flask guide to the Hosting Platforms section and record the documentation update in CHANGES.rst.

The link points to Cloudflare's current Flask-on-Python-Workers guide, which includes the minimal WSGI entrypoint and static asset integration examples.

Fixes #6146

Validation:
- `python -m pytest -q` (494 passed)
- `python -m sphinx -b html docs ...` completed; local intersphinx warnings are caused by the network-restricted environment.