### PR TITLE
[rejected AI] add Cloudflare Workers hosting guide

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Unreleased
     of only lower case file extensions. :pr:`6012`
 -   Fix parsing IPv6 with port in ``run`` and the test client. :pr:`6096`
 -   Add ``app.query`` route decorator for the HTTP QUERY method.
+-   Add Cloudflare Workers to the hosting platforms documentation. :issue:`6146`
 
 
 Version 3.1.3

--- a/docs/deploying/index.rst
+++ b/docs/deploying/index.rst
@@ -69,6 +69,7 @@ which have instructions for Flask, WSGI, or Python.
 - `Google Cloud Run <https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-python-service>`_
 - `AWS Elastic Beanstalk <https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create-deploy-python-flask.html>`_
 - `Microsoft Azure <https://docs.microsoft.com/en-us/azure/app-service/quickstart-python>`_
+- `Cloudflare Workers <https://developers.cloudflare.com/workers/languages/python/packages/flask/>`_
 
 This list is not exhaustive, and you should evaluate these and other
 services based on your application's needs. Different services will have


### PR DESCRIPTION
Add Cloudflare Workers to the deployment documentation's Hosting Platforms list, linking to Cloudflare's Flask deployment guide.

Closes #6146

Checks:
- `git diff --check` passed.
- Verified the Cloudflare Workers link is present in `docs/deploying/index.rst`.

The repository's configured `pre-commit` and Sphinx tools are not installed in this isolated runtime, so those checks could not be run locally.
