### PR TITLE
[rejected AI] Document Flask on Cloudflare Workers 

### DIFF
--- a/docs/deploying/index.rst
+++ b/docs/deploying/index.rst
@@ -69,6 +69,7 @@ which have instructions for Flask, WSGI, or Python.
 - `Google Cloud Run <https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-python-service>`_
 - `AWS Elastic Beanstalk <https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create-deploy-python-flask.html>`_
 - `Microsoft Azure <https://docs.microsoft.com/en-us/azure/app-service/quickstart-python>`_
+- `Cloudflare Workers <https://developers.cloudflare.com/workers/languages/python/packages/flask/>`_
 
 This list is not exhaustive, and you should evaluate these and other
 services based on your application's needs. Different services will have


### PR DESCRIPTION
Fixes #6146

Add Cloudflare Workers to the Hosting Platforms list using Cloudflare's official Flask deployment guide.

Checks: uv run --no-default-groups --group docs sphinx-build -E -W -b dirhtml docs docs/_build/dirhtml; uv run --no-default-groups --group pre-commit pre-commit run --files docs/deploying/index.rst; git diff --check.

I have read and will follow the project's contribution guidelines.