### PR TITLE
[rejected AI] add Cloudflare Workers to hosting platforms

### DIFF
--- a/docs/deploying/index.rst
+++ b/docs/deploying/index.rst
@@ -69,6 +69,7 @@ which have instructions for Flask, WSGI, or Python.
 - `Google Cloud Run <https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-python-service>`_
 - `AWS Elastic Beanstalk <https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create-deploy-python-flask.html>`_
 - `Microsoft Azure <https://docs.microsoft.com/en-us/azure/app-service/quickstart-python>`_
+- `Cloudflare Workers <https://developers.cloudflare.com/workers/languages/python/packages/flask/>`_
 
 This list is not exhaustive, and you should evaluate these and other
 services based on your application's needs. Different services will have


### PR DESCRIPTION
### Summary

Add Cloudflare Workers to the Hosting Platforms list in the deploying docs, linking to the official Flask guide.

Fixes #6146

### Checklist

- [x] Linked https://developers.cloudflare.com/workers/languages/python/packages/flask/
- [x] Follows the existing list formatting in `docs/deploying/index.rst`
