### PR TITLE
[rejected AI] only treat callable attributes as HTTP method handlers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,7 +29,11 @@ Unreleased
 -   ``Flask.select_jinja_autoescape`` uses case-insensitive comparison instead
     of only lower case file extensions. :pr:`6012`
 -   Fix parsing IPv6 with port in ``run`` and the test client. :pr:`6096`
--   Add ``app.query`` route decorator for the HTTP QUERY method.
+-   Add ``app.query`` route decorator for the HTTP QUERY method. ``MethodView``
+    subclasses with a ``query`` method handle it.
+-   ``MethodView`` only registers callable attributes as HTTP method handlers.
+    A non-callable attribute such as ``query = None`` is ignored instead of
+    causing a 500 error.
 
 
 Version 3.1.3

--- a/src/flask/views.py
+++ b/src/flask/views.py
@@ -173,7 +173,7 @@ class MethodView(View):
                     methods.update(base.methods)  # type: ignore[attr-defined]
 
             for key in http_method_funcs:
-                if hasattr(cls, key):
+                if callable(getattr(cls, key, None)):
                     methods.add(key.upper())
 
             if methods:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -269,3 +269,23 @@ def test_init_once(app, client):
     app.add_url_rule("/", view_func=CountInit.as_view("index"))
     assert client.get("/").data == b"1"
     assert client.get("/").data == b"1"
+
+
+def test_non_callable_attribute_is_not_a_method(app, client):
+    """A data attribute named like an HTTP method is not a handler.
+
+    ``query`` is a common attribute name (for example a SQLAlchemy
+    ``Model.query`` shortcut). Only callables register a method.
+    """
+
+    class Item(flask.views.MethodView):
+        query = None
+
+        def get(self):
+            return "GET"
+
+    assert Item.methods == {"GET"}
+    app.add_url_rule("/", view_func=Item.as_view("index"))
+    assert client.get("/").data == b"GET"
+    assert client.open("/", method="QUERY").status_code == 405
+    assert client.open("/", method="OPTIONS").allow == {"GET", "HEAD", "OPTIONS"}


### PR DESCRIPTION
Repo: pallets/flask · base: 2a8a38b051fc248865730bf3511bf2e2ea325e81 ("support query in methodview") · branch: charles-fix-flask

## Title

MethodView: register only callable attributes as HTTP methods

## Body

`MethodView.__init_subclass__` builds `cls.methods` with `hasattr(cls, key)` for every
name in `http_method_funcs`, and `dispatch_request` then does `getattr(self, request.method.lower())`
followed by `assert meth is not None`. 2a8a38b added `"query"` to that set, so any existing
`MethodView` subclass that carries a non-callable `query` attribute (for example a
`query = Model.query` shortcut, or `query = None` as a placeholder) now advertises `QUERY` in
`Allow` and answers a `QUERY` request with a 500 (`AssertionError: Unimplemented method 'QUERY'`)
where it returned 405 before. The mechanism predates this change and applies equally to
`get`/`post`/..., but `query` is a far more common data attribute name than the other verbs.

This change switches the detection to `callable(getattr(cls, key, None))`, so data attributes
never register a method; a `def query(self)` still maps to `QUERY` as intended. Reproduction:
`class Item(MethodView): query = None; def get(self): ...` → before: `Item.methods == {"GET", "QUERY"}`,
`QUERY /` → 500; after: `{"GET"}`, `QUERY /` → 405. A test pins this, and CHANGES.rst gains a line
for the new `MethodView`/`query` mapping and for the callable check.

Not covered: a real helper *method* named `query` with a different signature is still registered
(it is callable); that would need a signature check or an explicit opt-in and is a design call for
the maintainers.

## Severity

Low. Backward-compat regression limited to `MethodView` subclasses with a non-callable `query`
attribute, and only for clients that send `QUERY`. No data exposure; the effect is a 500 instead
of a 405 and a misleading `Allow` header.

## Verification

- `uv run --group tests pytest tests/test_views.py -k non_callable` fails on 2a8a38b (test-before.log) and passes with the fix.
- Full suite: 495 passed (test-after.log).
- Upstream `src/flask/views.py` on `main` was byte-identical to this case head at the time of writing.