### PR TITLE
[rejected AI] add Cloudflare Workers to hosting platforms list

### DIFF
--- a/docs/deploying/index.rst
+++ b/docs/deploying/index.rst
@@ -69,6 +69,7 @@ which have instructions for Flask, WSGI, or Python.
 - `Google Cloud Run <https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-python-service>`_
 - `AWS Elastic Beanstalk <https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create-deploy-python-flask.html>`_
 - `Microsoft Azure <https://docs.microsoft.com/en-us/azure/app-service/quickstart-python>`_
+- `Cloudflare Workers <https://developers.cloudflare.com/workers/languages/python/packages/flask/>`_
 
 This list is not exhaustive, and you should evaluate these and other
 services based on your application's needs. Different services will have


### PR DESCRIPTION
Adds the official Cloudflare Workers guide for Flask to the "Hosting
Platforms" list in the deploying docs, next to the existing entries for
PythonAnywhere, Google App Engine, Google Cloud Run, AWS Elastic
Beanstalk, and Microsoft Azure.

The guide (https://developers.cloudflare.com/workers/languages/python/packages/flask/)
documents installing Flask with its package manager and deploying it on
Workers. The section already links to platform guides "which have
instructions for Flask, WSGI, or Python", so this only closes a gap in
that list; it does not make any claim about supported runtimes.

The example repository the guide references now contains the example
(per the thread on #6146).

Refs #6146
